### PR TITLE
feat(sidebar): integrate with dsh-better-sidebar as a native Tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@
 ### 修复
 - **登录态跨 DSH 重启保持（复刻原版 ego-lite 哲学）**：此前手动重启 / 强杀 DSH 后需重新登录——worker 收到 SIGTERM/SIGINT 时只 detach 不落盘，且插件卸载的 `--stop` 宽限 4s 不够、常落到 SIGTERM crash 兜底。现在 worker 退场前先对浏览器发 CDP `Browser.close`（优雅关闭，Cookie journal 合并进磁盘 profile），插件 teardown 宽限提到 8s 足够优雅关完。**实测**：优雅重启登录完全保留；强杀（SIGKILL）长期登录态也已落盘、重启能读回。
 
+## [v0.7.1] - 2026-08
+
+修复版本：单次 `ego_space_open` 不再开两个浏览器窗口。
+
+### 修复
+- **`ego_space_open` 不再开两个浏览器窗口**：此前 launch 时把 `"about:blank"` 作为位置参数传入，会在默认 browser context 开一个残留 tab；而 `ego_space_open` 走 `useSpace+ensureRealTab`，在自己的 browser context 里再开一个 tab——Chrome 把不同 context 隔离到独立窗口，用户就看到了两窗。现在 `LAUNCH_FLAGS` 加 `--no-startup-window`、`launch()` 不再传位置 URL，启动即零 tab；第一个 tab 由 `ego_space_open`（或任何走 `useSpace+ensureRealTab` 的结构化 `ego_*` 工具）在自己的 context 中创建，这是用户唯一看到的窗口。旧注释称 `--no-startup-window` 会破坏所有 `page.*` 操作——那是引入 `useSpace+ensureRealTab` 路由之前的结论，对结构化工具不再成立。**已知回归（可接受）**：`ego_cli` / `ego_script` 中如果 heredoc 直接调 `page.*` 而不先 `taskSpaces.useOrCreate`，现在会抛 `"no active tab to attach session"`，错误信息明确，且推荐用法不受影响。
+
 ## [v0.7.0] - 2026-08
 
 小版本更新：观察窗状态灯呼吸效果 + 前端内存治理 + 工具超时/跨平台修正。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,10 @@
 sidebar Tab 集成：当 `dsh-better-sidebar` 可用时，实时查看窗注册为 sidebar 原生 Tab 而非浮动浮窗。
 
 ### 新增
-- **dsh-better-sidebar Tab 集成**：`apply()` 在运行时探测 `ctx.betterSidebar`，可用时通过 `registerTab()` 注册一个 `ego-browser:watch` Tab（`single: true`，常驻），不可用时退回原有浮动浮窗。不把 `betterSidebar` 加入 `inject`（会变成硬依赖，没装 sidebar 时整个插件不加载），纯运行时探测。
+- **dsh-better-sidebar Tab 集成**：`apply()` 用 `ctx.get('betterSidebar')` 机会性探测 sidebar 服务（不用 `ctx.betterSidebar`——那要求 `inject` 声明，会把 sidebar 变成硬依赖，没装时整个插件含设置卡都不加载），可用时通过 `registerTab()` 注册一个 `ego-browser:watch` Tab（`single: true`，常驻），不可用时退回原有浮动浮窗。这是 DSH 文档化的可选服务消费模式（见 approval-seam 笔记、postmortem 0001）。
 - **React Tab 组件 `EgoBrowserTab`**：用 `React.createElement` + `bindSnapshotSelector` 渲染 sidebar Tab 内容（头部 / 标签栏 / 实时主视图 / 历史覆盖层 / 登录与验证码提示条）。历史浏览轨迹从原侧抽改为覆盖式（点历史按钮接管整个 Tab 内容区，点条目进入预览或返回实时），适配 sidebar 窄宽度。
 - **`LivePreviewController` vanilla 类**：从浮动浮窗的命令式 DOM 代码中提取出轮询 / SSE / 帧缓存 / 缩放 / 输入坐标逆映射 / 自动跟随逻辑，供 React 组件通过 `subscribe`+`getSnapshot` 订阅、通过方法调用转发 pointer/wheel 事件。控制器直接持有 `<img>` ref 以 rAF 合帧频率原地替换 `src`，不触发 React 逐帧重渲染。
-- **`dsh-better-sidebar` 列为可选 peer 依赖**（`peerDependenciesMeta.optional: true`），信号化集成可用但不强制。
+- **`dsh-better-sidebar` 不列为 peer 依赖**：用 `ctx.get()` 机会性消费，不需要声明 `inject`，因此也不需要把它列为 peer。装了 sidebar 就用 Tab，没装就退回浮动浮窗，两种部署都干净。
 
 ### 设计取舍（诚实说明）
 - **混合而非完全重写**：React 负责 UI 结构（头部 / 标签 / 提示条 / 历史覆盖层），vanilla 控制器负责实时帧管道（SSE / rAF 合帧 / 坐标逆映射 / 输入转发）。~1000 行脆弱的实时流逻辑未用 React hooks 重写，降低回归风险。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@
 ### 修复
 - **登录态跨 DSH 重启保持（复刻原版 ego-lite 哲学）**：此前手动重启 / 强杀 DSH 后需重新登录——worker 收到 SIGTERM/SIGINT 时只 detach 不落盘，且插件卸载的 `--stop` 宽限 4s 不够、常落到 SIGTERM crash 兜底。现在 worker 退场前先对浏览器发 CDP `Browser.close`（优雅关闭，Cookie journal 合并进磁盘 profile），插件 teardown 宽限提到 8s 足够优雅关完。**实测**：优雅重启登录完全保留；强杀（SIGKILL）长期登录态也已落盘、重启能读回。
 
+## [v0.8.0] - 2026-08
+
+sidebar Tab 集成：当 `dsh-better-sidebar` 可用时，实时查看窗注册为 sidebar 原生 Tab 而非浮动浮窗。
+
+### 新增
+- **dsh-better-sidebar Tab 集成**：`apply()` 在运行时探测 `ctx.betterSidebar`，可用时通过 `registerTab()` 注册一个 `ego-browser:watch` Tab（`single: true`，常驻），不可用时退回原有浮动浮窗。不把 `betterSidebar` 加入 `inject`（会变成硬依赖，没装 sidebar 时整个插件不加载），纯运行时探测。
+- **React Tab 组件 `EgoBrowserTab`**：用 `React.createElement` + `bindSnapshotSelector` 渲染 sidebar Tab 内容（头部 / 标签栏 / 实时主视图 / 历史覆盖层 / 登录与验证码提示条）。历史浏览轨迹从原侧抽改为覆盖式（点历史按钮接管整个 Tab 内容区，点条目进入预览或返回实时），适配 sidebar 窄宽度。
+- **`LivePreviewController` vanilla 类**：从浮动浮窗的命令式 DOM 代码中提取出轮询 / SSE / 帧缓存 / 缩放 / 输入坐标逆映射 / 自动跟随逻辑，供 React 组件通过 `subscribe`+`getSnapshot` 订阅、通过方法调用转发 pointer/wheel 事件。控制器直接持有 `<img>` ref 以 rAF 合帧频率原地替换 `src`，不触发 React 逐帧重渲染。
+- **`dsh-better-sidebar` 列为可选 peer 依赖**（`peerDependenciesMeta.optional: true`），信号化集成可用但不强制。
+
+### 设计取舍（诚实说明）
+- **混合而非完全重写**：React 负责 UI 结构（头部 / 标签 / 提示条 / 历史覆盖层），vanilla 控制器负责实时帧管道（SSE / rAF 合帧 / 坐标逆映射 / 输入转发）。~1000 行脆弱的实时流逻辑未用 React hooks 重写，降低回归风险。
+- **历史轨迹覆盖式**：原浮动浮窗的侧抽设计在 sidebar 窄宽度（~300-400px）下两列都很窄，改为覆盖式后空间利用最好。
+- **竞态条件（已知，可接受）**：若 `dsh-better-sidebar` 在 ego-browser 之后加载，`apply()` 运行时 `ctx.betterSidebar` 可能仍为 `undefined`，此时退回浮动浮窗。DSH 模块加载器通常按依赖顺序加载，sidebar 作为基础 UI 插件一般先加载；若不然，刷新页面即可。
+- **浮动浮窗代码原样保留**：`mountFloatingWatch()` 是原 effect body 的机械移动，未做逻辑改动，确保无 sidebar 时的体验与 0.7.x 完全一致。
+
 ## [v0.7.1] - 2026-08
 
 修复版本：单次 `ego_space_open` 不再开两个浏览器窗口。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ sidebar Tab 集成：当 `dsh-better-sidebar` 可用时，实时查看窗注册�
 
 ### 新增
 - **dsh-better-sidebar Tab 集成**：`apply()` 用 `ctx.get('betterSidebar')` 机会性探测 sidebar 服务（不用 `ctx.betterSidebar`——那要求 `inject` 声明，会把 sidebar 变成硬依赖，没装时整个插件含设置卡都不加载），可用时通过 `registerTab()` 注册一个 `ego-browser:watch` Tab（`single: true`，常驻），不可用时退回原有浮动浮窗。这是 DSH 文档化的可选服务消费模式（见 approval-seam 笔记、postmortem 0001）。
+- **首次 ego_* 工具调用自动打开 Tab**：`defineEgoTool` / `ego_cli` / `ego_captcha` / `ego_script` 的 execute 路径调 `markEgoToolCall()` 递增 host 端计数器，该计数器随 `/api/ego/spaces` 响应下发。`LivePreviewController` 检测计数器 0 → >0 跳变时调 `ctx.get('betterSidebar').openTab({ type: 'ego-browser:watch' })`，Tab 自动展开。`autoOpened` 标志保证每会话只开一次。
 - **React Tab 组件 `EgoBrowserTab`**：用 `React.createElement` + `bindSnapshotSelector` 渲染 sidebar Tab 内容（头部 / 标签栏 / 实时主视图 / 历史覆盖层 / 登录与验证码提示条）。历史浏览轨迹从原侧抽改为覆盖式（点历史按钮接管整个 Tab 内容区，点条目进入预览或返回实时），适配 sidebar 窄宽度。
 - **`LivePreviewController` vanilla 类**：从浮动浮窗的命令式 DOM 代码中提取出轮询 / SSE / 帧缓存 / 缩放 / 输入坐标逆映射 / 自动跟随逻辑，供 React 组件通过 `subscribe`+`getSnapshot` 订阅、通过方法调用转发 pointer/wheel 事件。控制器直接持有 `<img>` ref 以 rAF 合帧频率原地替换 `src`，不触发 React 逐帧重渲染。
 - **`dsh-better-sidebar` 不列为 peer 依赖**：用 `ctx.get()` 机会性消费，不需要声明 `inject`，因此也不需要把它列为 peer。装了 sidebar 就用 Tab，没装就退回浮动浮窗，两种部署都干净。

--- a/PLAN-single-window-fix.md
+++ b/PLAN-single-window-fix.md
@@ -1,0 +1,63 @@
+# Plan: 修复 `ego_space_open` 打开两个窗口
+
+> 起因：一次 `ego_space_open` 在全新状态下产生了两个浏览器窗口。本文件记录根因、修复方案与执行步骤。
+
+## 1. 根因
+
+两条独立的"创建 tab"路径，运行在不同的 browser context 中，Chrome 把不同的 context 隔离到不同的窗口：
+
+1. **窗口 1（launch 残留 tab）** —— `runtime/ego-linux/src/chrome.mjs:395` 在启动 Chrome 时把 `"about:blank"` 作为位置参数传入。这会在 **默认** browser context 中开一个 tab。注释（`chrome.mjs:391-395`）说这是必须的：没有任何 tab 时，harness 的 `ensureSession`（`runtime/ego-browser/dist/out/index.js:431`）会抛 `"no active tab to attach session"`。
+
+2. **窗口 2（task space tab）** —— `runtime/ego-linux/src/task-spaces.mjs:414,460` 的 `taskSpaces.createTaskSpace()` 先 `Target.createBrowserContext`（新 context），再 `Target.createTarget({ url: "about:blank", browserContextId })`。Chrome 把不同 browser context 隔离到独立窗口 —— `task-spaces.mjs:145-147` 明确写了 *"A context-backed space cannot share a window with the default context, so every space is its own window"*。
+
+**净结果**：launch 残留 tab 在窗口 1，space tab 在窗口 2，用户看到两个窗口。
+
+`task-spaces.mjs:22-29` 的注释（*"Spaces deliberately do NOT get their own browser window... One window, tracked tab sets."*）是 **设计意图**，在引入 browser context 之前写的；`task-spaces.mjs:145-147` 的注释才是 **当前现实**（每个 context-backed space = 一个窗口）。两者矛盾。
+
+## 2. 修复方案
+
+**去掉 launch 残留 tab**：在 `runtime/ego-linux/src/chrome.mjs` 的 `launch()` 中，把位置参数 `"about:blank"` 换成 `--no-startup-window` 旗标。
+
+为什么现在可以这么做：`lib/index.js` 中所有 `ego_*` 页面操作工具都通过 `useSpace(...)+ensureRealTab()` 路由，会先 `taskSpaces.useOrCreate`（browser-level CDP，不需要 attached session）再在任何 `page.*` 调用前创建 tab。注释（`chrome.mjs:391-395`）里说"`--no-startup-window` was tried here and breaks every page operation"—— 那是在引入 `useSpace+ensureRealTab` 模式之前的旧结论，现在不再成立。
+
+**取舍**（诚实说明）：
+- `ego_cli` / `ego_script` 中如果用户写的 heredoc 直接调 `page.*` 而不先 `taskSpaces.useOrCreate`，现在会抛 `"no active tab to attach session"`，而不是悄悄复用 launch 残留 tab。这是可接受的回归 —— 错误信息明确，且推荐用法（所有结构化 `ego_*` 工具）都走 `useSpace+ensureRealTab`，不受影响。
+
+**不在本次范围**：更深层的 "N 个 space = N 个窗口" 架构问题（每个 context-backed space 各开一个窗口，见 `task-spaces.mjs:145-147`）。这是独立的设计问题，用户只报告了单次调用开两个窗口的现象。
+
+## 3. 执行步骤
+
+1. **拉取 `origin/master`**（当前 `a759af2`，已合并 Windows Chrome env 修复）。
+2. **新建分支** `fix/single-window-on-space-open`，基于更新后的 master。
+3. **编辑 `runtime/ego-linux/src/chrome.mjs`**（`launch()` 函数，约 375-396 行）：
+   - 删除位置参数 `"about:blank"`。
+   - 在 `LAUNCH_FLAGS` 加 `"--no-startup-window"`，或直接在 `launch()` 内联。
+   - 重写 391-395 行注释：launch 不再创建残留 tab；第一次 `ego_space_open`（或任何走 `useSpace+ensureRealTab` 的工具）在自己的 browser context 中创建第一个 tab，这是用户唯一看到的窗口。
+4. **加回归测试** 到 `tests/env.test.mjs`（沿用 306-338 行的源码文本检查风格）：
+   - 断言 `chrome.mjs` 源码含 `--no-startup-window`。
+   - 断言 `launch()` 不再传裸 `"about:blank"` 位置参数。
+5. **更新 `runtime/PATCHES.md`** —— 加一行 `chrome.mjs` 记录 `--no-startup-window` 改动及原因（消除单次 `ego_space_open` 的重复窗口）。
+6. **更新 `CHANGELOG.md`** —— 加 `## [0.7.1]` 段落，中文描述修复（沿用现有风格）。
+7. **bump `package.json`** 版本 `0.7.0` → `0.7.1`。
+8. **验证**：
+   - `pnpm test`（18 个已有 + 1 个新测试，全过）
+   - `pnpm run build`（`node --check` 语法校验）
+9. **手动验证**（由人类执行，AGENTS.md 禁止 agent 启 `dsh web`）：全新状态、无运行中的 Chrome，调一次 `ego_space_open` → 只出现 1 个窗口。
+10. **提交 + push** 到 `fork` remote，然后 `gh pr create` 对 `Fisfzy/ego-browser:master`。
+
+## 4. 涉及文件
+
+| 文件 | 改动类型 |
+|---|---|
+| `runtime/ego-linux/src/chrome.mjs` | 核心修复：去 `about:blank` 位置参数，加 `--no-startup-window`，更新注释 |
+| `tests/env.test.mjs` | 新增源码文本断言测试 |
+| `runtime/PATCHES.md` | 记录本地 runtime 改动 |
+| `CHANGELOG.md` | 新增 `0.7.1` 版本条目 |
+| `package.json` | 版本号 bump |
+
+## 5. 验收标准
+
+- [ ] `pnpm test` 全过（含新增回归测试）
+- [ ] `pnpm run build` 通过
+- [ ] 手动：单次 `ego_space_open` 只开 1 个窗口
+- [ ] PR 已创建，targeting `Fisfzy/ego-browser:master`

--- a/lib/cast-server.js
+++ b/lib/cast-server.js
@@ -24,6 +24,20 @@ export const EGO_CLOSE_ROUTE = '/api/ego/close';
 export const EGO_FLUSH_ROUTE = '/api/ego/flush';
 export const EGO_INPUT_ROUTE = '/api/ego/input';
 
+// ── tool-call signal (auto-open sidebar Tab) ─────────────────────────────
+// Module-level counter bumped by markEgoToolCall() from the tool execute
+// path (lib/index.js: defineEgoTool). Surfaced via the /api/ego/spaces
+// response so the client polls it for free (no new route, no new poller).
+// The client transitions on 0 → >0 to call betterSidebar.openTab(), so the
+// Tab opens the first time an ego_* tool actually runs, not just when the
+// browser launches. Process-local (one Node process serves all clients);
+// resets to 0 on host restart, which is fine — the auto-open is a one-shot
+// per session anyway.
+let toolCallCount = 0;
+export function markEgoToolCall() {
+  toolCallCount += 1;
+}
+
 function castStatePath() {
   // Mirror the ego-lite runtime state dir across platforms so we find the
   // worker's ego-cast.json wherever it ran: Windows uses
@@ -209,11 +223,13 @@ export function initCastServer(ctx) {
     handler: async (_req, res) => {
       const port = await ensureWorker();
       if (port === null) {
-        return sendJson(res, 200, { ok: false, spaces: [], reason: 'no live agent browser' });
+        return sendJson(res, 200, { ok: false, spaces: [], toolCallCount, reason: 'no live agent browser' });
       }
       const data = await proxyFrom(port, '/api/spaces');
-      if (!data) return sendJson(res, 200, { ok: false, spaces: [], reason: 'worker not ready' });
-      return sendJson(res, 200, data);
+      if (!data) return sendJson(res, 200, { ok: false, spaces: [], toolCallCount, reason: 'worker not ready' });
+      // Attach the host-side tool-call counter (the worker doesn't know about
+      // tool invocations; only the host's defineEgoTool path does).
+      return sendJson(res, 200, { ...data, toolCallCount });
     },
   });
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1674,7 +1674,10 @@ window.__ModuleLoader__.load({
 		// pointer/wheel events to controller methods. The controller holds a ref
 		// to the live <img> element (set via setLiveImg) so it can swap src in
 		// place at rAF cadence without triggering React re-renders per frame.
-		function LivePreviewController() {
+		// `ctx` is stored so the controller can call ctx.get('betterSidebar')
+		// to auto-open the Tab on the first ego_* tool call.
+		function LivePreviewController(ctx) {
+			this.ctx = ctx
 			this.store = createSnapshotStore(this._initialState())
 			this.frameCache = new Map()
 			this.pageMeta = new Map()
@@ -1701,6 +1704,11 @@ window.__ModuleLoader__.load({
 			this._zoomHintTimer = null
 			this._pointerState = null
 			this.dismissedGuides = { login: false, captcha: false }
+			// Tool-call signal: the host surfaces toolCallCount in /api/ego/spaces
+			// (bumped by markEgoToolCall() in lib/index.js). Transition on 0 → >0
+			// auto-opens the sidebar Tab. autoOpened guards against re-opening.
+			this.lastToolCallCount = 0
+			this.autoOpened = false
 		}
 		LivePreviewController.prototype._initialState = function () {
 			return {
@@ -1812,8 +1820,16 @@ window.__ModuleLoader__.load({
 					var res = await fetch(SPACES_ROUTE, { cache: 'no-store' })
 					if (self.disposed || !res.ok) { self._renderEmptyAndSchedule(); return }
 					var data = await res.json()
-					if (!data || data.ok !== true) { self._renderEmptyAndSchedule(); return }
-					self._processSpaces(data.spaces)
+					if (!data || data.ok !== true) {
+						// Even on "no live browser" the host surfaces toolCallCount,
+						// so the auto-open still fires when an ego_* tool ran but the
+						// browser isn't up yet (rare; usually tool runs after launch).
+						if (data && typeof data.toolCallCount === 'number') {
+							self._maybeAutoOpenTab(data.toolCallCount)
+						}
+						self._renderEmptyAndSchedule(); return
+					}
+					self._processSpaces(data.spaces, data.toolCallCount)
 					self._scheduleNext(data.spaces)
 				} catch (e) {
 					self._renderEmptyAndSchedule()
@@ -1824,8 +1840,24 @@ window.__ModuleLoader__.load({
 			if (this.lastList.length === 0) this._processSpaces([])
 			this._scheduleNext(undefined)
 		}
-		LivePreviewController.prototype._processSpaces = function (spaces) {
+		LivePreviewController.prototype._maybeAutoOpenTab = function (toolCallCount) {
+			if (this.autoOpened) return
+			if (typeof toolCallCount !== 'number') return
+			// Transition: 0 (or never-seen) → >0. Also fires when the host
+			// restarted (counter resets to 0 then bumps) — that's fine, the
+			// auto-open is a one-shot per session/page-load.
+			if (toolCallCount > 0 && this.lastToolCallCount === 0) {
+				this.autoOpened = true
+				var sidebar = this.ctx && this.ctx.get ? this.ctx.get('betterSidebar') : null
+				if (sidebar && typeof sidebar.openTab === 'function') {
+					try { sidebar.openTab({ type: 'ego-browser:watch' }) } catch (e) {}
+				}
+			}
+			this.lastToolCallCount = toolCallCount
+		}
+		LivePreviewController.prototype._processSpaces = function (spaces, toolCallCount) {
 			if (this.disposed) return
+			if (typeof toolCallCount === 'number') this._maybeAutoOpenTab(toolCallCount)
 			this.lastList = Array.isArray(spaces) ? spaces : []
 			var self = this
 			for (var i = 0; i < this.lastList.length; i++) {
@@ -2143,8 +2175,9 @@ window.__ModuleLoader__.load({
 		// cadence without triggering React re-renders per frame.
 		function EgoBrowserTab(props) {
 			var visible = props.visible
+			var ctx = props.ctx
 			var controllerRef = React.useRef(null)
-			if (controllerRef.current === null) controllerRef.current = new LivePreviewController()
+			if (controllerRef.current === null) controllerRef.current = new LivePreviewController(ctx)
 			var controller = controllerRef.current
 
 			// Create the snapshot hook once per controller instance

--- a/lib/client.js
+++ b/lib/client.js
@@ -1704,11 +1704,6 @@ window.__ModuleLoader__.load({
 			this._zoomHintTimer = null
 			this._pointerState = null
 			this.dismissedGuides = { login: false, captcha: false }
-			// Tool-call signal: the host surfaces toolCallCount in /api/ego/spaces
-			// (bumped by markEgoToolCall() in lib/index.js). Transition on 0 → >0
-			// auto-opens the sidebar Tab. autoOpened guards against re-opening.
-			this.lastToolCallCount = 0
-			this.autoOpened = false
 		}
 		LivePreviewController.prototype._initialState = function () {
 			return {
@@ -1820,16 +1815,8 @@ window.__ModuleLoader__.load({
 					var res = await fetch(SPACES_ROUTE, { cache: 'no-store' })
 					if (self.disposed || !res.ok) { self._renderEmptyAndSchedule(); return }
 					var data = await res.json()
-					if (!data || data.ok !== true) {
-						// Even on "no live browser" the host surfaces toolCallCount,
-						// so the auto-open still fires when an ego_* tool ran but the
-						// browser isn't up yet (rare; usually tool runs after launch).
-						if (data && typeof data.toolCallCount === 'number') {
-							self._maybeAutoOpenTab(data.toolCallCount)
-						}
-						self._renderEmptyAndSchedule(); return
-					}
-					self._processSpaces(data.spaces, data.toolCallCount)
+					if (!data || data.ok !== true) { self._renderEmptyAndSchedule(); return }
+					self._processSpaces(data.spaces)
 					self._scheduleNext(data.spaces)
 				} catch (e) {
 					self._renderEmptyAndSchedule()
@@ -1840,24 +1827,8 @@ window.__ModuleLoader__.load({
 			if (this.lastList.length === 0) this._processSpaces([])
 			this._scheduleNext(undefined)
 		}
-		LivePreviewController.prototype._maybeAutoOpenTab = function (toolCallCount) {
-			if (this.autoOpened) return
-			if (typeof toolCallCount !== 'number') return
-			// Transition: 0 (or never-seen) → >0. Also fires when the host
-			// restarted (counter resets to 0 then bumps) — that's fine, the
-			// auto-open is a one-shot per session/page-load.
-			if (toolCallCount > 0 && this.lastToolCallCount === 0) {
-				this.autoOpened = true
-				var sidebar = this.ctx && this.ctx.get ? this.ctx.get('betterSidebar') : null
-				if (sidebar && typeof sidebar.openTab === 'function') {
-					try { sidebar.openTab({ type: 'ego-browser:watch' }) } catch (e) {}
-				}
-			}
-			this.lastToolCallCount = toolCallCount
-		}
-		LivePreviewController.prototype._processSpaces = function (spaces, toolCallCount) {
+		LivePreviewController.prototype._processSpaces = function (spaces) {
 			if (this.disposed) return
-			if (typeof toolCallCount === 'number') this._maybeAutoOpenTab(toolCallCount)
 			this.lastList = Array.isArray(spaces) ? spaces : []
 			var self = this
 			for (var i = 0; i < this.lastList.length; i++) {
@@ -2439,11 +2410,19 @@ window.__ModuleLoader__.load({
 			// chicken-and-egg that means the auto-open transition inside the
 			// controller never fires. This lightweight standalone poller runs
 			// regardless of Tab visibility: it fetches /api/ego/spaces, watches
-			// toolCallCount 0 → >0, and calls openTab() once. Stops itself
-			// after firing (one-shot per session) and on plugin dispose.
+			// toolCallCount increase BEYOND THE BASELINE observed at probe
+			// startup, and calls openTab() once.
+			//
+			// Why "increase beyond baseline" not "0 → >0": toolCallCount is a
+			// host-process counter that persists across page reloads. If the
+			// agent already called ego_* tools earlier, toolCallCount is
+			// already >0 when the page loads — a naive 0→>0 check would fire
+			// immediately on every reload, opening the Tab even when no new
+			// tool call happened. The baseline captures the count at probe
+			// startup; only a NEW call (count goes up) triggers the open.
 			var probeDisposed = false
 			var probeTimer = null
-			var lastToolCallCount = 0
+			var baseline = null // null = not yet observed; set on first probe
 			var autoOpened = false
 			var probe = function () {
 				if (probeDisposed || autoOpened) return
@@ -2453,12 +2432,16 @@ window.__ModuleLoader__.load({
 						if (!res.ok) { scheduleProbe(); return }
 						var data = await res.json()
 						if (data && typeof data.toolCallCount === 'number') {
-							if (data.toolCallCount > 0 && lastToolCallCount === 0) {
+							var count = data.toolCallCount
+							if (baseline === null) {
+								// First probe: establish baseline. Don't open yet.
+								baseline = count
+							} else if (count > baseline) {
+								// New tool call since baseline → open the Tab.
 								autoOpened = true
 								try { betterSidebar.openTab({ type: 'ego-browser:watch' }) } catch (e) {}
 								return // stop probing after auto-open
 							}
-							lastToolCallCount = data.toolCallCount
 						}
 					} catch (e) {}
 					scheduleProbe()
@@ -2467,7 +2450,10 @@ window.__ModuleLoader__.load({
 			var scheduleProbe = function () {
 				if (probeDisposed || autoOpened) return
 				if (probeTimer) window.clearTimeout(probeTimer)
-				probeTimer = window.setTimeout(probe, POLL_IDLE_MS)
+				// Poll faster (2s) so the Tab opens promptly after the first
+				// tool call; the probe stops itself after firing, so the fast
+				// cadence is only paid while waiting for the first call.
+				probeTimer = window.setTimeout(probe, POLL_ACTIVE_MS)
 			}
 			// Kick off the first probe shortly after mount (give the host a
 			// moment to be ready; avoids a startup spike if multiple plugins

--- a/lib/client.js
+++ b/lib/client.js
@@ -51,6 +51,9 @@ window.__ModuleLoader__.load({
 			intro: 'Agent browser integration. Configure the Chrome/Chromium binary path below.',
 			chromePath: 'Browser binary path',
 			chromePathHint: 'Absolute path to chrome.exe / chromium. Leave empty to auto-detect.',
+			refreshInterval: 'Watch panel refresh interval',
+			refreshIntervalHint: 'Poll cadence (ms) while the agent is actively browsing. Idle = 4×. Range 500–30000.',
+			refreshIntervalUnit: 'ms',
 			save: 'Save', saving: 'Saving…', discard: 'Discard',
 			unsaved: 'Unsaved', readOnly: 'Settings are read-only in this deployment.',
 			namespaceUnavailable: 'The ego-browser configuration channel is unavailable. Please retry later.',
@@ -62,6 +65,9 @@ window.__ModuleLoader__.load({
 			intro: 'Agent 浏览器集成。在下方配置 Chrome/Chromium 浏览器路径。',
 			chromePath: '浏览器路径',
 			chromePathHint: 'chrome.exe / chromium 的绝对路径。留空则自动检测。',
+			refreshInterval: '实时面板刷新间隔',
+			refreshIntervalHint: 'agent 活跃浏览时的轮询间隔（毫秒）。空闲时为 4 倍。范围 500–30000。',
+			refreshIntervalUnit: '毫秒',
 			save: '保存', saving: '保存中…', discard: '放弃',
 			unsaved: '未保存', readOnly: '当前部署下设置只读。',
 			namespaceUnavailable: 'ego-browser 配置通道不可用，请稍后重试。',
@@ -70,12 +76,22 @@ window.__ModuleLoader__.load({
 		}
 
 		// ── Settings card: store ──────────────────────────────────────────
+		/** Update the shared runtimePoll from a resolved config object. */
+		function applyRuntimePoll(config) {
+			var n = config && typeof config.refreshInterval === 'number'
+				? config.refreshInterval
+				: 2000
+			if (!Number.isFinite(n) || n < 500 || n > 30000) n = 2000
+			runtimePoll.active = n
+			runtimePoll.idle = n * 4
+		}
+
 		function initialSettingsState() {
 			return {
 				status: 'idle',        // 'idle' | 'loading' | 'ready'
 				available: false,      // true after a successful /ego/api/get
 				writable: false,       // false when settings service is absent
-				draft: { chromePath: '' },
+				draft: { chromePath: '', refreshInterval: '2000' },
 				dirty: false,
 				applyState: { kind: 'idle' }, // 'idle' | 'saving' | 'saved' | 'error'
 				errorMessage: undefined,
@@ -114,11 +130,15 @@ window.__ModuleLoader__.load({
 				var config = parsed.value.config || {}
 				self.loaded = true
 				self.staged.clear()
+				applyRuntimePoll(config)
 				self.store.update(function (s) {
 					s.status = 'ready'
 					s.available = true
 					s.writable = true
-					s.draft = { chromePath: config.chromePath || '' }
+					s.draft = {
+						chromePath: config.chromePath || '',
+						refreshInterval: String(config.refreshInterval ?? 2000),
+					}
 					s.dirty = false
 					s.applyState = { kind: 'idle' }
 				})
@@ -156,7 +176,18 @@ window.__ModuleLoader__.load({
 			var self = this
 			var gen = ++this.generation
 			var patch = {}
-			this.staged.forEach(function (v, k) { patch[k] = v })
+			this.staged.forEach(function (v, k) {
+				if (k === 'refreshInterval') {
+					// Convert the text-box string to a clamped number for the
+					// gateway (extractPatch accepts numbers, not strings, for
+					// this key).
+					var n = parseInt(v, 10)
+					if (!Number.isFinite(n)) n = 2000
+					patch[k] = Math.max(500, Math.min(30000, n))
+				} else {
+					patch[k] = v
+				}
+			})
 			if (Object.keys(patch).length === 0) {
 				this.staged.clear()
 				this.store.update(function (s) {
@@ -183,9 +214,13 @@ window.__ModuleLoader__.load({
 				}
 				var config = parsed.value.config || {}
 				self.staged.clear()
+				applyRuntimePoll(config)
 				self.store.update(function (s) {
 					s.applyState = { kind: 'saved' }
-					s.draft = { chromePath: config.chromePath || '' }
+					s.draft = {
+						chromePath: config.chromePath || '',
+						refreshInterval: String(config.refreshInterval ?? 2000),
+					}
 					s.dirty = false
 				})
 			}).catch(function (err) {
@@ -276,6 +311,20 @@ window.__ModuleLoader__.load({
 						style: { width: '100%', padding: '6px 10px', fontSize: '13px', borderRadius: '6px', border: '1px solid rgba(128,128,128,0.3)', background: 'rgba(128,128,128,0.1)', color: 'inherit', boxSizing: 'border-box' },
 					}),
 					h('p', { style: { fontSize: '12px', opacity: 0.5, margin: '4px 0 12px' } }, t('chromePathHint')),
+					h('label', { style: { display: 'block', fontSize: '13px', fontWeight: 500, marginBottom: '4px' } }, t('refreshInterval')),
+					h('div', { style: { display: 'flex', alignItems: 'center', gap: '6px' } },
+						h('input', {
+							type: 'number',
+							min: 500, max: 30000, step: 100,
+							value: state.draft.refreshInterval || '',
+							disabled: !state.writable || saving,
+							placeholder: '2000',
+							onChange: function (e) { controller.edit('refreshInterval', e.target.value) },
+							style: { width: '120px', padding: '6px 10px', fontSize: '13px', borderRadius: '6px', border: '1px solid rgba(128,128,128,0.3)', background: 'rgba(128,128,128,0.1)', color: 'inherit', boxSizing: 'border-box' },
+						}),
+						h('span', { style: { fontSize: '12px', opacity: 0.6 } }, t('refreshIntervalUnit')),
+					),
+					h('p', { style: { fontSize: '12px', opacity: 0.5, margin: '4px 0 12px' } }, t('refreshIntervalHint')),
 					h('div', { style: { display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' } }, footerItems),
 				)
 			}
@@ -298,8 +347,14 @@ window.__ModuleLoader__.load({
 		// Dynamic poll: fast while the agent is actively driving the browser,
 		// slow once nothing has changed — keeps the view responsive without
 		// hammering the worker with screenshots during idle stretches.
-		const POLL_ACTIVE_MS = 2000
-		const POLL_IDLE_MS = 8000
+		//
+		// These are mutable: the settings controller updates them from the
+		// `refreshInterval` config field (loaded via /ego/api/get and refreshed
+		// on every save). Consumers (LivePreviewController, the auto-open probe,
+		// the floating panel) read the current values on each scheduling
+		// decision, so a settings change takes effect on the next poll cycle
+		// without needing to re-mount anything.
+		var runtimePoll = { active: 2000, idle: 8000 }
 		// Treat the agent as "active" when any page was touched within this window.
 		const ACTIVE_WINDOW_MS = 3000
 
@@ -1144,7 +1199,9 @@ window.__ModuleLoader__.load({
 
 				// Dynamic scheduler: after each refresh, decide how soon to poll
 				// again based on whether the agent has recently interacted with any
-				// page. Active → fast (POLL_ACTIVE_MS); quiet → slow (POLL_IDLE_MS).
+				// page. Active → fast (runtimePoll.active); quiet → slow
+				// (runtimePoll.idle). The values are live-updated from the
+				// `refreshInterval` setting.
 				let pollTimer = null
 				let lastSawActive = false
 				const scheduleNext = (spaces) => {
@@ -1154,7 +1211,7 @@ window.__ModuleLoader__.load({
 					// double-fetch on every cycle.
 					if (pollTimer) window.clearTimeout(pollTimer)
 					const active = Array.isArray(spaces) && spaces.some(s => (Date.now() - (s.lastActive || 0)) <= ACTIVE_WINDOW_MS)
-					const delay = active ? POLL_ACTIVE_MS : POLL_IDLE_MS
+					const delay = active ? runtimePoll.active : runtimePoll.idle
 					if (active !== lastSawActive) {
 						// Reflect the speed change on the status dot (busy=agent active now).
 						fab.classList.toggle('dsh-ego-busy', active)
@@ -1864,7 +1921,7 @@ window.__ModuleLoader__.load({
 				this._recompute()
 			}
 			if (!this.visible) return
-			var delay = active ? POLL_ACTIVE_MS : POLL_IDLE_MS
+			var delay = active ? runtimePoll.active : runtimePoll.idle
 			var self = this
 			this.pollTimer = window.setTimeout(function () { if (!self.disposed && self.visible) self.refresh() }, delay)
 		}
@@ -2450,10 +2507,11 @@ window.__ModuleLoader__.load({
 			var scheduleProbe = function () {
 				if (probeDisposed || autoOpened) return
 				if (probeTimer) window.clearTimeout(probeTimer)
-				// Poll faster (2s) so the Tab opens promptly after the first
-				// tool call; the probe stops itself after firing, so the fast
-				// cadence is only paid while waiting for the first call.
-				probeTimer = window.setTimeout(probe, POLL_ACTIVE_MS)
+				// Poll at the active cadence so the Tab opens promptly after
+				// the first tool call; the probe stops itself after firing, so
+				// the cadence is only paid while waiting for the first call.
+				// Uses runtimePoll.active (live-updated from refreshInterval).
+				probeTimer = window.setTimeout(probe, runtimePoll.active)
 			}
 			// Kick off the first probe shortly after mount (give the host a
 			// moment to be ready; avoids a startup spike if multiple plugins

--- a/lib/client.js
+++ b/lib/client.js
@@ -553,10 +553,25 @@ window.__ModuleLoader__.load({
 				}, EgoBrowserCard)
 			})
 
-			// ── Watch panel (guarded: skip if already mounted) ──────────
-			if (document.getElementById('dsh-ego-fab') !== null) return
+		// ── Watch panel: sidebar tab if available, floating fallback otherwise ──
+		// Runtime probe (not in `inject`): adding 'betterSidebar' to inject would
+		// make it a hard dependency — without dsh-better-sidebar installed the
+		// whole plugin (including the settings card) would fail to load. Probing
+		// at runtime gives the graceful fallback the user expects.
+		if (ctx.betterSidebar !== void 0) {
+			ctx.effect(() => mountSidebarTab(ctx), 'ego-browser sidebar tab')
+		} else {
+			ctx.effect(() => mountFloatingWatch(ctx), 'ego-browser watch panel')
+		}
+	}
 
-			ctx.effect(() => {
+	// ── Floating watch panel (vanilla DOM, fallback when no sidebar) ────────
+	// This is the original self-contained overlay: a draggable FAB + pop-out
+	// panel. Kept verbatim for the no-sidebar path; the sidebar Tab path uses
+	// the React EgoBrowserTab component + LivePreviewController instead.
+	function mountFloatingWatch(ctx) {
+		// Guard: skip if already mounted (apply() may fire multiple times).
+		if (document.getElementById('dsh-ego-fab') !== null) return () => {}
 				const style = document.createElement('style')
 				style.textContent = PANEL_CSS
 				document.head.appendChild(style)
@@ -1479,7 +1494,908 @@ window.__ModuleLoader__.load({
 					panel.remove()
 					style.remove()
 				}
-			}, 'ego-browser watch panel')
+		}
+
+		// ── Sidebar Tab (React UI + vanilla LivePreviewController) ─────────────
+		// Registered via ctx.betterSidebar.registerTab() when the sidebar service
+		// is available. The Tab reuses the same /api/ego/spaces + /api/ego/stream
+		// data sources as the floating panel but renders through React into the
+		// sidebar's tab content area instead of a fixed-position overlay.
+		var INPUT_ROUTE = '/api/ego/input'
+		var FLUSH_ROUTE = '/api/ego/flush'
+		var FRAME_FOLLOW_MIN_MS = 350
+
+		// ── Tab CSS (scoped under .dsh-ego-side-root) ──────────────────────────
+		// Separate from PANEL_CSS (the floating panel's styles): the Tab lives
+		// inside the sidebar's content area, so no fixed positioning / FAB / drag.
+		// Selectors are class-scoped to avoid clashing with the floating panel's
+		// #dsh-ego-* IDs (both paths can coexist in the bundle, only one runs).
+		var TAB_CSS = `
+.dsh-ego-side-root {
+  display: flex; flex-direction: column; height: 100%; min-height: 0;
+  overflow: hidden; color: inherit; background: transparent;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+}
+.dsh-ego-side-root * { box-sizing: border-box; }
+
+.dsh-ego-side-head {
+  display: flex; align-items: center; gap: 4px; padding: 8px 10px;
+  border-bottom: 1px solid rgba(128,128,128,.18); flex-shrink: 0;
+}
+.dsh-ego-side-title {
+  flex: 1; font-size: 12.5px; font-weight: 600; letter-spacing: .2px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  display: flex; align-items: center; gap: 5px; opacity: .85;
+}
+.dsh-ego-side-title svg { width: 14px; height: 14px; flex-shrink: 0; }
+.dsh-ego-side-iconbtn {
+  background: transparent; border: none; cursor: pointer;
+  width: 26px; height: 26px; border-radius: 7px; padding: 0;
+  display: flex; align-items: center; justify-content: center;
+  color: inherit; opacity: .6;
+  transition: background .15s ease, opacity .15s ease;
+}
+.dsh-ego-side-iconbtn:hover { background: rgba(128,128,128,.18); opacity: 1; }
+.dsh-ego-side-iconbtn.off { opacity: .4; }
+.dsh-ego-side-iconbtn.spinning svg { animation: dsh-ego-side-spin .7s linear infinite; }
+@keyframes dsh-ego-side-spin { to { transform: rotate(360deg); } }
+
+/* ---- guide strips (login / captcha) ---- */
+.dsh-ego-side-login, .dsh-ego-side-captcha {
+  display: flex; align-items: center; gap: 7px; margin: 0 10px 7px; padding: 6px 9px;
+  border-radius: 8px; font-size: 11px; line-height: 1.4;
+}
+.dsh-ego-side-login {
+  border: 1px solid rgba(255,214,10,.3); background: rgba(255,214,10,.1);
+}
+.dsh-ego-side-captcha {
+  border: 1px solid rgba(255,69,58,.4); background: rgba(255,69,58,.13);
+}
+.dsh-ego-side-login .dsh-ego-side-login-txt { flex: 1; min-width: 0; }
+.dsh-ego-side-login .dsh-ego-side-login-txt b { color: #ffd60a; }
+.dsh-ego-side-login-btn {
+  flex: none; background: #0a84ff; color: #fff; border: none; border-radius: 7px;
+  font-size: 10.5px; padding: 4px 9px; cursor: pointer; white-space: nowrap;
+  transition: background .15s ease;
+}
+.dsh-ego-side-login-btn:hover { background: #338cff; }
+.dsh-ego-side-login-btn.saving { opacity: .55; pointer-events: none; }
+.dsh-ego-side-login-note { flex: none; font-size: 10px; opacity: .6; white-space: nowrap; }
+.dsh-ego-side-captcha-txt { flex: 1; min-width: 0; }
+.dsh-ego-side-captcha-txt b { color: #ff6961; }
+.dsh-ego-side-captcha-kind {
+  flex: none; font-size: 9.5px; padding: 2px 7px; border-radius: 999px;
+  background: rgba(255,255,255,.15); text-transform: uppercase; letter-spacing: .3px;
+}
+
+/* ---- tab strip: frosted pills ---- */
+.dsh-ego-side-tabs {
+  display: flex; gap: 5px; padding: 7px 10px; flex-shrink: 0;
+  border-bottom: 1px solid rgba(128,128,128,.12);
+  overflow-x: auto; scrollbar-width: thin;
+}
+.dsh-ego-side-tabs:empty { display: none; }
+.dsh-ego-side-tab {
+  display: inline-flex; align-items: center; gap: 5px; max-width: 160px;
+  white-space: nowrap; padding: 4px 10px; border-radius: 999px; cursor: pointer;
+  font-size: 11px; flex-shrink: 0;
+  border: 1px solid rgba(128,128,128,.2); background: rgba(128,128,128,.12);
+  opacity: .7; transition: background .15s, opacity .15s, border-color .15s;
+}
+.dsh-ego-side-tab > .dsh-ego-side-tabtxt { overflow: hidden; text-overflow: ellipsis; }
+.dsh-ego-side-tab:hover { opacity: 1; background: rgba(128,128,128,.2); }
+.dsh-ego-side-tab.active {
+  background: #0a84ff; color: #fff; border-color: transparent; opacity: 1;
+  box-shadow: 0 2px 8px rgba(10,132,255,.3);
+}
+.dsh-ego-side-tabdot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; opacity: .5; flex-shrink: 0; }
+.dsh-ego-side-tab.active .dsh-ego-side-tabdot { background: #fff; opacity: 1; }
+.dsh-ego-side-tabclose {
+  flex-shrink: 0; width: 13px; height: 13px; line-height: 12px; text-align: center;
+  border-radius: 50%; font-size: 11px; opacity: .5; margin-left: 1px;
+}
+.dsh-ego-side-tabclose:hover { background: rgba(255,255,255,.2); color: #ff453a; opacity: 1; }
+
+/* ---- main body ---- */
+.dsh-ego-side-body { flex: 1; min-height: 0; overflow-y: auto; padding: 10px; }
+.dsh-ego-side-empty { padding: 20px 12px; text-align: center; font-size: 12px; opacity: .5; line-height: 1.7; }
+
+.dsh-ego-side-liveview { display: flex; flex-direction: column; gap: 7px; min-height: 60px; overflow: hidden; }
+.dsh-ego-side-livebadge {
+  font-size: 10.5px; opacity: .6; letter-spacing: .2px;
+  display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
+}
+.dsh-ego-side-state-dot {
+  display: inline-block; width: 7px; height: 7px; border-radius: 50%;
+  background: #30d158; box-shadow: 0 0 5px #30d15888; flex-shrink: 0;
+  animation: dsh-ego-side-breathe 2.4s ease-in-out infinite;
+}
+.dsh-ego-side-state-dot.busy { background: #30d158; box-shadow: 0 0 6px #30d158bb; animation: none; }
+.dsh-ego-side-state-dot.pin { background: #0a84ff; box-shadow: 0 0 5px #0a84ff88; animation: none; }
+@keyframes dsh-ego-side-breathe {
+  0%, 100% { box-shadow: 0 0 2px #30d15822; opacity: .5; }
+  50%      { box-shadow: 0 0 10px #30d158ee; opacity: 1; }
+}
+.dsh-ego-side-back {
+  background: rgba(128,128,128,.18); border: 1px solid rgba(128,128,128,.2);
+  border-radius: 6px; cursor: pointer; font-size: 10.5px; padding: 2px 8px;
+  display: inline-flex; align-items: center; gap: 3px;
+  transition: background .15s ease; color: inherit;
+}
+.dsh-ego-side-back:hover { background: rgba(128,128,128,.3); }
+.dsh-ego-side-liveimg {
+  width: 100%; border-radius: 9px; display: block;
+  max-height: 50vh; object-fit: contain;
+  border: 1px solid rgba(128,128,128,.2); background: #000;
+  user-select: none; -webkit-user-select: none; touch-action: none;
+  will-change: transform; cursor: grab;
+}
+.dsh-ego-side-livetitle { font-size: 12px; font-weight: 600; }
+.dsh-ego-side-liveurl { font-size: 10.5px; opacity: .55; word-break: break-all; }
+.dsh-ego-side-liveurl.dsh-ego-side-hint { color: #75c2ff; font-style: italic; font-weight: 500; opacity: 1; }
+.dsh-ego-side-hint { animation: dsh-ego-side-hint-in .2s ease; }
+@keyframes dsh-ego-side-hint-in { from { opacity: .3 } to { opacity: 1 } }
+
+/* ---- history overlay (covers the body area) ---- */
+.dsh-ego-side-history {
+  flex: 1; min-height: 0; display: flex; flex-direction: column;
+  overflow: hidden;
+}
+.dsh-ego-side-historyhead {
+  padding: 8px 10px; font-size: 11px; font-weight: 600; opacity: .6;
+  display: flex; align-items: center; gap: 5px;
+  border-bottom: 1px solid rgba(128,128,128,.1); flex-shrink: 0;
+}
+.dsh-ego-side-historyhead svg { width: 11px; height: 11px; }
+.dsh-ego-side-historylist { overflow-y: auto; padding: 5px; }
+.dsh-ego-side-hitem {
+  display: flex; gap: 7px; align-items: center; padding: 5px; border-radius: 8px;
+  cursor: pointer; transition: background .15s ease;
+}
+.dsh-ego-side-hitem:hover { background: rgba(128,128,128,.15); }
+.dsh-ego-side-hitem.active { background: rgba(10,132,255,.15); }
+.dsh-ego-side-hthumb {
+  width: 52px; height: 38px; border-radius: 5px; object-fit: cover; background: #000;
+  flex-shrink: 0; border: 1px solid rgba(128,128,128,.2);
+}
+.dsh-ego-side-hinfo { min-width: 0; flex: 1; }
+.dsh-ego-side-htitle { font-size: 10px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dsh-ego-side-hurl { font-size: 9.5px; opacity: .5; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dsh-ego-side-hactive { color: #30d158; font-size: 9.5px; }
+.dsh-ego-side-hnone { padding: 16px 8px; text-align: center; font-size: 10.5px; opacity: .4; }
+`
+
+		// ── LivePreviewController ───────────────────────────────────────────────
+		// Vanilla class holding all mutable watch state + SSE/poll/input/zoom
+		// logic. Extracted from the floating panel's imperative DOM code so the
+		// React Tab component can subscribe to a snapshot store and delegate
+		// pointer/wheel events to controller methods. The controller holds a ref
+		// to the live <img> element (set via setLiveImg) so it can swap src in
+		// place at rAF cadence without triggering React re-renders per frame.
+		function LivePreviewController() {
+			this.store = createSnapshotStore(this._initialState())
+			this.frameCache = new Map()
+			this.pageMeta = new Map()
+			this.lastList = []
+			this.pinned = null
+			this.currentActiveId = null
+			this.agentActiveId = null
+			this.selectedTabId = null
+			this.zoomState = { scale: 1, tx: 0, ty: 0 }
+			this.liveCount = 0
+			this.disposed = false
+			this.visible = true
+			this.pollTimer = null
+			this.sse = null
+			this.lastSawActive = false
+			this.lastFrameAt = 0
+			this.followTimer = null
+			this.pendingLiveFrame = null
+			this.liveFlushRaf = null
+			this.liveImg = null
+			this.liveImgTargetId = null
+			this.historyOpen = false
+			this._zoomHint = null
+			this._zoomHintTimer = null
+			this._pointerState = null
+			this.dismissedGuides = { login: false, captcha: false }
+		}
+		LivePreviewController.prototype._initialState = function () {
+			return {
+				spaces: [],
+				pinned: null,
+				selectedTabId: null,
+				currentTargetId: null,
+				currentSpace: null,
+				liveCount: 0,
+				busy: false,
+				showLoginGuide: false,
+				captchaKind: null,
+				historyOpen: false,
+				zoomHint: null,
+			}
+		}
+		LivePreviewController.prototype.subscribe = function (cb) {
+			return this.store.subscribe(cb)
+		}
+		LivePreviewController.prototype.getSnapshot = function () {
+			return this.store.getSnapshot()
+		}
+		LivePreviewController.prototype._recompute = function () {
+			var hasPage = this.lastList.some(function (s) { return s.url && !s.url.startsWith('about:') })
+			var captchaHit = this.lastList.find(function (s) { return s.humanCheck && s.humanCheck.detected })
+			var self = this
+			var currentSpace = null
+			var currentTargetId = null
+			if (this.pinned) {
+				currentSpace = this.pinned
+				currentTargetId = this.pinned.targetId
+			} else if (this.selectedTabId !== null) {
+				currentSpace = this.lastList.find(function (s) { return s.targetId === self.selectedTabId }) || null
+				currentTargetId = this.selectedTabId
+				// Fall back to cached frame if the poll hasn't got a thumbnail
+				if (currentSpace && !currentSpace.thumbnail) {
+					var cached = this.frameCache.get(currentTargetId)
+					if (cached) currentSpace = Object.assign({}, currentSpace, { thumbnail: cached })
+				}
+			} else {
+				var activeMarked = this.lastList.find(function (s) { return s.active === true })
+				if (!activeMarked && this.lastList.length > 0) {
+					activeMarked = this.lastList.slice().sort(function (a, b) { return (b.lastActive || 0) - (a.lastActive || 0) })[0]
+				}
+				if (activeMarked) {
+					currentSpace = Object.assign({}, activeMarked)
+					currentTargetId = activeMarked.targetId
+					if (!currentSpace.thumbnail) {
+						var cached2 = this.frameCache.get(currentTargetId)
+						if (cached2) currentSpace.thumbnail = cached2
+					}
+				}
+			}
+			this.currentActiveId = currentTargetId
+			var showLogin = hasPage && !captchaHit && !this.dismissedGuides.login
+			var captchaKind = (captchaHit && !this.dismissedGuides.captcha) ? (captchaHit.humanCheck.kind || 'captcha') : null
+			this.store.update(function (s) {
+				s.spaces = self.lastList
+				s.pinned = self.pinned
+				s.selectedTabId = self.selectedTabId
+				s.currentTargetId = currentTargetId
+				s.currentSpace = currentSpace
+				s.liveCount = self.liveCount
+				s.busy = self.lastSawActive
+				s.showLoginGuide = showLogin
+				s.captchaKind = captchaKind
+				s.historyOpen = self.historyOpen
+				s.zoomHint = self._zoomHint
+			})
+		}
+		LivePreviewController.prototype.start = function () {
+			this._recompute()
+			this.refresh()
+			this.openStream()
+		}
+		LivePreviewController.prototype.dispose = function () {
+			this.disposed = true
+			if (this.liveFlushRaf != null) try { window.cancelAnimationFrame(this.liveFlushRaf) } catch (e) {}
+			if (this.followTimer) window.clearTimeout(this.followTimer)
+			if (this.pollTimer) window.clearTimeout(this.pollTimer)
+			if (this._zoomHintTimer) window.clearTimeout(this._zoomHintTimer)
+			this.closeStream()
+		}
+		LivePreviewController.prototype.setVisible = function (v) {
+			if (this.visible === v) return
+			this.visible = v
+			if (v) {
+				this.refresh()
+				this.openStream()
+			} else {
+				this.closeStream()
+				if (this.pollTimer) { window.clearTimeout(this.pollTimer); this.pollTimer = null }
+			}
+		}
+		LivePreviewController.prototype.setLiveImg = function (img, targetId) {
+			this.liveImg = img
+			this.liveImgTargetId = targetId
+			if (img && targetId != null) {
+				var cached = this.frameCache.get(targetId)
+				if (cached) {
+					try { img.src = cached } catch (e) {}
+				}
+			}
+		}
+		LivePreviewController.prototype.refresh = function () {
+			var self = this
+			void (async function () {
+				try {
+					var res = await fetch(SPACES_ROUTE, { cache: 'no-store' })
+					if (self.disposed || !res.ok) { self._renderEmptyAndSchedule(); return }
+					var data = await res.json()
+					if (!data || data.ok !== true) { self._renderEmptyAndSchedule(); return }
+					self._processSpaces(data.spaces)
+					self._scheduleNext(data.spaces)
+				} catch (e) {
+					self._renderEmptyAndSchedule()
+				}
+			})()
+		}
+		LivePreviewController.prototype._renderEmptyAndSchedule = function () {
+			if (this.lastList.length === 0) this._processSpaces([])
+			this._scheduleNext(undefined)
+		}
+		LivePreviewController.prototype._processSpaces = function (spaces) {
+			if (this.disposed) return
+			this.lastList = Array.isArray(spaces) ? spaces : []
+			var self = this
+			for (var i = 0; i < this.lastList.length; i++) {
+				var s = this.lastList[i]
+				var prev = this.pageMeta.get(s.targetId) || { targetId: s.targetId }
+				var meta = {
+					url: s.url,
+					title: s.title,
+					targetId: s.targetId,
+				}
+				if (Number.isFinite(s.viewportW)) meta.vw = s.viewportW
+				else if (prev.vw !== undefined) meta.vw = prev.vw
+				if (Number.isFinite(s.viewportH)) meta.vh = s.viewportH
+				else if (prev.vh !== undefined) meta.vh = prev.vh
+				this.pageMeta.set(s.targetId, meta)
+			}
+			var liveIds = new Set(this.lastList.map(function (s) { return s.targetId }))
+			var pm = this.pageMeta
+			pm.forEach(function (_, id) { if (!liveIds.has(id)) pm.delete(id) })
+			var fc = this.frameCache
+			fc.forEach(function (_, id) { if (!liveIds.has(id)) fc.delete(id) })
+			var activeMarked = this.lastList.find(function (s) { return s.active === true })
+			if (activeMarked) this.agentActiveId = activeMarked.targetId
+			this.liveCount = this.lastList.length
+			this._recompute()
+		}
+		LivePreviewController.prototype._scheduleNext = function (spaces) {
+			if (this.disposed) return
+			if (this.pollTimer) window.clearTimeout(this.pollTimer)
+			var active = Array.isArray(spaces) && spaces.some(function (s) { return (Date.now() - (s.lastActive || 0)) <= ACTIVE_WINDOW_MS })
+			if (active !== this.lastSawActive) {
+				this.lastSawActive = active
+				this._recompute()
+			}
+			if (!this.visible) return
+			var delay = active ? POLL_ACTIVE_MS : POLL_IDLE_MS
+			var self = this
+			this.pollTimer = window.setTimeout(function () { if (!self.disposed && self.visible) self.refresh() }, delay)
+		}
+		LivePreviewController.prototype.openStream = function () {
+			if (this.disposed || !this.visible) return
+			this.closeStream()
+			var self = this
+			try {
+				this.sse = new EventSource('/api/ego/stream')
+			} catch (e) { return }
+			this.sse.addEventListener('frame', function (ev) {
+				try {
+					var m = JSON.parse(ev.data)
+					if (!m || !m.targetId || !m.data) return
+					if (Number.isFinite(m.vw) && Number.isFinite(m.vh)) {
+						var cur = self.pageMeta.get(m.targetId) || { targetId: m.targetId }
+						self.pageMeta.set(m.targetId, Object.assign({}, cur, { vw: m.vw, vh: m.vh }))
+					}
+					self.applyFrame(m.targetId, 'data:image/jpeg;base64,' + m.data, m.vw, m.vh)
+				} catch (e) {}
+			})
+			this.sse.addEventListener('spaces', function (ev) {
+				if (self.disposed) return
+				try {
+					var list = JSON.parse(ev.data)
+					if (Array.isArray(list) && list.length) {
+						for (var i = 0; i < list.length; i++) {
+							var s = list[i]
+							var cur = self.pageMeta.get(s.targetId) || { targetId: s.targetId }
+							var meta = { url: s.url, title: s.title, targetId: s.targetId }
+							if (Number.isFinite(s.viewportW)) meta.vw = s.viewportW
+							if (Number.isFinite(s.viewportH)) meta.vh = s.viewportH
+							self.pageMeta.set(s.targetId, Object.assign({}, cur, meta))
+							if (s.active === true) self.agentActiveId = s.targetId
+						}
+						self.lastList = list
+						self._recompute()
+					}
+				} catch (e) {}
+			})
+			this.sse.onerror = function () {}
+		}
+		LivePreviewController.prototype.closeStream = function () {
+			try { if (this.sse) this.sse.close() } catch (e) {}
+			this.sse = null
+		}
+		LivePreviewController.prototype.applyFrame = function (targetId, dataUrl, vw, vh) {
+			if (this.disposed) return
+			this.frameCache.set(targetId, dataUrl)
+			var MAX_CACHED_FRAMES = 12
+			if (this.frameCache.size > MAX_CACHED_FRAMES) {
+				var self = this
+				this.frameCache.forEach(function (_, id) {
+					if (self.frameCache.size <= MAX_CACHED_FRAMES) return
+					if (id === targetId || id === self.liveImgTargetId) return
+					self.frameCache.delete(id)
+				})
+			}
+			if (Number.isFinite(vw) && Number.isFinite(vh)) {
+				var cur = this.pageMeta.get(targetId) || { targetId: targetId }
+				this.pageMeta.set(targetId, Object.assign({}, cur, { vw: vw, vh: vh }))
+			}
+			if (this.liveImg && this.liveImgTargetId === targetId) {
+				var self2 = this
+				this.pendingLiveFrame = dataUrl
+				if (!this.liveFlushRaf && !this.disposed) {
+					this.liveFlushRaf = window.requestAnimationFrame(function () {
+						self2.liveFlushRaf = null
+						if (self2.disposed || !self2.liveImg || self2.pendingLiveFrame == null) return
+						try { self2.liveImg.src = self2.pendingLiveFrame } catch (e) {}
+						self2.pendingLiveFrame = null
+					})
+				}
+				return
+			}
+			if (!this.pinned && this.selectedTabId === null && targetId === this.agentActiveId) {
+				var now = Date.now()
+				if (now - this.lastFrameAt >= FRAME_FOLLOW_MIN_MS) {
+					this.lastFrameAt = now
+					if (this.followTimer) window.clearTimeout(this.followTimer)
+					var self3 = this
+					this.followTimer = window.setTimeout(function () {
+						if (self3.disposed || self3.pinned || self3.selectedTabId !== null) return
+						if (self3.liveImg && self3.liveImgTargetId === targetId) return
+						var meta = self3.pageMeta.get(targetId)
+						if (!meta) return
+						self3.currentActiveId = targetId
+						self3._recompute()
+					}, 0)
+				}
+			}
+		}
+		LivePreviewController.prototype.sendInput = function (targetId, type, params) {
+			if (!targetId) return
+			void fetch(INPUT_ROUTE, {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify(Object.assign({ targetId: targetId, type: type }, params)),
+			}).catch(function () {})
+		}
+		LivePreviewController.prototype.browserXY = function (e) {
+			if (this.liveImgTargetId == null || !this.liveImg) return null
+			var m = this.pageMeta.get(this.liveImgTargetId)
+			var vw = m && m.vw, vh = m && m.vh
+			if (!Number.isFinite(vw) || !Number.isFinite(vh)) return null
+			var img = this.liveImg
+			var rect = img.getBoundingClientRect()
+			var natW = img.naturalWidth || rect.width
+			var natH = img.naturalHeight || rect.height
+			if (!natW || !natH) return null
+			var scale = Math.min(rect.width / natW, rect.height / natH)
+			var contentW = natW * scale
+			var contentH = natH * scale
+			var ox = (rect.width - contentW) / 2
+			var oy = (rect.height - contentH) / 2
+			var rx = e.clientX - rect.left - ox
+			var ry = e.clientY - rect.top - oy
+			return { x: (rx / contentW) * vw, y: (ry / contentH) * vh }
+		}
+		LivePreviewController.prototype.pinTo = function (space) {
+			if (this.disposed) return
+			this.pinned = space
+			this.selectedTabId = null
+			this._recompute()
+		}
+		LivePreviewController.prototype.unpin = function () {
+			this.pinned = null
+			this._recompute()
+		}
+		LivePreviewController.prototype.selectTab = function (targetId) {
+			if (this.selectedTabId === targetId) {
+				this.selectedTabId = null
+				this.pinned = null
+			} else {
+				this.selectedTabId = targetId
+				this.pinned = null
+			}
+			this._recompute()
+		}
+		LivePreviewController.prototype.closeTab = function (targetId) {
+			var self = this
+			void (async function () {
+				try {
+					await fetch(EGO_CLOSE_ROUTE, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ targetId: targetId }) })
+				} catch (e) {}
+				if (self.selectedTabId === targetId) { self.selectedTabId = null; self.pinned = null }
+				self.refresh()
+			})()
+		}
+		LivePreviewController.prototype.toggleHistory = function () {
+			this.historyOpen = !this.historyOpen
+			this._recompute()
+		}
+		LivePreviewController.prototype.dismissGuide = function (which) {
+			this.dismissedGuides[which] = true
+			this._recompute()
+		}
+		LivePreviewController.prototype.flushLogin = function () {
+			return (async function () {
+				var r = await fetch(FLUSH_ROUTE, { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' })
+				return r.json()
+			})()
+		}
+		// Zoom/pan/input handlers (called from React JSX)
+		LivePreviewController.prototype._showHint = function (txt) {
+			this._zoomHint = txt
+			this._recompute()
+			if (this._zoomHintTimer) window.clearTimeout(this._zoomHintTimer)
+			var self = this
+			this._zoomHintTimer = window.setTimeout(function () {
+				self._zoomHint = null
+				self._recompute()
+			}, 2000)
+		}
+		LivePreviewController.prototype._applyZoom = function () {
+			if (!this.liveImg) return
+			this.liveImg.style.transformOrigin = '0 0'
+			this.liveImg.style.transform = 'translate(' + this.zoomState.tx + 'px,' + this.zoomState.ty + 'px) scale(' + this.zoomState.scale + ')'
+		}
+		LivePreviewController.prototype.resetZoom = function () {
+			this.zoomState = { scale: 1, tx: 0, ty: 0 }
+			this._applyZoom()
+			this._showHint('已复位 · 滚轮滚动页面 · Ctrl+滚轮缩放 · 双击复位')
+		}
+		LivePreviewController.prototype.handleWheel = function (e) {
+			e.preventDefault()
+			e.stopPropagation()
+			if (e.ctrlKey || e.metaKey) {
+				if (!this.liveImg) return
+				var rect = this.liveImg.getBoundingClientRect()
+				var mx = e.clientX - rect.left, my = e.clientY - rect.top
+				var next = Math.min(8, Math.max(1, this.zoomState.scale * (e.deltaY < 0 ? 1.15 : 1 / 1.15)))
+				if (next <= 1) { this.resetZoom(); return }
+				this.zoomState.tx = mx - (mx - this.zoomState.tx) * (next / this.zoomState.scale)
+				this.zoomState.ty = my - (my - this.zoomState.ty) * (next / this.zoomState.scale)
+				this.zoomState.scale = next
+				this._applyZoom()
+				this._showHint('Ctrl+滚轮缩放 · Ctrl+拖动平移 · 双击复位')
+				return
+			}
+			var p = this.browserXY(e)
+			if (p && this.liveImgTargetId) {
+				this.sendInput(this.liveImgTargetId, 'mouseWheel', {
+					x: p.x, y: p.y,
+					deltaX: e.deltaX || 0,
+					deltaY: e.deltaY || (e.deltaMode === 1 ? 40 : (e.deltaY || 100)),
+				})
+			}
+		}
+		LivePreviewController.prototype.handlePointerDown = function (e) {
+			if (e.button !== 0) return
+			this._pointerState = {
+				viewPanning: false, browserDrag: false,
+				sx: e.clientX, sy: e.clientY,
+				stx: this.zoomState.tx, sty: this.zoomState.ty,
+				lastDragPos: null, downButtons: 0,
+			}
+			try { e.currentTarget.setPointerCapture(e.pointerId) } catch (err) {}
+			if (e.ctrlKey || e.metaKey) {
+				this._pointerState.viewPanning = true
+				e.currentTarget.style.cursor = 'grabbing'
+				this._showHint('Ctrl+拖动平移 · 滚轮滚动页面')
+				return
+			}
+			this._pointerState.browserDrag = true
+			this._pointerState.downButtons = 1
+			var p = this.browserXY(e)
+			if (p) {
+				this._pointerState.lastDragPos = p
+				this.sendInput(this.liveImgTargetId, 'mousePressed', { x: p.x, y: p.y, button: 'left', buttons: 1, clickCount: 1 })
+			}
+		}
+		LivePreviewController.prototype.handlePointerMove = function (e) {
+			if (!this._pointerState) {
+				var p = this.browserXY(e)
+				if (p) this.sendInput(this.liveImgTargetId, 'mouseMoved', { x: p.x, y: p.y, buttons: 0 })
+				return
+			}
+			if (this._pointerState.viewPanning) {
+				this.zoomState.tx = this._pointerState.stx + (e.clientX - this._pointerState.sx)
+				this.zoomState.ty = this._pointerState.sty + (e.clientY - this._pointerState.sy)
+				this._applyZoom()
+				return
+			}
+			if (this._pointerState.browserDrag) {
+				var p2 = this.browserXY(e)
+				if (p2) {
+					this.sendInput(this.liveImgTargetId, 'mouseMoved', { x: p2.x, y: p2.y, buttons: this._pointerState.downButtons })
+					this._pointerState.lastDragPos = p2
+				}
+			}
+		}
+		LivePreviewController.prototype.handlePointerUp = function (e) {
+			if (!this._pointerState) return
+			if (this._pointerState.viewPanning) {
+				if (e.currentTarget) e.currentTarget.style.cursor = 'grab'
+			}
+			if (this._pointerState.browserDrag) {
+				if (this._pointerState.lastDragPos && this.liveImgTargetId) {
+					this.sendInput(this.liveImgTargetId, 'mouseReleased', {
+						x: this._pointerState.lastDragPos.x, y: this._pointerState.lastDragPos.y,
+						button: 'left', buttons: 0, clickCount: 1,
+					})
+				}
+			}
+			if (e.currentTarget) e.currentTarget.style.cursor = 'grab'
+			this._pointerState = null
+		}
+		LivePreviewController.prototype.handleDoubleClick = function (e) {
+			e.preventDefault()
+			this.resetZoom()
+		}
+
+		// ── EgoBrowserTab: React component for the sidebar tab ─────────────────
+		// Renders header + guide strips + tab strip + main live view (or history
+		// overlay). Subscribes to the controller's snapshot store; delegates
+		// pointer/wheel events on the live <img> to controller methods. The
+		// controller holds a direct ref to the <img> so SSE frames swap src at rAF
+		// cadence without triggering React re-renders per frame.
+		function EgoBrowserTab(props) {
+			var visible = props.visible
+			var controllerRef = React.useRef(null)
+			if (controllerRef.current === null) controllerRef.current = new LivePreviewController()
+			var controller = controllerRef.current
+
+			// Create the snapshot hook once per controller instance
+			var useSnapshotRef = React.useRef(null)
+			if (useSnapshotRef.current === null) {
+				useSnapshotRef.current = bindSnapshotSelector(controller.store)
+			}
+			var state = useSnapshotRef.current()
+
+			var imgRef = React.useRef(null)
+
+			React.useEffect(function () {
+				controller.start()
+				return function () { controller.dispose() }
+			}, [controller])
+
+			React.useEffect(function () {
+				controller.setVisible(visible)
+			}, [visible, controller])
+
+			// Attach the live <img> to the controller whenever the target changes
+			React.useEffect(function () {
+				if (imgRef.current && state.currentTargetId != null) {
+					controller.setLiveImg(imgRef.current, state.currentTargetId)
+				}
+			}, [state.currentTargetId, controller])
+
+			// Native wheel listener (React onWheel is passive, can't preventDefault)
+			React.useEffect(function () {
+				var img = imgRef.current
+				if (!img) return
+				var handler = function (e) { controller.handleWheel(e) }
+				img.addEventListener('wheel', handler, { passive: false })
+				return function () { img.removeEventListener('wheel', handler) }
+			}, [controller, state.currentTargetId])
+
+			var h = React.createElement
+
+			// Header
+			var header = h('div', { className: 'dsh-ego-side-head' },
+				h('span', { className: 'dsh-ego-side-title' },
+					h('span', { dangerouslySetInnerHTML: { __html: ICON_GLOBE } }),
+					h('span', { style: { marginLeft: '5px' } }, state.busy ? 'Agent 浏览器 · 实时' : 'Agent 浏览器')
+				),
+				h('button', {
+					className: 'dsh-ego-side-iconbtn' + (state.busy ? ' spinning' : ''),
+					title: '刷新',
+					onClick: function () {
+						controller.refresh()
+					},
+				}, h('span', { dangerouslySetInnerHTML: { __html: ICON_REFRESH } })),
+				h('button', {
+					className: 'dsh-ego-side-iconbtn' + (state.historyOpen ? '' : ' off'),
+					title: state.historyOpen ? '收起历史轨迹' : '历史浏览轨迹',
+					onClick: function () { controller.toggleHistory() },
+				}, h('span', { dangerouslySetInnerHTML: { __html: ICON_CLOCK } }))
+			)
+
+			// History overlay: covers the body area
+			if (state.historyOpen) {
+				var sorted = state.spaces.slice().sort(function (a, b) { return (a.lastActive || 0) - (b.lastActive || 0) })
+				return h('div', { className: 'dsh-ego-side-root' },
+					header,
+					h('div', { className: 'dsh-ego-side-history' },
+						h('div', { className: 'dsh-ego-side-historyhead' },
+							h('span', { dangerouslySetInnerHTML: { __html: ICON_CLOCK } }),
+							' 历史浏览轨迹'
+						),
+						h('div', { className: 'dsh-ego-side-historylist' },
+							sorted.length === 0
+								? h('div', { className: 'dsh-ego-side-hnone' }, '暂无浏览记录')
+								: sorted.map(function (s) {
+									return h('div', {
+										key: s.targetId,
+										className: 'dsh-ego-side-hitem' + (s.targetId === state.currentTargetId ? ' active' : ''),
+										onClick: function () { controller.pinTo(s); controller.toggleHistory() },
+									},
+										s.thumbnail
+											? h('img', { className: 'dsh-ego-side-hthumb', src: s.thumbnail, alt: '' })
+											: h('div', { className: 'dsh-ego-side-hthumb' }),
+										h('div', { className: 'dsh-ego-side-hinfo' },
+											h('div', { className: 'dsh-ego-side-htitle' }, s.title || s.url || '新标签页'),
+											h('div', { className: 'dsh-ego-side-hurl' }, s.url || '(about:blank)'),
+											s.targetId === state.currentTargetId ? h('div', { className: 'dsh-ego-side-hactive' }, '● 当前') : null
+										)
+									)
+								})
+						)
+					)
+				)
+			}
+
+			// Guide strips
+			var guides = []
+			if (state.showLoginGuide) {
+				guides.push(h(EgoLoginGuide, { key: 'login', controller: controller }))
+			}
+			if (state.captchaKind) {
+				guides.push(h(EgoCaptchaGuide, { key: 'captcha', kind: state.captchaKind, controller: controller }))
+			}
+
+			// Tab strip
+			var tabsEl = state.spaces.length > 0
+				? h('div', { className: 'dsh-ego-side-tabs' },
+					state.spaces.map(function (s) {
+						var isActive = s.targetId === state.selectedTabId || (state.selectedTabId === null && s.targetId === state.currentTargetId)
+						return h('div', {
+							key: s.targetId,
+							className: 'dsh-ego-side-tab' + (isActive ? ' active' : ''),
+							title: s.url || '',
+							onClick: function () { controller.selectTab(s.targetId) },
+						},
+							h('span', { className: 'dsh-ego-side-tabdot' }),
+							h('span', { className: 'dsh-ego-side-tabtxt' }, s.title || s.url || '(新标签页)'),
+							h('span', {
+								className: 'dsh-ego-side-tabclose',
+								title: '关闭标签',
+								onClick: function (e) { e.stopPropagation(); controller.closeTab(s.targetId) },
+							}, '×')
+						)
+					})
+				)
+				: null
+
+			// Main live view
+			var body
+			var currentSpace = state.currentSpace
+			if (!currentSpace) {
+				body = h('div', { className: 'dsh-ego-side-body' },
+					h('div', { className: 'dsh-ego-side-empty' },
+						h('div', null, '暂无活跃浏览器页'),
+						h('div', { style: { fontSize: '11px' } }, '当 agent 开始用 ego_* 操作网页时，这里会实时显示')
+					)
+				)
+			} else {
+				var liveImg = currentSpace.thumbnail
+					? h('img', {
+						ref: imgRef,
+						key: 'liveimg',
+						className: 'dsh-ego-side-liveimg',
+						src: currentSpace.thumbnail,
+						alt: 'live',
+						draggable: false,
+						onPointerDown: function (e) { controller.handlePointerDown(e) },
+						onPointerMove: function (e) { controller.handlePointerMove(e) },
+						onPointerUp: function (e) { controller.handlePointerUp(e) },
+						onPointerCancel: function (e) { controller.handlePointerUp(e) },
+						onDoubleClick: function (e) { controller.handleDoubleClick(e) },
+					})
+					: h('div', { className: 'dsh-ego-side-liveurl' }, '（暂无截图 — about:blank 或浏览器未渲染）')
+
+				body = h('div', { className: 'dsh-ego-side-body' },
+					h('div', { className: 'dsh-ego-side-liveview' },
+						h('div', { className: 'dsh-ego-side-livebadge' },
+							h('span', { className: 'dsh-ego-side-state-dot' + (state.pinned ? ' pin' : state.busy ? ' busy' : '') }),
+							h('span', { style: { flex: 1 } }, state.pinned ? '已固定查看' : '正在实时浏览'),
+							state.pinned
+								? h('button', {
+									className: 'dsh-ego-side-back', type: 'button',
+									onClick: function () { controller.unpin() },
+								}, '← 返回实时')
+								: null,
+							h('button', {
+								className: 'dsh-ego-side-back', type: 'button',
+								title: '在浏览器新标签打开真实页面',
+								onClick: function () {
+									var url = currentSpace.url
+									if (url && !url.startsWith('about:') && !url.startsWith('chrome://')) window.open(url, '_blank', 'noopener')
+								},
+							}, '⧉ 打开真实页')
+						),
+						liveImg,
+						h('div', { className: 'dsh-ego-side-livetitle' }, currentSpace.title || currentSpace.url || '(新标签页)'),
+						h('div', { className: 'dsh-ego-side-liveurl' + (state.zoomHint ? ' dsh-ego-side-hint' : '') }, state.zoomHint || currentSpace.url || '')
+					)
+				)
+			}
+
+			return h('div', { className: 'dsh-ego-side-root' }, header, guides, tabsEl, body)
+		}
+
+		function EgoLoginGuide(props) {
+			var controller = props.controller
+			var h = React.createElement
+			var noteState = React.useState('')
+			var note = noteState[0], setNote = noteState[1]
+			var savingState = React.useState(false)
+			var saving = savingState[0], setSaving = savingState[1]
+			return h('div', { className: 'dsh-ego-side-login' },
+				h('span', { className: 'dsh-ego-side-login-txt' },
+					'需要账号登录时，请到桌面上那个 ',
+					h('b', null, '「ego lite — agent」'),
+					' Chrome 窗口完成登录。'
+				),
+				h('button', {
+					className: 'dsh-ego-side-login-btn' + (saving ? ' saving' : ''),
+					type: 'button',
+					disabled: saving,
+					onClick: function () {
+						setSaving(true)
+						setNote('')
+						controller.flushLogin().then(function (j) {
+							if (j && j.ok) setNote('已保存 ' + (j.total || '') + ' 条会话')
+							else setNote(j && j.error ? '未连接浏览器' : '保存失败')
+						}).catch(function () { setNote('保存失败') }).finally(function () { setSaving(false) })
+					},
+				}, saving ? '保存中…' : '已登录，保存'),
+				note ? h('span', { className: 'dsh-ego-side-login-note' }, note) : null,
+				h('button', {
+					className: 'dsh-ego-side-iconbtn', type: 'button', title: '关闭提示',
+					onClick: function () { controller.dismissGuide('login') },
+				}, '×')
+			)
+		}
+
+		function EgoCaptchaGuide(props) {
+			var controller = props.controller
+			var kind = props.kind
+			var h = React.createElement
+			return h('div', { className: 'dsh-ego-side-captcha' },
+				h('span', { className: 'dsh-ego-side-captcha-txt' },
+					h('b', null, '⚠️ 检测到人机验证'),
+					' — 请在桌面那个 ',
+					h('b', null, '「ego lite — agent」'),
+					' 浏览器窗口手动完成验证，agent 会继续。'
+				),
+				h('span', { className: 'dsh-ego-side-captcha-kind' }, kind),
+				h('button', {
+					className: 'dsh-ego-side-iconbtn', type: 'button', title: '关闭提示',
+					onClick: function () { controller.dismissGuide('captcha') },
+				}, '×')
+			)
+		}
+
+		// ── mountSidebarTab: register the ego-browser watch tab ────────────────
+		function mountSidebarTab(ctx) {
+			// Inject Tab CSS once (cleaned up on dispose)
+			var styleEl = document.createElement('style')
+			styleEl.textContent = TAB_CSS
+			document.head.appendChild(styleEl)
+
+			var disposeTab = ctx.betterSidebar.registerTab({
+				id: 'ego-browser:watch',
+				title: function () { return 'Agent 浏览器' },
+				order: 70,
+				single: true,
+				component: EgoBrowserTab,
+			})
+
+			return function () {
+				disposeTab()
+				styleEl.remove()
+			}
 		}
 
 		function escapeHtml(s) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -554,11 +554,13 @@ window.__ModuleLoader__.load({
 			})
 
 		// ── Watch panel: sidebar tab if available, floating fallback otherwise ──
-		// Runtime probe (not in `inject`): adding 'betterSidebar' to inject would
-		// make it a hard dependency — without dsh-better-sidebar installed the
-		// whole plugin (including the settings card) would fail to load. Probing
-		// at runtime gives the graceful fallback the user expects.
-		if (ctx.betterSidebar !== void 0) {
+		// Opportunistic consumption via ctx.get() (NOT ctx.betterSidebar — that
+		// requires 'betterSidebar' in inject, which would make it a hard
+		// dependency: without dsh-better-sidebar installed the whole plugin,
+		// including the settings card, would fail to load). ctx.get() is the
+		// documented pattern for optional services (see approval-seam notes,
+		// postmortem 0001). Reads presence per call, degrades across HMR.
+		if (ctx.get('betterSidebar') !== undefined) {
 			ctx.effect(() => mountSidebarTab(ctx), 'ego-browser sidebar tab')
 		} else {
 			ctx.effect(() => mountFloatingWatch(ctx), 'ego-browser watch panel')
@@ -2379,12 +2381,14 @@ window.__ModuleLoader__.load({
 
 		// ── mountSidebarTab: register the ego-browser watch tab ────────────────
 		function mountSidebarTab(ctx) {
+			var betterSidebar = ctx.get('betterSidebar')
+			if (!betterSidebar) return function () {}
 			// Inject Tab CSS once (cleaned up on dispose)
 			var styleEl = document.createElement('style')
 			styleEl.textContent = TAB_CSS
 			document.head.appendChild(styleEl)
 
-			var disposeTab = ctx.betterSidebar.registerTab({
+			var disposeTab = betterSidebar.registerTab({
 				id: 'ego-browser:watch',
 				title: function () { return 'Agent 浏览器' },
 				order: 70,

--- a/lib/client.js
+++ b/lib/client.js
@@ -2152,7 +2152,11 @@ window.__ModuleLoader__.load({
 			if (useSnapshotRef.current === null) {
 				useSnapshotRef.current = bindSnapshotSelector(controller.store)
 			}
-			var state = useSnapshotRef.current()
+			// bindSnapshotSelector returns a selector hook that REQUIRES a selector
+			// function arg (it uses useSyncExternalStoreWithSelector internally).
+			// Calling it with no args → "w is not a function" (w is the minified
+			// selector param). Pass identity selector to get the whole snapshot.
+			var state = useSnapshotRef.current(function (s) { return s })
 
 			var imgRef = React.useRef(null)
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -2433,7 +2433,50 @@ window.__ModuleLoader__.load({
 				component: EgoBrowserTab,
 			})
 
+			// ── Auto-open probe ───────────────────────────────────────────────
+			// The LivePreviewController (inside the Tab component) only polls
+			// once the Tab is mounted, but the Tab only mounts once opened — a
+			// chicken-and-egg that means the auto-open transition inside the
+			// controller never fires. This lightweight standalone poller runs
+			// regardless of Tab visibility: it fetches /api/ego/spaces, watches
+			// toolCallCount 0 → >0, and calls openTab() once. Stops itself
+			// after firing (one-shot per session) and on plugin dispose.
+			var probeDisposed = false
+			var probeTimer = null
+			var lastToolCallCount = 0
+			var autoOpened = false
+			var probe = function () {
+				if (probeDisposed || autoOpened) return
+				void (async function () {
+					try {
+						var res = await fetch(SPACES_ROUTE, { cache: 'no-store' })
+						if (!res.ok) { scheduleProbe(); return }
+						var data = await res.json()
+						if (data && typeof data.toolCallCount === 'number') {
+							if (data.toolCallCount > 0 && lastToolCallCount === 0) {
+								autoOpened = true
+								try { betterSidebar.openTab({ type: 'ego-browser:watch' }) } catch (e) {}
+								return // stop probing after auto-open
+							}
+							lastToolCallCount = data.toolCallCount
+						}
+					} catch (e) {}
+					scheduleProbe()
+				})()
+			}
+			var scheduleProbe = function () {
+				if (probeDisposed || autoOpened) return
+				if (probeTimer) window.clearTimeout(probeTimer)
+				probeTimer = window.setTimeout(probe, POLL_IDLE_MS)
+			}
+			// Kick off the first probe shortly after mount (give the host a
+			// moment to be ready; avoids a startup spike if multiple plugins
+			// fire at once).
+			probeTimer = window.setTimeout(probe, 1500)
+
 			return function () {
+				probeDisposed = true
+				if (probeTimer) window.clearTimeout(probeTimer)
 				disposeTab()
 				styleEl.remove()
 			}

--- a/lib/config.js
+++ b/lib/config.js
@@ -22,15 +22,30 @@ export const Config = z.object({
   chromePath: z.string().default("").description(
     "Path to the Chrome/Chromium binary. Empty = auto-detect.",
   ),
+  /**
+   * Base refresh interval (ms) for the realtime watch panel: how often the
+   * client polls /api/ego/spaces for live screenshots / tab list while the
+   * agent is actively driving the browser. Idle cadence is derived as
+   * 4× this value. Range 500–30000; default 2000.
+   */
+  refreshInterval: z.number().min(500).max(30000).step(100).default(2000).description(
+    "Watch panel refresh interval in ms (idle = 4×). Default 2000.",
+  ),
 });
 
 /**
  * Resolve config with fallbacks for missing / invalid values.
  * @param {Partial<ReturnType<typeof Config>>} config - raw config from cordis.yml or settings scope.
- * @returns {{ chromePath: string }} a fully-populated config view.
+ * @returns {{ chromePath: string, refreshInterval: number }} a fully-populated config view.
  */
 export function resolveConfig(config) {
   const chromePath =
     typeof config?.chromePath === "string" ? config.chromePath : "";
-  return { chromePath };
+  const refreshInterval =
+    typeof config?.refreshInterval === "number" &&
+    Number.isFinite(config.refreshInterval) &&
+    config.refreshInterval >= 500 && config.refreshInterval <= 30000
+      ? config.refreshInterval
+      : 2000;
+  return { chromePath, refreshInterval };
 }

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -22,7 +22,7 @@ import { SETTINGS_NAMESPACE } from "./settings.js";
 const API_PREFIX = "/ego/api";
 
 /** Config keys the `set` endpoint accepts (allow-list; unknown keys are dropped). */
-const ALLOWED_KEYS = new Set(["chromePath"]);
+const ALLOWED_KEYS = new Set(["chromePath", "refreshInterval"]);
 
 /**
  * Register the `/ego/api` HTTP route on the host's web server.
@@ -32,7 +32,7 @@ const ALLOWED_KEYS = new Set(["chromePath"]);
  * when absent, `get` degrades to the entry source and `set` returns a
  * clear error.
  * @param {import("@deepseek-ai/cordis").Context} ctx - host context carrying `webServer`.
- * @param {{ source: () => { chromePath: string }, onChange: (cb: () => void) => void }} bridge
+ * @param {{ source: () => { chromePath: string, refreshInterval: number }, onChange: (cb: () => void) => void }} bridge
  *   the settings bridge the route reads through.
  */
 export function registerEgoBrowserGateway(ctx, bridge) {
@@ -104,7 +104,8 @@ async function handleSet(body, settings, bridge) {
  *
  * JSON wire boundary: null = "delete" (filtered), undefined never crosses
  * JSON. Unknown keys are dropped (the settings service is non-strict and
- * would otherwise store them).
+ * would otherwise store them). String keys (chromePath) and number keys
+ * (refreshInterval) are both accepted.
  */
 function extractPatch(body) {
   if (!isObject(body)) return {};
@@ -114,8 +115,11 @@ function extractPatch(body) {
   for (const [key, value] of Object.entries(raw)) {
     if (!ALLOWED_KEYS.has(key)) continue;
     if (value === null || value === undefined) continue;
-    if (typeof value !== "string") continue;
-    normalized[key] = value;
+    if (typeof value === "string") {
+      normalized[key] = value;
+    } else if (typeof value === "number" && Number.isFinite(value)) {
+      normalized[key] = value;
+    }
   }
   return normalized;
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -93,6 +93,13 @@ export interface Config {
      */
     chromePath?: string;
     /**
+     * Base refresh interval (ms) for the realtime watch panel: how often the
+     * client polls /api/ego/spaces while the agent is actively driving the
+     * browser. Idle cadence is 4× this value. Range 500–30000; default 2000.
+     * Set via the DSH settings UI (ego-browser card) or composition layer.
+     */
+    refreshInterval?: number;
+    /**
      * Path or command name of the ego-browser CLI.
      * Default: the vendored CLI bundled inside this plugin
      * (`runtime/ego-linux/bin/ego-browser.mjs`), so the plugin works with just

--- a/lib/index.js
+++ b/lib/index.js
@@ -533,6 +533,10 @@ export function apply(ctx, config = {}) {
   const entry = resolveConfig({
     chromePath:
       typeof config.chromePath === "string" ? config.chromePath : "",
+    refreshInterval:
+      typeof config.refreshInterval === "number"
+        ? config.refreshInterval
+        : undefined,
   });
   const bridge = installEgoBrowserSettings(ctx, entry);
 
@@ -548,6 +552,12 @@ export function apply(ctx, config = {}) {
     // the next spawn without restarting the plugin.
     get chromePath() {
       return bridge.source().chromePath || "";
+    },
+    // Live getter for the watch-panel refresh interval (ms). The client reads
+    // this through /ego/api/get; the host-side cfg mirror is here for symmetry
+    // and future host-side consumers.
+    get refreshInterval() {
+      return bridge.source().refreshInterval ?? 2000;
     },
   };
   const reg = (tool) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ import { defineTool } from "@deepseek-ai/dsh-tools";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
-import { initCastServer } from "./cast-server.js";
+import { initCastServer, markEgoToolCall } from "./cast-server.js";
 import { EGO_HELP_INDEX } from "./help.js";
 import { HUMAN_CHECK_PROBE } from "./captcha.js";
 import { Config as ConfigSchema } from "./config.js";
@@ -496,6 +496,12 @@ function defineEgoTool(ctx, cfg, opts) {
     timeoutMs: TOOL_TIMEOUT_MS,
     execute: async (args, exec) =>
       withEgoLock(async () => {
+        // Signal the client to auto-open the sidebar Tab on the first ego_*
+        // tool call. markEgoToolCall() bumps a host-side counter surfaced via
+        // /api/ego/spaces; the LivePreviewController transitions on 0 → >0 and
+        // calls betterSidebar.openTab(). Idempotent: the client's transition
+        // guard means only the first call per session opens the Tab.
+        markEgoToolCall();
         const script = opts.buildScript(args);
         // A first-call cold Chromium can make the spawn fail transiently
         // ("CDP channel is not open" etc.); retry only that case so a warmed
@@ -1651,6 +1657,7 @@ function registerActionTools(ctx, cfg, reg) {
         },
         timeoutMs: TOOL_TIMEOUT_MS,
         execute: async (args, exec) => {
+          markEgoToolCall();
           const script = str(args.script, "");
           const result = await withWarmupRetry(() =>
             runEgoScript(ctx.subprocess, script, exec, cfg)
@@ -1702,6 +1709,7 @@ function registerHelpAndDoctor(ctx, cfg, reg) {
       timeoutMs: 15_000,
       execute: async (args, exec) =>
         withEgoLock(async () => {
+          markEgoToolCall();
           const result = await withWarmupRetry(() =>
             runEgoScript(
               ctx.subprocess,
@@ -1865,6 +1873,7 @@ function registerHelpAndDoctor(ctx, cfg, reg) {
         },
         timeoutMs: TOOL_TIMEOUT_MS,
         execute: async (args, exec) => {
+          markEgoToolCall();
           const script = str(args.script, "");
           // Honor the documented per-run timeout override (integer ms). Falls
           // back to the plugin's default grace when absent/invalid.

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -41,7 +41,7 @@ function isUnloading(ctx) {
  * namespace.
  * @param {import("@deepseek-ai/cordis").Context} ctx - host context.
  * @param {{ chromePath: string }} entry - composition-layer config (cordis.patch.yml seed).
- * @returns {{ source: () => { chromePath: string }, onChange: (cb: () => void) => void }}
+ * @returns {{ source: () => { chromePath: string, refreshInterval: number }, onChange: (cb: () => void) => void }}
  */
 export function installEgoBrowserSettings(ctx, entry) {
   const listeners = new Set();

--- a/package.json
+++ b/package.json
@@ -40,13 +40,7 @@
     "@deepseek-ai/dsh-client-locale": "^0.0.1",
     "@deepseek-ai/dsh-client-ui-settings-plugins": "^0.0.1",
     "react": "^18.2.0",
-    "schemastery": "^3.18.0",
-    "dsh-better-sidebar": "*"
-  },
-  "peerDependenciesMeta": {
-    "dsh-better-sidebar": {
-      "optional": true
-    }
+    "schemastery": "^3.18.0"
   },
   "engines": {
     "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsh-external/ego-browser",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "ego-browser (ego-lite) integration plugin for DSH: structured browser-automation tools (30+ ego_*) that drive the vendored ego runtime through ctx.subprocess, plus a realtime watch panel (live SSE screencast + direct mouse interaction with the agent browser + download capture + human-verification notice + tab bar + login guide).",
   "private": true,
   "type": "module",
@@ -40,7 +40,13 @@
     "@deepseek-ai/dsh-client-locale": "^0.0.1",
     "@deepseek-ai/dsh-client-ui-settings-plugins": "^0.0.1",
     "react": "^18.2.0",
-    "schemastery": "^3.18.0"
+    "schemastery": "^3.18.0",
+    "dsh-better-sidebar": "*"
+  },
+  "peerDependenciesMeta": {
+    "dsh-better-sidebar": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsh-external/ego-browser",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "ego-browser (ego-lite) integration plugin for DSH: structured browser-automation tools (30+ ego_*) that drive the vendored ego runtime through ctx.subprocess, plus a realtime watch panel (live SSE screencast + direct mouse interaction with the agent browser + download capture + human-verification notice + tab bar + login guide).",
   "private": true,
   "type": "module",

--- a/runtime/PATCHES.md
+++ b/runtime/PATCHES.md
@@ -12,6 +12,7 @@
 |---|---|---|
 | `runtime/ego-linux/src/cursor.mjs` | 光标覆盖层默认名 `Claude` → `DeepSeek`（4 处：默认值 + 注释） | 品牌统一，`dacbd47` |
 | `runtime/ego-linux/src/chrome.mjs` | `resolveBinary()`: `candidate.includes("/")` → `isAbsolute(candidate)`；`which()`: Windows 用 `where` 替代 `which` | Windows 支持：POSIX `includes("/")` 不识别 `C:\\` 路径，`which` 在 Windows 不存在 |
+| `runtime/ego-linux/src/chrome.mjs` | `LAUNCH_FLAGS` 加 `--no-startup-window`；`launch()` 删除 `"about:blank"` 位置参数 | 消除单次 `ego_space_open` 开两个窗口：原位置参数在默认 browser context 开残留 tab，space tab 走独立 context 又开一个窗口，Chrome 把不同 context 隔离到不同窗口 → 用户看到两窗。`useSpace+ensureRealTab` 路由下不再需要 launch 残留 tab |
 | `runtime/ego-linux/src/paths.mjs` | Windows 用 `%LOCALAPPDATA%\\ego-lite-linux` 作为 DATA_DIR / STATE_DIR；`CHROME_CONFIG_CANDIDATES` 加 Windows 路径 | Windows 支持：XDG 变量在 Windows 不存在；`ego_doctor` 已预期 `%LOCALAPPDATA%` |
 | （其余 runtime 文件）| 与 vendoring 时一致 | 无后续本地改动 |
 

--- a/runtime/ego-linux/src/chrome.mjs
+++ b/runtime/ego-linux/src/chrome.mjs
@@ -57,6 +57,17 @@ const LAUNCH_FLAGS = [
   // appears as its own running app and the launcher icon cannot raise it.
   // Paired with StartupWMClass in the desktop entry.
   `--class=${WM_CLASS}`,
+  // The browser must come up holding NO tab. ego_space_open (and every other
+  // structured ego_* tool) routes through useSpace(...) + ensureRealTab(),
+  // which creates the first tab inside its own browser context — Chrome
+  // isolates each context to its own window, so that tab is the single window
+  // the user sees. If launch also opened a tab (the old "about:blank"
+  // positional arg), it would land in the default context and force a second
+  // window. The "no active tab to attach session" failure that used to make
+  // --no-startup-window unsafe only fired when a tool called page.* directly
+  // without first going through useSpace+ensureRealTab; the structured tools
+  // all do, so it no longer applies.
+  "--no-startup-window",
 ];
 
 /**
@@ -388,11 +399,6 @@ async function launch({ headless }) {
           "--proxy-bypass-list=<-loopback>;127.0.0.1;localhost;[::1];172.16.0.0/12;10.0.0.0/8;*.local",
         ]
       : []),
-    // The harness attaches its CDP session to the active tab and fails with
-    // "no active tab to attach session" when there is none, so the browser has
-    // to come up holding one. --no-startup-window was tried here and breaks
-    // every page operation for that reason.
-    "about:blank",
   ];
   const child = spawn(binary, args, {
     detached: true,

--- a/tests/env.test.mjs
+++ b/tests/env.test.mjs
@@ -337,3 +337,43 @@ describe("runtime chrome.mjs (Windows path handling)", () => {
     );
   });
 });
+
+// ─── runtime/ego-linux/src/chrome.mjs (single-window launch) ───────────────
+// Regression: ego_space_open used to open two windows because launch() passed
+// "about:blank" as a positional arg (opening a tab in the default browser
+// context), and ego_space_open then created another tab in its own context —
+// Chrome isolates contexts to separate windows. The fix is --no-startup-window
+// in LAUNCH_FLAGS and no positional URL. See PLAN-single-window-fix.md.
+
+describe("runtime chrome.mjs (single-window launch)", () => {
+  const readSrc = () =>
+    import("node:fs/promises").then((fs) =>
+      fs.readFile(
+        new URL("../runtime/ego-linux/src/chrome.mjs", import.meta.url),
+        "utf8",
+      ),
+    );
+
+  it("LAUNCH_FLAGS contains --no-startup-window", async () => {
+    const src = await readSrc();
+    assert.ok(
+      src.includes('"--no-startup-window"'),
+      "chrome.mjs LAUNCH_FLAGS should include --no-startup-window so launch " +
+        "does not open a residual tab in the default browser context",
+    );
+  });
+
+  it("launch() does not pass a bare about:blank positional arg", async () => {
+    const src = await readSrc();
+    // The old form was a standalone line `    "about:blank",` inside the
+    // launch() args array. Match it as the sole non-whitespace content of a
+    // line (with trailing comma) — flag-form uses like --no-startup-window
+    // don't match because they start with --.
+    assert.ok(
+      !/^\s*"about:blank",\s*$/m.test(src),
+      "chrome.mjs launch() should not pass a bare 'about:blank' positional " +
+        "URL — that opens a tab in the default context and forces a second " +
+        "window when ego_space_open later creates its own context-backed tab",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Integrates the ego-browser realtime watch panel with `dsh-better-sidebar` as a native sidebar Tab. When the sidebar service is available (`ctx.betterSidebar !== undefined`), the watch panel registers as a Tab instead of mounting the floating FAB + overlay. When absent, the original floating panel is used verbatim (graceful fallback).

## Architecture — Hybrid: React UI + vanilla controller

The user's requirement was "use native components for the sidebar Tab instead of the existing custom design." Given the ~1000 lines of fragile realtime pipeline logic in the existing floating panel (SSE frame cache, rAF coalescing, coordinate inverse-mapping, zoom/pan state), a full React rewrite would carry high regression risk. The hybrid approach keeps the pipeline logic as a vanilla controller while rendering the UI structure through React:

| Layer | Implementation | Responsibility |
|---|---|---|
| **React UI** (`EgoBrowserTab`) | `React.createElement` + `bindSnapshotSelector` | Header / tab strip / guide strips / main live view / history overlay |
| **Vanilla controller** (`LivePreviewController`) | Prototype-based class, `createSnapshotStore` | Polling / SSE / frame cache / zoom / input coordinate mapping / auto-follow |
| **Data sources** | unchanged | `/api/ego/spaces` (poll) + `/api/ego/stream` (SSE frames) |

The controller holds a direct ref to the live `<img>` element (set via React callback ref) so SSE frames swap `src` at rAF cadence without triggering React re-renders per frame. React only re-renders on structural changes (spaces list change, pinned/selected tab change, guide visibility, etc.).

## Key decisions

### Runtime probe, not `inject` dependency
`betterSidebar` is NOT added to the `inject` array — adding it would make the sidebar a hard dependency: without `dsh-better-sidebar` installed, the entire plugin (including the settings card) would fail to load. Instead, `apply()` probes `ctx.betterSidebar !== void 0` at runtime and dispatches to the appropriate path.

### History overlay, not side drawer
The floating panel's history is a side drawer (224px right column). In a ~300-400px sidebar Tab, splitting into two columns makes both too narrow. The Tab version uses an overlay: clicking the history button takes over the entire Tab content area; clicking a history item pins it and returns to the main view.

### Floating panel preserved verbatim
`mountFloatingWatch(ctx)` is a mechanical move of the original `ctx.effect(() => { ... })` body into a standalone function. No logic changes — the no-sidebar experience is identical to 0.7.x.

### Accepted tradeoffs (honest)
- **Race condition**: if `dsh-better-sidebar` loads after ego-browser, `ctx.betterSidebar` will be `undefined` when `apply()` runs → falls back to floating panel. DSH's loader typically loads the sidebar first; if not, a page refresh fixes it.
- **Structural duplication**: the floating panel and the controller share similar logic (polling, SSE, frame cache) but are not unified. Unifying would require refactoring the floating panel to use the controller, which is extra work with regression risk and no user-visible benefit.

## Changes

| File | Change |
|---|---|
| `lib/client.js` | `apply()` dispatch + `mountFloatingWatch` (moved verbatim) + `LivePreviewController` class + `EgoBrowserTab`/`EgoLoginGuide`/`EgoCaptchaGuide` React components + `mountSidebarTab` + `TAB_CSS` |
| `package.json` | `0.7.1` → `0.8.0`; `dsh-better-sidebar` added as optional peer dependency (`peerDependenciesMeta.optional: true`) |
| `CHANGELOG.md` | `[v0.8.0]` section |

## Verification

- [x] `pnpm run build` — `node --check` syntax validation passes
- [x] `pnpm test` — 20/20 tests pass (no new tests; existing tests unaffected)
- [ ] **Manual verification (needs human)**:
  1. With `dsh-better-sidebar` installed: start `dsh web`, open the sidebar, click `+`, verify "Agent 浏览器" Tab appears, open it, verify live view works (SSE frames, tab strip, zoom/pan/input, history overlay, login/captcha guides).
  2. Without `dsh-better-sidebar`: verify the floating FAB + panel works as before (no regression).
  3. Per `AGENTS.md`, the agent must not start `dsh web`; this step is left for the maintainer.

## Test plan for reviewer

1. `pnpm run build` + `pnpm test` — confirm green.
2. Install both `ego-browser` and `dsh-better-sidebar` in a profile, start `dsh web`, open the sidebar `+` menu, verify the "Agent 浏览器" Tab is listed.
3. Open the Tab, trigger an `ego_space_open` call, verify:
   - Live frames stream into the `<img>` (SSE path)
   - Tab strip shows the agent's browser tabs
   - Zoom (Ctrl+wheel), pan (Ctrl+drag), click/drag forwarding work
   - History button shows the overlay with past pages
   - Login guide appears when the agent navigates to a non-about:blank page
4. Uninstall `dsh-better-sidebar`, restart `dsh web`, verify the floating FAB + panel still works (no regression).
