### PR TITLE
[WIP] fix(launch): single window on ego_space_open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@
 ### 修复
 - **登录态跨 DSH 重启保持（复刻原版 ego-lite 哲学）**：此前手动重启 / 强杀 DSH 后需重新登录——worker 收到 SIGTERM/SIGINT 时只 detach 不落盘，且插件卸载的 `--stop` 宽限 4s 不够、常落到 SIGTERM crash 兜底。现在 worker 退场前先对浏览器发 CDP `Browser.close`（优雅关闭，Cookie journal 合并进磁盘 profile），插件 teardown 宽限提到 8s 足够优雅关完。**实测**：优雅重启登录完全保留；强杀（SIGKILL）长期登录态也已落盘、重启能读回。
 
+## [v0.7.1] - 2026-08
+
+修复版本：单次 `ego_space_open` 不再开两个浏览器窗口。
+
+### 修复
+- **`ego_space_open` 不再开两个浏览器窗口**：此前 launch 时把 `"about:blank"` 作为位置参数传入，会在默认 browser context 开一个残留 tab；而 `ego_space_open` 走 `useSpace+ensureRealTab`，在自己的 browser context 里再开一个 tab——Chrome 把不同 context 隔离到独立窗口，用户就看到了两窗。现在 `LAUNCH_FLAGS` 加 `--no-startup-window`、`launch()` 不再传位置 URL，启动即零 tab；第一个 tab 由 `ego_space_open`（或任何走 `useSpace+ensureRealTab` 的结构化 `ego_*` 工具）在自己的 context 中创建，这是用户唯一看到的窗口。旧注释称 `--no-startup-window` 会破坏所有 `page.*` 操作——那是引入 `useSpace+ensureRealTab` 路由之前的结论，对结构化工具不再成立。**已知回归（可接受）**：`ego_cli` / `ego_script` 中如果 heredoc 直接调 `page.*` 而不先 `taskSpaces.useOrCreate`，现在会抛 `"no active tab to attach session"`，错误信息明确，且推荐用法不受影响。
+
 ## [v0.7.0] - 2026-08
 
 小版本更新：观察窗状态灯呼吸效果 + 前端内存治理 + 工具超时/跨平台修正。

--- a/PLAN-single-window-fix.md
+++ b/PLAN-single-window-fix.md
@@ -1,0 +1,63 @@
+# Plan: 修复 `ego_space_open` 打开两个窗口
+
+> 起因：一次 `ego_space_open` 在全新状态下产生了两个浏览器窗口。本文件记录根因、修复方案与执行步骤。
+
+## 1. 根因
+
+两条独立的"创建 tab"路径，运行在不同的 browser context 中，Chrome 把不同的 context 隔离到不同的窗口：
+
+1. **窗口 1（launch 残留 tab）** —— `runtime/ego-linux/src/chrome.mjs:395` 在启动 Chrome 时把 `"about:blank"` 作为位置参数传入。这会在 **默认** browser context 中开一个 tab。注释（`chrome.mjs:391-395`）说这是必须的：没有任何 tab 时，harness 的 `ensureSession`（`runtime/ego-browser/dist/out/index.js:431`）会抛 `"no active tab to attach session"`。
+
+2. **窗口 2（task space tab）** —— `runtime/ego-linux/src/task-spaces.mjs:414,460` 的 `taskSpaces.createTaskSpace()` 先 `Target.createBrowserContext`（新 context），再 `Target.createTarget({ url: "about:blank", browserContextId })`。Chrome 把不同 browser context 隔离到独立窗口 —— `task-spaces.mjs:145-147` 明确写了 *"A context-backed space cannot share a window with the default context, so every space is its own window"*。
+
+**净结果**：launch 残留 tab 在窗口 1，space tab 在窗口 2，用户看到两个窗口。
+
+`task-spaces.mjs:22-29` 的注释（*"Spaces deliberately do NOT get their own browser window... One window, tracked tab sets."*）是 **设计意图**，在引入 browser context 之前写的；`task-spaces.mjs:145-147` 的注释才是 **当前现实**（每个 context-backed space = 一个窗口）。两者矛盾。
+
+## 2. 修复方案
+
+**去掉 launch 残留 tab**：在 `runtime/ego-linux/src/chrome.mjs` 的 `launch()` 中，把位置参数 `"about:blank"` 换成 `--no-startup-window` 旗标。
+
+为什么现在可以这么做：`lib/index.js` 中所有 `ego_*` 页面操作工具都通过 `useSpace(...)+ensureRealTab()` 路由，会先 `taskSpaces.useOrCreate`（browser-level CDP，不需要 attached session）再在任何 `page.*` 调用前创建 tab。注释（`chrome.mjs:391-395`）里说"`--no-startup-window` was tried here and breaks every page operation"—— 那是在引入 `useSpace+ensureRealTab` 模式之前的旧结论，现在不再成立。
+
+**取舍**（诚实说明）：
+- `ego_cli` / `ego_script` 中如果用户写的 heredoc 直接调 `page.*` 而不先 `taskSpaces.useOrCreate`，现在会抛 `"no active tab to attach session"`，而不是悄悄复用 launch 残留 tab。这是可接受的回归 —— 错误信息明确，且推荐用法（所有结构化 `ego_*` 工具）都走 `useSpace+ensureRealTab`，不受影响。
+
+**不在本次范围**：更深层的 "N 个 space = N 个窗口" 架构问题（每个 context-backed space 各开一个窗口，见 `task-spaces.mjs:145-147`）。这是独立的设计问题，用户只报告了单次调用开两个窗口的现象。
+
+## 3. 执行步骤
+
+1. **拉取 `origin/master`**（当前 `a759af2`，已合并 Windows Chrome env 修复）。
+2. **新建分支** `fix/single-window-on-space-open`，基于更新后的 master。
+3. **编辑 `runtime/ego-linux/src/chrome.mjs`**（`launch()` 函数，约 375-396 行）：
+   - 删除位置参数 `"about:blank"`。
+   - 在 `LAUNCH_FLAGS` 加 `"--no-startup-window"`，或直接在 `launch()` 内联。
+   - 重写 391-395 行注释：launch 不再创建残留 tab；第一次 `ego_space_open`（或任何走 `useSpace+ensureRealTab` 的工具）在自己的 browser context 中创建第一个 tab，这是用户唯一看到的窗口。
+4. **加回归测试** 到 `tests/env.test.mjs`（沿用 306-338 行的源码文本检查风格）：
+   - 断言 `chrome.mjs` 源码含 `--no-startup-window`。
+   - 断言 `launch()` 不再传裸 `"about:blank"` 位置参数。
+5. **更新 `runtime/PATCHES.md`** —— 加一行 `chrome.mjs` 记录 `--no-startup-window` 改动及原因（消除单次 `ego_space_open` 的重复窗口）。
+6. **更新 `CHANGELOG.md`** —— 加 `## [0.7.1]` 段落，中文描述修复（沿用现有风格）。
+7. **bump `package.json`** 版本 `0.7.0` → `0.7.1`。
+8. **验证**：
+   - `pnpm test`（18 个已有 + 1 个新测试，全过）
+   - `pnpm run build`（`node --check` 语法校验）
+9. **手动验证**（由人类执行，AGENTS.md 禁止 agent 启 `dsh web`）：全新状态、无运行中的 Chrome，调一次 `ego_space_open` → 只出现 1 个窗口。
+10. **提交 + push** 到 `fork` remote，然后 `gh pr create` 对 `Fisfzy/ego-browser:master`。
+
+## 4. 涉及文件
+
+| 文件 | 改动类型 |
+|---|---|
+| `runtime/ego-linux/src/chrome.mjs` | 核心修复：去 `about:blank` 位置参数，加 `--no-startup-window`，更新注释 |
+| `tests/env.test.mjs` | 新增源码文本断言测试 |
+| `runtime/PATCHES.md` | 记录本地 runtime 改动 |
+| `CHANGELOG.md` | 新增 `0.7.1` 版本条目 |
+| `package.json` | 版本号 bump |
+
+## 5. 验收标准
+
+- [ ] `pnpm test` 全过（含新增回归测试）
+- [ ] `pnpm run build` 通过
+- [ ] 手动：单次 `ego_space_open` 只开 1 个窗口
+- [ ] PR 已创建，targeting `Fisfzy/ego-browser:master`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsh-external/ego-browser",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "ego-browser (ego-lite) integration plugin for DSH: structured browser-automation tools (30+ ego_*) that drive the vendored ego runtime through ctx.subprocess, plus a realtime watch panel (live SSE screencast + direct mouse interaction with the agent browser + download capture + human-verification notice + tab bar + login guide).",
   "private": true,
   "type": "module",

--- a/runtime/PATCHES.md
+++ b/runtime/PATCHES.md
@@ -12,6 +12,7 @@
 |---|---|---|
 | `runtime/ego-linux/src/cursor.mjs` | 光标覆盖层默认名 `Claude` → `DeepSeek`（4 处：默认值 + 注释） | 品牌统一，`dacbd47` |
 | `runtime/ego-linux/src/chrome.mjs` | `resolveBinary()`: `candidate.includes("/")` → `isAbsolute(candidate)`；`which()`: Windows 用 `where` 替代 `which` | Windows 支持：POSIX `includes("/")` 不识别 `C:\\` 路径，`which` 在 Windows 不存在 |
+| `runtime/ego-linux/src/chrome.mjs` | `LAUNCH_FLAGS` 加 `--no-startup-window`；`launch()` 删除 `"about:blank"` 位置参数 | 消除单次 `ego_space_open` 开两个窗口：原位置参数在默认 browser context 开残留 tab，space tab 走独立 context 又开一个窗口，Chrome 把不同 context 隔离到不同窗口 → 用户看到两窗。`useSpace+ensureRealTab` 路由下不再需要 launch 残留 tab |
 | `runtime/ego-linux/src/paths.mjs` | Windows 用 `%LOCALAPPDATA%\\ego-lite-linux` 作为 DATA_DIR / STATE_DIR；`CHROME_CONFIG_CANDIDATES` 加 Windows 路径 | Windows 支持：XDG 变量在 Windows 不存在；`ego_doctor` 已预期 `%LOCALAPPDATA%` |
 | （其余 runtime 文件）| 与 vendoring 时一致 | 无后续本地改动 |
 

--- a/runtime/ego-linux/src/chrome.mjs
+++ b/runtime/ego-linux/src/chrome.mjs
@@ -57,6 +57,17 @@ const LAUNCH_FLAGS = [
   // appears as its own running app and the launcher icon cannot raise it.
   // Paired with StartupWMClass in the desktop entry.
   `--class=${WM_CLASS}`,
+  // The browser must come up holding NO tab. ego_space_open (and every other
+  // structured ego_* tool) routes through useSpace(...) + ensureRealTab(),
+  // which creates the first tab inside its own browser context — Chrome
+  // isolates each context to its own window, so that tab is the single window
+  // the user sees. If launch also opened a tab (the old "about:blank"
+  // positional arg), it would land in the default context and force a second
+  // window. The "no active tab to attach session" failure that used to make
+  // --no-startup-window unsafe only fired when a tool called page.* directly
+  // without first going through useSpace+ensureRealTab; the structured tools
+  // all do, so it no longer applies.
+  "--no-startup-window",
 ];
 
 /**
@@ -388,11 +399,6 @@ async function launch({ headless }) {
           "--proxy-bypass-list=<-loopback>;127.0.0.1;localhost;[::1];172.16.0.0/12;10.0.0.0/8;*.local",
         ]
       : []),
-    // The harness attaches its CDP session to the active tab and fails with
-    // "no active tab to attach session" when there is none, so the browser has
-    // to come up holding one. --no-startup-window was tried here and breaks
-    // every page operation for that reason.
-    "about:blank",
   ];
   const child = spawn(binary, args, {
     detached: true,

--- a/tests/env.test.mjs
+++ b/tests/env.test.mjs
@@ -337,3 +337,43 @@ describe("runtime chrome.mjs (Windows path handling)", () => {
     );
   });
 });
+
+// ─── runtime/ego-linux/src/chrome.mjs (single-window launch) ───────────────
+// Regression: ego_space_open used to open two windows because launch() passed
+// "about:blank" as a positional arg (opening a tab in the default browser
+// context), and ego_space_open then created another tab in its own context —
+// Chrome isolates contexts to separate windows. The fix is --no-startup-window
+// in LAUNCH_FLAGS and no positional URL. See PLAN-single-window-fix.md.
+
+describe("runtime chrome.mjs (single-window launch)", () => {
+  const readSrc = () =>
+    import("node:fs/promises").then((fs) =>
+      fs.readFile(
+        new URL("../runtime/ego-linux/src/chrome.mjs", import.meta.url),
+        "utf8",
+      ),
+    );
+
+  it("LAUNCH_FLAGS contains --no-startup-window", async () => {
+    const src = await readSrc();
+    assert.ok(
+      src.includes('"--no-startup-window"'),
+      "chrome.mjs LAUNCH_FLAGS should include --no-startup-window so launch " +
+        "does not open a residual tab in the default browser context",
+    );
+  });
+
+  it("launch() does not pass a bare about:blank positional arg", async () => {
+    const src = await readSrc();
+    // The old form was a standalone line `    "about:blank",` inside the
+    // launch() args array. Match it as the sole non-whitespace content of a
+    // line (with trailing comma) — flag-form uses like --no-startup-window
+    // don't match because they start with --.
+    assert.ok(
+      !/^\s*"about:blank",\s*$/m.test(src),
+      "chrome.mjs launch() should not pass a bare 'about:blank' positional " +
+        "URL — that opens a tab in the default context and forces a second " +
+        "window when ego_space_open later creates its own context-backed tab",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes: a single `ego_space_open` call opened **two** browser windows on a fresh Chrome state.

### Root cause

Two independent "create tab" paths ran in different browser contexts, and Chrome isolates contexts to separate windows:

1. **Window 1 (launch residual tab)** — `runtime/ego-linux/src/chrome.mjs` passed `"about:blank"` as a positional arg in `launch()`, opening a tab in the **default** browser context. The inline comment justified this as required by `ensureSession` ("no active tab to attach session").
2. **Window 2 (task space tab)** — `task-spaces.mjs`'s `createTaskSpace()` called `Target.createBrowserContext` (new context) then `Target.createTarget({ url: "about:blank", browserContextId })`, opening a tab in that **new** context.

Net: residual tab in window 1, space tab in window 2 → user sees two windows.

### Fix

Drop the `about:blank` positional arg from `launch()` and add `--no-startup-window` to `LAUNCH_FLAGS`. The browser now comes up holding **zero** tabs; the first tab is created by `ego_space_open` (or any structured `ego_*` tool) inside its own browser context via `useSpace(...) + ensureRealTab()` — the single window the user sees.

The old comment claiming `--no-startup-window` "breaks every page operation" predates the `useSpace + ensureRealTab` routing pattern and no longer holds for the structured tools, which all route through it.

### Accepted regression (honest tradeoff)

`ego_cli` / `ego_script` heredocs that call `page.*` directly **without** first calling `taskSpaces.useOrCreate` will now throw `"no active tab to attach session"` instead of silently reusing the launch residual tab. The error message is clear, and the recommended usage (all structured `ego_*` tools) is unaffected.

### Out of scope

The deeper "N spaces = N windows" architectural issue (each context-backed space opens its own window) is a separate design problem; only the single-call-double-window symptom is addressed here.

## Changes

| File | Change |
|---|---|
| `runtime/ego-linux/src/chrome.mjs` | Add `--no-startup-window` to `LAUNCH_FLAGS`; drop `about:blank` positional arg; rewrite the stale comment |
| `tests/env.test.mjs` | New `describe("runtime chrome.mjs (single-window launch)")` block with two source-text regression assertions |
| `runtime/PATCHES.md` | Record the `chrome.mjs` change in the local-patches table |
| `CHANGELOG.md` | New `## [v0.7.1] - 2026-08` section |
| `package.json` | `0.7.0` → `0.7.1` |
| `PLAN-single-window-fix.md` | Root-cause analysis document (referenced by the new test) |

## Verification

- [x] `pnpm test` — 20/20 pass (18 existing + 2 new regression tests)
- [x] `pnpm run build` — `node --check` syntax validation passes
- [ ] **Manual verification (needs human)** — fresh state, no running Chrome, single `ego_space_open` call should produce exactly 1 window. Per `AGENTS.md`, the agent must not start `dsh web`; this step is left for the maintainer.

## Test plan for reviewer

1. `pnpm test` — confirm 20 tests pass.
2. `pnpm run build` — confirm `build-ok`.
3. Manual: cold-start the agent browser (no running Chrome), call `ego_space_open` once, verify only one window appears.
4. (Optional) Sanity-check a structured `ego_*` tool (e.g. `ego_navigate`) still works through `useSpace + ensureRealTab`.
