### PR TITLE
feat: pure SSE watch panel + user-configurable cast worker parameters

### DIFF
--- a/bin/ego-cast-worker.mjs
+++ b/bin/ego-cast-worker.mjs
@@ -282,7 +282,10 @@ async function snapshotSpaces() {
     // Read only already-cached frames — never call startScreencast here. That
     // keeps the initial "spaces" push instant and, crucially, does not steal
     // the one screencast stream Chrome allows per target away from the live
-    // fan-out below.
+    // fan-out below. We also do NOT include the frame bytes in the snapshot
+    // anymore — the live JPEGs stream over SSE `frame` events; the snapshot
+    // is pure metadata so the panel can render its tab list without waiting
+    // on a captureScreenshot per target.
     const frames = active.pool.cachedFrames ? active.pool.cachedFrames() : new Map();
     const spaces = [];
     for (const t of targets.slice(0, 30)) {
@@ -303,7 +306,6 @@ async function snapshotSpaces() {
         url: t.url,
         title: t.title,
         active: isActive,
-        thumbnail: meta?.frame ? `data:image/jpeg;base64,${meta.frame}` : null,
         lastActive: meta?.lastActive ?? 0,
         viewportW: meta?.viewportW ?? undefined,
         viewportH: meta?.viewportH ?? undefined,
@@ -694,8 +696,37 @@ async function runConnectLoop() {
  * Runs until `session` stops being current (its socket dropped). frameFor is
  * idempotent for existing casts, so calling it often is cheap; the screenshot
  * backstop is throttled per target by refreshFrame's own 500ms floor.
+ *
+ * This loop ALSO broadcasts a `spaces` event on every tick (URL/title/active
+ * changes), so the watch panel no longer needs to poll /api/spaces. The tick
+ * cadence is the panel's metadata freshness bound — every 500ms by default.
  */
-async function keepCastsAlive(session, intervalMs = 3000) {
+
+// Metadata broadcast throttle. `spaces` events are cheap (no JPEG bytes), but
+// we still don't want to flood the SSE pipe on a busy tab churn — coalesce
+// back-to-back triggers into a single push within this window.
+let spacesBroadcastPending = false;
+let spacesBroadcastTimer = null;
+const SPACES_BROADCAST_THROTTLE_MS = 250;
+/**
+ * Schedule a `spaces` event broadcast on the next microtask, coalesced so a
+ * flurry of target changes / url updates collapses into a single push.
+ * Safe to call from any path (CDP event handler, keepalive tick, etc).
+ */
+function scheduleSpacesBroadcast() {
+  if (spacesBroadcastPending) return;
+  spacesBroadcastPending = true;
+  spacesBroadcastTimer = setTimeout(() => {
+    spacesBroadcastPending = false;
+    spacesBroadcastTimer = null;
+    if (sseClients.size === 0) return;
+    snapshotSpaces().then((snap) => {
+      if (sseClients.size > 0) sseBroadcast("spaces", snap);
+    }).catch(() => {});
+  }, SPACES_BROADCAST_THROTTLE_MS);
+}
+
+async function keepCastsAlive(session, intervalMs = 500) {
   while (active === session) {
     try {
       const targets = await listPageTargets(session.cdp);
@@ -712,6 +743,9 @@ async function keepCastsAlive(session, intervalMs = 3000) {
           sseBroadcast("frame", { targetId: t.targetId, data: cast.frame, ts: Date.now() });
         }
       }
+      // Push the current tab list (url/title/active/viewport/humanCheck) so
+      // the panel can render its tab bar without polling /api/spaces.
+      scheduleSpacesBroadcast();
     } catch {
       // browser call failed; keep trying on the next tick
     }
@@ -828,48 +862,17 @@ async function main() {
       return;
     }
     if (req.method === "GET" && url.pathname === "/api/spaces") {
+      // Lightweight metadata endpoint. Used as the initial snapshot when a
+      // watch panel's SSE connection comes up, and as a reconnect fallback.
+      // Returns ONLY metadata (url/title/active/viewport/humanCheck) — no
+      // thumbnail bytes — because the live frames already stream over SSE.
+      // This drops a 30-tab response from ~30 × 700ms captureScreenshot calls
+      // down to a single Target.getTargets + cachedFrames() map lookup (<50ms).
       const sess = active;
       if (!sess) return sendJson(res, 200, { ok: true, spaces: [] });
       try {
-        const targets = await listPageTargets(sess.cdp);
-        const activeId = await activeTabId();
-        const spaces = [];
-        for (const t of targets.slice(0, 30)) {
-          try {
-            // refreshFrame forces a fresh screenshot so the watch panel shows
-            // the CURRENT picture of each page (screencast alone can freeze on
-            // pages that change without repainting, e.g. a playing video).
-            const cast = await sess.pool.refreshFrame(t.targetId);
-            const cached = probeCache.get(t.targetId);
-            if (!cached || Date.now() - cached.at > PROBE_INTERVAL_MS) {
-              probeHuman(sess.cdp, sess.pool.sessionFor ? sess.pool.sessionFor(t.targetId) : null)
-                .then((human) => probeCache.set(t.targetId, { at: Date.now(), human }))
-                .catch(() => {});
-            }
-            spaces.push({
-              targetId: t.targetId,
-              url: t.url,
-              title: t.title,
-              active: activeId !== null && t.targetId === activeId,
-              thumbnail: cast?.frame ? `data:image/jpeg;base64,${cast.frame}` : null,
-              // Most-recently-active first: the page the agent is currently
-              // looking at (or just touched) gets the newest lastActive.
-              lastActive: cast?.lastActive ?? 0,
-              viewportW: cast?.viewportW ?? undefined,
-              viewportH: cast?.viewportH ?? undefined,
-              humanCheck: (cached && cached.human) ?? null,
-            });
-          } catch {
-            /* skip broken target */
-          }
-        }
-        // The agent's browser-MRU-active tab always on top; the rest by activity.
-        spaces.sort((a, b) => {
-          const ad = a.active ? 1 : 0, bd = b.active ? 1 : 0;
-          if (ad !== bd) return bd - ad;
-          return (b.lastActive ?? 0) - (a.lastActive ?? 0);
-        });
-        return sendJson(res, 200, { ok: true, spaces });
+        const snap = await snapshotSpaces();
+        return sendJson(res, 200, { ok: true, spaces: snap });
       } catch {
         return sendJson(res, 200, { ok: true, spaces: [] });
       }

--- a/bin/ego-cast-worker.mjs
+++ b/bin/ego-cast-worker.mjs
@@ -342,6 +342,40 @@ async function snapshotSpaces() {
   }
 }
 
+/**
+ * Script injected into every page target to force the compositor to keep
+ * producing frames. Without this, pages that don't visibly repaint — video
+ * players with hardware-accelerated <video>, canvas animations rendered in
+ * a separate compositor layer, or simply static pages — never trigger
+ * Page.screencastFrame events, so the watch panel freezes until the 5-second
+ * captureScreenshot backstop fires.
+ *
+ * The element is a 1px fully-transparent div with an infinite opacity
+ * animation. The animation forces the compositor to recomposite every frame
+ * (opacity is a compositor-layer property), which in turn causes Chrome to
+ * emit Page.screencastFrame events at the browser's native cadence. The
+ * element is invisible (opacity:0 + pointer-events:none + z-index:-1) and
+ * costs negligible CPU/GPU on modern hardware.
+ *
+ * Idempotent: the guard variable prevents double-injection on
+ * addScriptToEvaluateOnNewDocument + Runtime.evaluate overlap.
+ */
+const FORCE_REPAINT_SCRIPT = `(function(){
+  if(window.__egoForceRepaint__)return;
+  window.__egoForceRepaint__=true;
+  var s=document.createElement('style');
+  s.textContent='@keyframes __ego_fr__{0%,100%{opacity:0}50%{opacity:0.001}}';
+  (document.head||document.documentElement).appendChild(s);
+  function add(){
+    var el=document.createElement('div');
+    el.setAttribute('data-ego-fr','');
+    el.style.cssText='position:fixed;top:0;left:0;width:1px;height:1px;pointer-events:none;z-index:-1;opacity:0;animation:__ego_fr__ 0.5s infinite';
+    (document.body||document.documentElement).appendChild(el);
+  }
+  if(document.body)add();
+  else document.addEventListener('DOMContentLoaded',add);
+})();`;
+
 /** Screencast pool: one live stream per page target, newest JPEG cached. */
 function createCastPool(cdp) {
   const casts = new Map();
@@ -417,7 +451,25 @@ function createCastPool(cdp) {
     try {
       const { result } = await cdp.call("Target.attachToTarget", { targetId, flatten: true });
       sessionId = result.sessionId;
+      // Enable Page domain explicitly so screencastFrame events are delivered.
+      // startScreencast implicitly enables it in most Chrome builds, but being
+      // explicit avoids relying on undocumented behavior.
+      await cdp.call("Page.enable", {}, sessionId).catch(() => {});
       await cdp.call("Page.startScreencast", { format: "jpeg", quality: castConfig.screencastQuality, maxWidth: castConfig.screencastMaxWidth, everyNthFrame: 1 }, sessionId);
+      // Inject a force-repaint animation so the compositor keeps producing
+      // frames even on pages that don't repaint on their own — video players,
+      // canvas animations, and static pages with hardware-accelerated content
+      // all freeze the screencast stream because Chrome's compositor only
+      // emits a new frame when something visible changes. The injected element
+      // is a 1px transparent div with an infinite opacity animation; this
+      // forces the compositor to recomposite every frame, which triggers
+      // Page.screencastFrame events at the browser's native cadence.
+      // addScriptToEvaluateOnNewDocument survives navigation; Runtime.evaluate
+      // covers the current page immediately.
+      try {
+        await cdp.call("Page.addScriptToEvaluateOnNewDocument", { source: FORCE_REPAINT_SCRIPT }, sessionId);
+        await cdp.call("Runtime.evaluate", { expression: FORCE_REPAINT_SCRIPT, silent: true }, sessionId);
+      } catch { /* best-effort — screencast still works, just may be slow on static pages */ }
     } catch (err) {
       return null; // attach/screencast failed — caller reports no thumbnail
     }

--- a/bin/ego-cast-worker.mjs
+++ b/bin/ego-cast-worker.mjs
@@ -216,14 +216,32 @@ function sseBroadcast(event, payload) {
 /** Rebuild the current snapshot ({targetId,url,title,lastActive}) for a client. */
 const probeCache = new Map(); // targetId -> { at, human }
 const PROBE_INTERVAL_MS = 5000;
-// Optional cap on live-frame fan-out. 0 / unset = uncapped (full speed, requires
-// --disable-frame-rate-limit in the wrapper to actually exceed the default
-// compositor ceiling). >0 = at most N frames/sec sent to clients; the watched
-// (active) tab is never throttled so the user always sees the page being
-// operated at full rate, only background repainting tabs are capped. This keeps
-// panel bandwidth/CPU bounded on dynamic pages without degrading the one you're
-// looking at.
-const CAST_FPS_CAP = Number(process.env.EGO_CAST_FPS_CAP || 0);
+// ── Cast config (live-hot-swappable) ────────────────────────────────────────
+// The host spawns this worker with the current cast settings as a JSON argv
+// arg (process.argv[2]); subsequent settings edits are hot-pushed via
+// POST /api/config. All three values are mutable so the watch panel's
+// screencast parameters can be tuned at runtime without restarting the
+// worker or the browser attachment.
+//
+//   castFpsCap        : 0 = uncapped (full repaint cadence); >0 = at most N
+//                       frames/sec pushed to clients. The watched (active)
+//                       tab is never throttled; only background repainting
+//                       tabs are rate-limited.
+//   screencastQuality : JPEG quality (1-100) for startScreencast + backstop
+//                       captureScreenshot.
+//   screencastMaxWidth: max CSS px width of each pushed frame.
+let castConfig = { castFpsCap: 0, screencastQuality: 55, screencastMaxWidth: 960 };
+try {
+  const arg = process.argv[2];
+  if (arg) {
+    const parsed = JSON.parse(arg);
+    if (parsed && typeof parsed === "object") {
+      if (typeof parsed.castFpsCap === "number") castConfig.castFpsCap = parsed.castFpsCap;
+      if (typeof parsed.screencastQuality === "number") castConfig.screencastQuality = parsed.screencastQuality;
+      if (typeof parsed.screencastMaxWidth === "number") castConfig.screencastMaxWidth = parsed.screencastMaxWidth;
+    }
+  }
+} catch { /* malformed argv — keep defaults */ }
 
 // ── active-tab tracking ─────────────────────────────────────────────────────
 // Which page the agent is CURRENTLY on is the single most important fact for the
@@ -348,7 +366,7 @@ function createCastPool(cdp) {
         // Optional fan-out cap. Uncapped (0) → always send. Capped → the
         // watched (active) tab always passes; only background repainting tabs
         // are rate-limited to free bandwidth/CPU on dynamic pages.
-        let pass = CAST_FPS_CAP <= 0;
+        let pass = castConfig.castFpsCap <= 0;
         if (!pass) {
           // Sync path: use the cached active id so a frame is never gated
           // behind an await. The cap is opt-in; the default (0) short-circuits
@@ -358,7 +376,7 @@ function createCastPool(cdp) {
           if (isWatched) {
             pass = true;
           } else {
-            const minGapMs = 1000 / CAST_FPS_CAP;
+            const minGapMs = 1000 / castConfig.castFpsCap;
             const now = Date.now();
             if (!cast.lastCastAt || now - cast.lastCastAt >= minGapMs) {
               cast.lastCastAt = now;
@@ -399,7 +417,7 @@ function createCastPool(cdp) {
     try {
       const { result } = await cdp.call("Target.attachToTarget", { targetId, flatten: true });
       sessionId = result.sessionId;
-      await cdp.call("Page.startScreencast", { format: "jpeg", quality: 55, maxWidth: 960, everyNthFrame: 1 }, sessionId);
+      await cdp.call("Page.startScreencast", { format: "jpeg", quality: castConfig.screencastQuality, maxWidth: castConfig.screencastMaxWidth, everyNthFrame: 1 }, sessionId);
     } catch (err) {
       return null; // attach/screencast failed — caller reports no thumbnail
     }
@@ -447,7 +465,7 @@ function createCastPool(cdp) {
     if (pending.has(targetId)) return pending.get(targetId);
     const p = (async () => {
       try {
-        const shot = await cdp.call("Page.captureScreenshot", { format: "jpeg", quality: 55 }, cast.sessionId);
+        const shot = await cdp.call("Page.captureScreenshot", { format: "jpeg", quality: castConfig.screencastQuality }, cast.sessionId);
         const data = shot?.result?.data || shot?.data || null;
         if (data && data.length > 0) {
           cast.frame = data;
@@ -513,7 +531,29 @@ function createCastPool(cdp) {
     return casts.get(targetId)?.sessionId ?? null;
   }
 
-  return { frameFor, refreshFrame, removeCast, cachedFrames, sendInput, sessionFor };
+  /**
+   * Restart every active screencast stream with the given parameters. Used
+   * when the user changes screencastQuality / screencastMaxWidth in the
+   * settings card — Chrome only honors new params on a fresh
+   * startScreencast call (the running stream keeps its original params).
+   * Best-effort: a target whose restart fails is left with its old stream.
+   */
+  async function restartScreencasts({ quality, maxWidth }) {
+    const tasks = [];
+    for (const [tid, cast] of casts) {
+      tasks.push((async () => {
+        try {
+          await cdp.call("Page.stopScreencast", {}, cast.sessionId);
+        } catch { /* may already be stopped */ }
+        try {
+          await cdp.call("Page.startScreencast", { format: "jpeg", quality, maxWidth, everyNthFrame: 1 }, cast.sessionId);
+        } catch { /* target may have died — drop will follow on targetDestroyed */ }
+      })());
+    }
+    await Promise.all(tasks);
+  }
+
+  return { frameFor, refreshFrame, removeCast, cachedFrames, sendInput, sessionFor, restartScreencasts };
 }
 
 async function listPageTargets(cdp) {
@@ -767,6 +807,39 @@ async function main() {
   const server = createServer(async (req, res) => {
     const url = new URL(req.url, "http://127.0.0.1");
     if (req.method === "GET" && url.pathname === "/api/health") return sendJson(res, 200, { ok: !!active });
+    if (req.method === "POST" && url.pathname === "/api/config") {
+      // Hot-update cast parameters. castFpsCap takes effect immediately (the
+      // screencastFrame handler reads castConfig on every frame);
+      // screencastQuality / screencastMaxWidth require restarting the running
+      // screencast streams (Chrome only honors new params on a fresh
+      // startScreencast call).
+      try {
+        const body = JSON.parse((await readBody(req)) || "{}");
+        const prev = { ...castConfig };
+        if (typeof body.castFpsCap === "number" && body.castFpsCap >= 0 && body.castFpsCap <= 60) {
+          castConfig.castFpsCap = body.castFpsCap;
+        }
+        if (typeof body.screencastQuality === "number" && body.screencastQuality >= 1 && body.screencastQuality <= 100) {
+          castConfig.screencastQuality = body.screencastQuality;
+        }
+        if (typeof body.screencastMaxWidth === "number" && body.screencastMaxWidth >= 320 && body.screencastMaxWidth <= 1920) {
+          castConfig.screencastMaxWidth = body.screencastMaxWidth;
+        }
+        // If quality or width changed, restart the running screencast streams
+        // so the new params take effect immediately. fpsCap needs no restart.
+        const needsRestart = castConfig.screencastQuality !== prev.screencastQuality
+          || castConfig.screencastMaxWidth !== prev.screencastMaxWidth;
+        if (needsRestart && active?.pool?.restartScreencasts) {
+          active.pool.restartScreencasts({
+            quality: castConfig.screencastQuality,
+            maxWidth: castConfig.screencastMaxWidth,
+          }).catch(() => {});
+        }
+        return sendJson(res, 200, { ok: true, config: castConfig });
+      } catch (err) {
+        return sendJson(res, 500, { ok: false, error: String(err?.message || err) });
+      }
+    }
     if (req.method === "POST" && url.pathname === "/api/close") {
       const sess = active;
       if (!sess) return sendJson(res, 400, { ok: false, error: "no live browser" });

--- a/bin/ego-cast-worker.mjs
+++ b/bin/ego-cast-worker.mjs
@@ -230,7 +230,7 @@ const PROBE_INTERVAL_MS = 5000;
 //   screencastQuality : JPEG quality (1-100) for startScreencast + backstop
 //                       captureScreenshot.
 //   screencastMaxWidth: max CSS px width of each pushed frame.
-let castConfig = { castFpsCap: 0, screencastQuality: 55, screencastMaxWidth: 960 };
+let castConfig = { castFpsCap: 0, screencastQuality: 55, screencastMaxWidth: 960, backstopIntervalMs: 5000 };
 try {
   const arg = process.argv[2];
   if (arg) {
@@ -239,6 +239,7 @@ try {
       if (typeof parsed.castFpsCap === "number") castConfig.castFpsCap = parsed.castFpsCap;
       if (typeof parsed.screencastQuality === "number") castConfig.screencastQuality = parsed.screencastQuality;
       if (typeof parsed.screencastMaxWidth === "number") castConfig.screencastMaxWidth = parsed.screencastMaxWidth;
+      if (typeof parsed.backstopIntervalMs === "number") castConfig.backstopIntervalMs = parsed.backstopIntervalMs;
     }
   }
 } catch { /* malformed argv — keep defaults */ }
@@ -512,8 +513,13 @@ function createCastPool(cdp) {
   function refreshFrame(targetId) {
     const cast = casts.get(targetId);
     if (!cast) return frameFor(targetId);
+    // The minimum interval between forced captures for the same target is
+    // derived from castConfig.backstopIntervalMs so lowering the backstop
+    // setting actually increases the forced-capture rate (the previous
+    // hardcoded 500ms floor could silently cap a user-set 200ms backstop).
+    const floorMs = Math.max(100, Math.min(castConfig.backstopIntervalMs, 2000));
     const since = Date.now() - (lastShot.get(targetId) || 0);
-    if (since < 500) return cast;
+    if (since < floorMs) return cast;
     if (pending.has(targetId)) return pending.get(targetId);
     const p = (async () => {
       try {
@@ -725,11 +731,10 @@ async function cleanStaleCastState() {
 // ---------------------------------------------------------------------------
 const RETRY_NO_BROWSER_MS = 3000;  // no browser.json / unreachable
 const RETRY_AFTER_DROP_MS = 2000;  // CDP socket closed or errored
-// How long a page may go without a pushed screencast frame before the periodic
-// backstop issues a forced screenshot for it. Longer than the keepalive interval
-// so a live page (fed by screencast each repaint) is never needlessly captured,
-// while a quiet/backgrounded page still gets rescued within a visible window.
-const BACKSTOP_STALE_MS = 5000;
+// Backstop stale threshold is now configurable via castConfig.backstopIntervalMs
+// (see castConfig above). The default (5000ms) is applied when no config is
+// provided. The value is read live from castConfig in keepCastsAlive so a
+// hot-update via POST /api/config takes effect on the next tick.
 let active = null; // { cdp, pool } for the live browser attachment
 
 async function openBrowserSession(wsUrl, browserPort = null) {
@@ -828,7 +833,7 @@ async function keepCastsAlive(session, intervalMs = 500) {
         if (!session.pool.frameFor) continue;
         await session.pool.frameFor(t.targetId).catch(() => {});
         const meta = cached.get(t.targetId);
-        const stale = !meta || (now - (meta.lastActive || 0)) > BACKSTOP_STALE_MS;
+        const stale = !meta || (now - (meta.lastActive || 0)) > castConfig.backstopIntervalMs;
         if (!stale) continue;
         const cast = await session.pool.refreshFrame(t.targetId).catch(() => null);
         if (cast?.frame && sseClients.size > 0) {
@@ -876,6 +881,9 @@ async function main() {
         }
         if (typeof body.screencastMaxWidth === "number" && body.screencastMaxWidth >= 320 && body.screencastMaxWidth <= 1920) {
           castConfig.screencastMaxWidth = body.screencastMaxWidth;
+        }
+        if (typeof body.backstopIntervalMs === "number" && body.backstopIntervalMs >= 200 && body.backstopIntervalMs <= 10000) {
+          castConfig.backstopIntervalMs = body.backstopIntervalMs;
         }
         // If quality or width changed, restart the running screencast streams
         // so the new params take effect immediately. fpsCap needs no restart.

--- a/lib/cast-server.js
+++ b/lib/cast-server.js
@@ -26,16 +26,23 @@ export const EGO_INPUT_ROUTE = '/api/ego/input';
 
 // ── tool-call signal (auto-open sidebar Tab) ─────────────────────────────
 // Module-level counter bumped by markEgoToolCall() from the tool execute
-// path (lib/index.js: defineEgoTool). Surfaced via the /api/ego/spaces
-// response so the client polls it for free (no new route, no new poller).
-// The client transitions on 0 → >0 to call betterSidebar.openTab(), so the
-// Tab opens the first time an ego_* tool actually runs, not just when the
-// browser launches. Process-local (one Node process serves all clients);
-// resets to 0 on host restart, which is fine — the auto-open is a one-shot
-// per session anyway.
+// path (lib/index.js: defineEgoTool). When a new tool call lands, we
+// broadcast a `tool-call` SSE event to every connected watch-panel client
+// so the sidebar auto-opens instantly — NO client-side polling needed.
+// (Previously the client polled /api/ego/spaces every 2s to detect this;
+//  that loop is now gone.) Process-local; resets to 0 on host restart,
+// which is fine — the auto-open is a one-shot per session anyway.
 let toolCallCount = 0;
+const sseClients = new Set();
 export function markEgoToolCall() {
   toolCallCount += 1;
+  // Push the new count to every connected SSE client immediately. The event
+  // payload is tiny (just the counter); frames and spaces events continue
+  // to flow from the worker as before.
+  const frame = `event: tool-call\ndata: ${JSON.stringify({ count: toolCallCount })}\n\n`;
+  for (const res of sseClients) {
+    try { res.write(frame); } catch { sseClients.delete(res); }
+  }
 }
 
 function castStatePath() {
@@ -100,11 +107,15 @@ async function proxyPost(port, path, body) {
  * background loop. The connection stays open until the worker stream ends or
  * the client disconnects. If the worker is unreachable we still emit a valid
  * empty SSE stream (the panel stays quiet instead of erroring).
+ *
+ * Each `res` is also registered in the module-level `sseClients` set so
+ * markEgoToolCall() can inject `tool-call` events directly into the live
+ * stream (the sidebar auto-open signal), without the client polling.
  */
 function proxyWorkerStream(port, res, path) {
   let cancelled = false;
   let ended = false;
-  const endOnce = () => { if (ended) return; ended = true; try { res.end(); } catch {} };
+  const endOnce = () => { if (ended) return; ended = true; sseClients.delete(res); try { res.end(); } catch {} };
   res.writeHead(200, {
     'content-type': 'text/event-stream',
     'cache-control': 'no-cache',
@@ -112,6 +123,7 @@ function proxyWorkerStream(port, res, path) {
     'x-accel-buffering': 'no',
   });
   res.write(':ok\n\n');
+  sseClients.add(res);
   // Use node:http (not fetch) to consume the worker's SSE stream. fetch buffers
   // chunked responses in a way that delays/interleaves the first data chunks
   // under Node's undici, which the real-time frame pipeline cannot tolerate —
@@ -129,9 +141,9 @@ function proxyWorkerStream(port, res, path) {
   );
   up.on('error', endOnce);
   up.end();
-  const onClose = () => { cancelled = true; try { up.destroy(); } catch {} }; // don't end res here; let worker stream close it
+  const onClose = () => { cancelled = true; sseClients.delete(res); try { up.destroy(); } catch {} }; // don't end res here; let worker stream close it
   res.on('close', onClose);
-  return () => { cancelled = true; try { up.destroy(); } catch {} };
+  return () => { cancelled = true; sseClients.delete(res); try { up.destroy(); } catch {} };
 }
 
 /** Read the worker's { port, pid } from ego-cast.json, if any. */

--- a/lib/cast-server.js
+++ b/lib/cast-server.js
@@ -177,8 +177,14 @@ function isProcessAlive(pid) {
  * pid no longer alive or its /api/health does not answer), so a crashed
  * worker is brought back without a host restart. Spawn is rate-limited to
  * avoid hot-looping while a headless container has no browser yet.
+ *
+ * `cfg` is the live config source (getters for castFpsCap /
+ * screencastQuality / screencastMaxWidth). On spawn, the current values are
+ * passed to the worker via argv as a JSON string; the worker reads them as
+ * initial screencast parameters. Subsequent config edits are pushed to a
+ * running worker via POST /api/config (see pushConfig below).
  */
-function makeEnsureWorker(ctx) {
+function makeEnsureWorker(ctx, cfg) {
   let lastAttempt = 0;
   async function launchedWorkerPort() {
     const state = await knownWorkerState();
@@ -194,8 +200,16 @@ function makeEnsureWorker(ctx) {
     if (now - lastAttempt > 8000) {
       lastAttempt = now;
       try {
+        // Pass the current cast config to the worker as a JSON argv arg so it
+        // starts with the right screencast parameters without needing an
+        // extra round-trip POST. The worker reads process.argv[2].
+        const initCfg = JSON.stringify({
+          castFpsCap: cfg.castFpsCap,
+          screencastQuality: cfg.screencastQuality,
+          screencastMaxWidth: cfg.screencastMaxWidth,
+        });
         const handle = ctx.subprocess.spawn({
-          argv: [process.execPath, WORKER_BIN],
+          argv: [process.execPath, WORKER_BIN, initCfg],
           stdio: {
             stdin: { data: '' },
             stdout: { maxBytes: 8192 },
@@ -214,11 +228,48 @@ function makeEnsureWorker(ctx) {
 }
 
 /**
+ * Push the current cast config to a running worker via POST /api/config.
+ * Best-effort: if the worker is unreachable or the POST fails, the config
+ * will take effect on the next worker spawn (argv seed). Called whenever the
+ * settings layer reports a change.
+ */
+function makePushConfig(ensureWorker) {
+  let lastPush = '';
+  return async function pushConfig(cfg) {
+    const port = await ensureWorker();
+    if (port === null) return;
+    const payload = JSON.stringify({
+      castFpsCap: cfg.castFpsCap,
+      screencastQuality: cfg.screencastQuality,
+      screencastMaxWidth: cfg.screencastMaxWidth,
+    });
+    // Dedupe: don't re-push identical config (settings onChange can fire
+    // multiple times for a single logical edit).
+    if (payload === lastPush) return;
+    lastPush = payload;
+    try {
+      await proxyPost(port, '/api/config', JSON.parse(payload));
+    } catch {
+      // worker may be mid-restart; the next ensureWorker will re-seed via argv
+    }
+  };
+}
+
+/**
  * Register the watch-panel routes. Call inside plugin apply() with the real
  * ctx; dispose is returned for ctx.effect cleanup.
+ *
+ * `cfg` is the live config source (getters for castFpsCap /
+ * screencastQuality / screencastMaxWidth). The worker is spawned with the
+ * current values as an argv seed; subsequent edits are hot-pushed via
+ * POST /api/config (see makePushConfig).
+ *
+ * `bridge` is the settings bridge — its `onChange` is used to react to
+ * live settings saves and push the new config to a running worker.
  */
-export function initCastServer(ctx) {
-  const ensureWorker = makeEnsureWorker(ctx);
+export function initCastServer(ctx, cfg, bridge) {
+  const ensureWorker = makeEnsureWorker(ctx, cfg);
+  const pushConfig = makePushConfig(ensureWorker);
   // The web shell exposes `webServer` (the only HTTP host surface the plugin
   // declares in inject). We deliberately reach for `webServer` alone: touching
   // an undeclared `httpServer` on a strict-inject host would trip the
@@ -227,6 +278,16 @@ export function initCastServer(ctx) {
   const server = ctx.webServer;
   if (!server || typeof server.register !== 'function') {
     return;
+  }
+
+  // Hot-push config changes to a running worker. The settings bridge fires
+  // onChange whenever the user saves a new castFpsCap / screencastQuality /
+  // screencastMaxWidth in the settings card.
+  if (typeof bridge?.onChange === 'function') {
+    const off = bridge.onChange(() => { pushConfig(cfg); });
+    if (typeof off === 'function') {
+      ctx.effect?.(() => () => { try { off() } catch {} });
+    }
   }
 
   const disposeSpaces = server.register({

--- a/lib/cast-server.js
+++ b/lib/cast-server.js
@@ -207,6 +207,7 @@ function makeEnsureWorker(ctx, cfg) {
           castFpsCap: cfg.castFpsCap,
           screencastQuality: cfg.screencastQuality,
           screencastMaxWidth: cfg.screencastMaxWidth,
+          backstopIntervalMs: cfg.backstopIntervalMs,
         });
         const handle = ctx.subprocess.spawn({
           argv: [process.execPath, WORKER_BIN, initCfg],
@@ -242,6 +243,7 @@ function makePushConfig(ensureWorker) {
       castFpsCap: cfg.castFpsCap,
       screencastQuality: cfg.screencastQuality,
       screencastMaxWidth: cfg.screencastMaxWidth,
+      backstopIntervalMs: cfg.backstopIntervalMs,
     });
     // Dedupe: don't re-push identical config (settings onChange can fire
     // multiple times for a single logical edit).

--- a/lib/client.js
+++ b/lib/client.js
@@ -59,6 +59,9 @@ window.__ModuleLoader__.load({
 			screencastMaxWidth: 'Frame max width',
 			screencastMaxWidthHint: 'Max width of screencast frames in CSS px (320–1920). Lower = smaller payload, less detail.',
 			screencastMaxWidthUnit: 'px',
+			backstopIntervalMs: 'Backstop interval',
+			backstopIntervalMsHint: 'How long (ms) a page may go without a screencast frame before a forced screenshot. Also the min interval between forced captures. Lower = more frequent backstop frames (higher CPU). Range 200–10000.',
+			backstopIntervalMsUnit: 'ms',
 			save: 'Save', saving: 'Saving…', discard: 'Discard',
 			unsaved: 'Unsaved', readOnly: 'Settings are read-only in this deployment.',
 			namespaceUnavailable: 'The ego-browser configuration channel is unavailable. Please retry later.',
@@ -78,6 +81,9 @@ window.__ModuleLoader__.load({
 			screencastMaxWidth: '帧最大宽度',
 			screencastMaxWidthHint: '推流帧的最大 CSS 像素宽度（320–1920）。越低体积越小、细节越少。',
 			screencastMaxWidthUnit: 'px',
+			backstopIntervalMs: '兜底间隔',
+			backstopIntervalMsHint: '页面多久没收到 screencast 帧就强制截图（毫秒）。也是两次强制截图的最小间隔。越低帧越频繁（CPU 越高）。范围 200–10000。',
+			backstopIntervalMsUnit: 'ms',
 			save: '保存', saving: '保存中…', discard: '放弃',
 			unsaved: '未保存', readOnly: '当前部署下设置只读。',
 			namespaceUnavailable: 'ego-browser 配置通道不可用，请稍后重试。',
@@ -91,7 +97,7 @@ window.__ModuleLoader__.load({
 				status: 'idle',        // 'idle' | 'loading' | 'ready'
 				available: false,      // true after a successful /ego/api/get
 				writable: false,       // false when settings service is absent
-				draft: { chromePath: '', castFpsCap: '0', screencastQuality: '55', screencastMaxWidth: '960' },
+				draft: { chromePath: '', castFpsCap: '0', screencastQuality: '55', screencastMaxWidth: '960', backstopIntervalMs: '5000' },
 				dirty: false,
 				applyState: { kind: 'idle' }, // 'idle' | 'saving' | 'saved' | 'error'
 				errorMessage: undefined,
@@ -134,14 +140,15 @@ window.__ModuleLoader__.load({
 					s.status = 'ready'
 					s.available = true
 					s.writable = true
-					s.draft = {
-						chromePath: config.chromePath || '',
-						castFpsCap: String(config.castFpsCap ?? 0),
-						screencastQuality: String(config.screencastQuality ?? 55),
-						screencastMaxWidth: String(config.screencastMaxWidth ?? 960),
-					}
-					s.dirty = false
-					s.applyState = { kind: 'idle' }
+				s.draft = {
+					chromePath: config.chromePath || '',
+					castFpsCap: String(config.castFpsCap ?? 0),
+					screencastQuality: String(config.screencastQuality ?? 55),
+					screencastMaxWidth: String(config.screencastMaxWidth ?? 960),
+					backstopIntervalMs: String(config.backstopIntervalMs ?? 5000),
+				}
+				s.dirty = false
+				s.applyState = { kind: 'idle' }
 				})
 			}).catch(function () {
 				if (gen !== self.generation) return
@@ -181,6 +188,7 @@ window.__ModuleLoader__.load({
 				castFpsCap: { min: 0, max: 60, def: 0 },
 				screencastQuality: { min: 1, max: 100, def: 55 },
 				screencastMaxWidth: { min: 320, max: 1920, def: 960 },
+				backstopIntervalMs: { min: 200, max: 10000, def: 5000 },
 			}
 			this.staged.forEach(function (v, k) {
 				var spec = NUMERIC_FIELDS[k]
@@ -219,14 +227,15 @@ window.__ModuleLoader__.load({
 				var config = parsed.value.config || {}
 				self.staged.clear()
 				self.store.update(function (s) {
-					s.applyState = { kind: 'saved' }
-					s.draft = {
-						chromePath: config.chromePath || '',
-						castFpsCap: String(config.castFpsCap ?? 0),
-						screencastQuality: String(config.screencastQuality ?? 55),
-						screencastMaxWidth: String(config.screencastMaxWidth ?? 960),
-					}
-					s.dirty = false
+				s.applyState = { kind: 'saved' }
+				s.draft = {
+					chromePath: config.chromePath || '',
+					castFpsCap: String(config.castFpsCap ?? 0),
+					screencastQuality: String(config.screencastQuality ?? 55),
+					screencastMaxWidth: String(config.screencastMaxWidth ?? 960),
+					backstopIntervalMs: String(config.backstopIntervalMs ?? 5000),
+				}
+				s.dirty = false
 				})
 			}).catch(function (err) {
 				if (gen !== self.generation) return
@@ -416,6 +425,17 @@ window.__ModuleLoader__.load({
 							min: 320, max: 1920, step: 40,
 							disabled: busy,
 							onEdit: function (v) { controller.edit('screencastMaxWidth', v) },
+						}),
+						h(SettingsField, {
+							id: 'plugin-config-ego-browser-backstop',
+							label: t('backstopIntervalMs'),
+							hint: t('backstopIntervalMsHint'),
+							value: state.draft.backstopIntervalMs || '',
+							placeholder: '5000',
+							numeric: true, narrow: true, unit: t('backstopIntervalMsUnit'),
+							min: 200, max: 10000, step: 100,
+							disabled: busy,
+							onEdit: function (v) { controller.edit('backstopIntervalMs', v) },
 						}),
 					),
 					h('div', { className: 'dsh-ego-card__footer' },

--- a/lib/client.js
+++ b/lib/client.js
@@ -50,12 +50,7 @@ window.__ModuleLoader__.load({
 			title: 'ego-browser',
 			intro: 'Agent browser integration. Configure the Chrome/Chromium binary path below.',
 			chromePath: 'Browser binary path',
-			chromePathHint: 'Absolute path to chrome.exe / chromium. Leave empty to auto-detect.',
-			refreshInterval: 'Auto-open probe interval',
-			refreshIntervalHint: 'Poll cadence (ms) for the sidebar-tab auto-open detector (waits for the first ego_* tool call). The watch panel itself is real-time SSE-driven, so this does NOT affect live-update speed. Idle = refreshInterval × idleMultiplier. Range 100–30000.',
-			refreshIntervalUnit: 'ms',
-			idleMultiplier: 'Idle multiplier',
-			idleMultiplierHint: 'Idle probe cadence = refreshInterval × this. 1 = no slowdown; 4 = idle polls every 4× the active interval. Range 1–20.',
+			chromePathHint: 'Path to the Chrome/Chromium/Edge binary. Empty = auto-detect.',
 			save: 'Save', saving: 'Saving…', discard: 'Discard',
 			unsaved: 'Unsaved', readOnly: 'Settings are read-only in this deployment.',
 			namespaceUnavailable: 'The ego-browser configuration channel is unavailable. Please retry later.',
@@ -66,12 +61,7 @@ window.__ModuleLoader__.load({
 			title: 'ego-browser',
 			intro: 'Agent 浏览器集成。在下方配置 Chrome/Chromium 浏览器路径。',
 			chromePath: '浏览器路径',
-			chromePathHint: 'chrome.exe / chromium 的绝对路径。留空则自动检测。',
-			refreshInterval: '自动打开探针间隔',
-			refreshIntervalHint: '侧栏 Tab 自动打开探测器的轮询间隔（毫秒）——等待首次 ego_* 工具调用。实时面板本身是 SSE 驱动，此设置不影响面板的实时刷新速度。空闲时为 refreshInterval × idleMultiplier。范围 100–30000。',
-			refreshIntervalUnit: '毫秒',
-			idleMultiplier: '空闲倍率',
-			idleMultiplierHint: '空闲探针间隔 = 刷新间隔 × 此值。1 = 不降速；4 = 空闲时每 4 倍间隔轮询一次。范围 1–20。',
+			chromePathHint: 'Chrome/Chromium/Edge 可执行文件路径。留空 = 自动检测。',
 			save: '保存', saving: '保存中…', discard: '放弃',
 			unsaved: '未保存', readOnly: '当前部署下设置只读。',
 			namespaceUnavailable: 'ego-browser 配置通道不可用，请稍后重试。',
@@ -80,26 +70,12 @@ window.__ModuleLoader__.load({
 		}
 
 		// ── Settings card: store ──────────────────────────────────────────
-		/** Update the shared runtimePoll from a resolved config object. */
-		function applyRuntimePoll(config) {
-			var n = config && typeof config.refreshInterval === 'number'
-				? config.refreshInterval
-				: 2000
-			if (!Number.isFinite(n) || n < 100 || n > 30000) n = 2000
-			var m = config && typeof config.idleMultiplier === 'number'
-				? config.idleMultiplier
-				: 4
-			if (!Number.isFinite(m) || m < 1 || m > 20) m = 4
-			runtimePoll.active = n
-			runtimePoll.idle = n * m
-		}
-
 		function initialSettingsState() {
 			return {
 				status: 'idle',        // 'idle' | 'loading' | 'ready'
 				available: false,      // true after a successful /ego/api/get
 				writable: false,       // false when settings service is absent
-				draft: { chromePath: '', refreshInterval: '2000', idleMultiplier: '4' },
+				draft: { chromePath: '' },
 				dirty: false,
 				applyState: { kind: 'idle' }, // 'idle' | 'saving' | 'saved' | 'error'
 				errorMessage: undefined,
@@ -138,15 +114,12 @@ window.__ModuleLoader__.load({
 				var config = parsed.value.config || {}
 				self.loaded = true
 				self.staged.clear()
-				applyRuntimePoll(config)
 				self.store.update(function (s) {
 					s.status = 'ready'
 					s.available = true
 					s.writable = true
 					s.draft = {
 						chromePath: config.chromePath || '',
-						refreshInterval: String(config.refreshInterval ?? 2000),
-						idleMultiplier: String(config.idleMultiplier ?? 4),
 					}
 					s.dirty = false
 					s.applyState = { kind: 'idle' }
@@ -186,20 +159,7 @@ window.__ModuleLoader__.load({
 			var gen = ++this.generation
 			var patch = {}
 			this.staged.forEach(function (v, k) {
-				if (k === 'refreshInterval' || k === 'idleMultiplier') {
-					// Convert the text-box string to a clamped number for the
-					// gateway (extractPatch accepts numbers, not strings, for
-					// these keys).
-					var n = parseInt(v, 10)
-					if (!Number.isFinite(n)) n = k === 'refreshInterval' ? 2000 : 4
-					if (k === 'refreshInterval') {
-						patch[k] = Math.max(100, Math.min(30000, n))
-					} else {
-						patch[k] = Math.max(1, Math.min(20, n))
-					}
-				} else {
-					patch[k] = v
-				}
+				patch[k] = v
 			})
 			if (Object.keys(patch).length === 0) {
 				this.staged.clear()
@@ -227,13 +187,10 @@ window.__ModuleLoader__.load({
 				}
 				var config = parsed.value.config || {}
 				self.staged.clear()
-				applyRuntimePoll(config)
 				self.store.update(function (s) {
 					s.applyState = { kind: 'saved' }
 					s.draft = {
 						chromePath: config.chromePath || '',
-						refreshInterval: String(config.refreshInterval ?? 2000),
-						idleMultiplier: String(config.idleMultiplier ?? 4),
 					}
 					s.dirty = false
 				})
@@ -393,28 +350,6 @@ window.__ModuleLoader__.load({
 							disabled: busy,
 							onEdit: function (v) { controller.edit('chromePath', v) },
 						}),
-						h(SettingsField, {
-							id: 'plugin-config-ego-browser-refresh',
-							label: t('refreshInterval'),
-							hint: t('refreshIntervalHint'),
-							value: state.draft.refreshInterval || '',
-							placeholder: '2000',
-							numeric: true, narrow: true, unit: t('refreshIntervalUnit'),
-							min: 100, max: 30000, step: 100,
-							disabled: busy,
-							onEdit: function (v) { controller.edit('refreshInterval', v) },
-						}),
-						h(SettingsField, {
-							id: 'plugin-config-ego-browser-idle-multiplier',
-							label: t('idleMultiplier'),
-							hint: t('idleMultiplierHint'),
-							value: state.draft.idleMultiplier || '',
-							placeholder: '4',
-							numeric: true, narrow: true,
-							min: 1, max: 20, step: 1,
-							disabled: busy,
-							onEdit: function (v) { controller.edit('idleMultiplier', v) },
-						}),
 					),
 					h('div', { className: 'dsh-ego-card__footer' },
 						errorText !== undefined ? h('p', { className: 'dsh-ego-card__failed', role: 'status' }, errorText) : null,
@@ -442,17 +377,6 @@ window.__ModuleLoader__.load({
 		const SPACES_ROUTE = '/api/ego/spaces'
 		const EGO_CLOSE_ROUTE = '/api/ego/close'
 		const OPEN_KEY = 'dsh.ego.watch.open'
-		// Dynamic poll: fast while the agent is actively driving the browser,
-		// slow once nothing has changed — keeps the view responsive without
-		// hammering the worker with screenshots during idle stretches.
-		//
-		// These are mutable: the settings controller updates them from the
-		// `refreshInterval` config field (loaded via /ego/api/get and refreshed
-		// on every save). Consumers (LivePreviewController, the auto-open probe,
-		// the floating panel) read the current values on each scheduling
-		// decision, so a settings change takes effect on the next poll cycle
-		// without needing to re-mount anything.
-		var runtimePoll = { active: 2000, idle: 8000 }
 		// Treat the agent as "active" when any page was touched within this window.
 		const ACTIVE_WINDOW_MS = 3000
 
@@ -2592,66 +2516,70 @@ window.__ModuleLoader__.load({
 				component: EgoBrowserTab,
 			})
 
-			// ── Auto-open probe ───────────────────────────────────────────────
-			// The LivePreviewController (inside the Tab component) only polls
-			// once the Tab is mounted, but the Tab only mounts once opened — a
-			// chicken-and-egg that means the auto-open transition inside the
-			// controller never fires. This lightweight standalone poller runs
-			// regardless of Tab visibility: it fetches /api/ego/spaces, watches
-			// toolCallCount increase BEYOND THE BASELINE observed at probe
-			// startup, and calls openTab() once.
+			// ── Auto-open probe (SSE-driven, no polling) ─────────────────────
+			// Listens for `tool-call` events on the SSE stream to detect when
+			// the agent first calls an ego_* tool, then opens the sidebar Tab.
+			// No /api/ego/spaces polling — the host-side markEgoToolCall()
+			// pushes the event into the SSE stream the moment a tool runs.
 			//
 			// Why "increase beyond baseline" not "0 → >0": toolCallCount is a
-			// host-process counter that persists across page reloads. If the
-			// agent already called ego_* tools earlier, toolCallCount is
-			// already >0 when the page loads — a naive 0→>0 check would fire
-			// immediately on every reload, opening the Tab even when no new
-			// tool call happened. The baseline captures the count at probe
-			// startup; only a NEW call (count goes up) triggers the open.
+			// host-process counter that persists across page reloads. The
+			// baseline is fetched ONCE at mount via a single /api/ego/spaces
+			// request; after that, only a NEW tool call (count goes up)
+			// triggers the open.
 			var probeDisposed = false
-			var probeTimer = null
-			var baseline = null // null = not yet observed; set on first probe
+			var baseline = null // null = not yet observed; set on first fetch
 			var autoOpened = false
-			var probe = function () {
-				if (probeDisposed || autoOpened) return
-				void (async function () {
+			// One-shot baseline fetch (NOT a polling loop). After this, the
+			// SSE `tool-call` event is the sole signal.
+			void (async function () {
+				if (probeDisposed) return
+				try {
+					var res = await fetch(SPACES_ROUTE, { cache: 'no-store' })
+					if (!res.ok) return
+					var data = await res.json()
+					if (data && typeof data.toolCallCount === 'number') {
+						baseline = data.toolCallCount
+					}
+				} catch (e) {}
+			})()
+			// Listen for tool-call events on the shared SSE stream. The probe
+			// opens its OWN EventSource so it works even before the Tab is
+			// mounted (the Tab's controller only connects after the Tab opens).
+			var probeSse = null
+			try { probeSse = new EventSource('/api/ego/stream') } catch (e) {}
+			if (probeSse) {
+				probeSse.addEventListener('tool-call', function (ev) {
+					if (probeDisposed || autoOpened) return
 					try {
-						var res = await fetch(SPACES_ROUTE, { cache: 'no-store' })
-						if (!res.ok) { scheduleProbe(); return }
-						var data = await res.json()
-						if (data && typeof data.toolCallCount === 'number') {
-							var count = data.toolCallCount
-							if (baseline === null) {
-								// First probe: establish baseline. Don't open yet.
-								baseline = count
-							} else if (count > baseline) {
-								// New tool call since baseline → open the Tab.
+						var m = JSON.parse(ev.data)
+						if (!m || typeof m.count !== 'number') return
+						if (baseline === null) {
+							// Event arrived before the baseline fetch resolved —
+							// treat this count as the baseline (it's the first
+							// we've seen) and open on the NEXT one. But if count
+							// is already >0, the agent has called a tool this
+							// session, so open now.
+							baseline = m.count
+							if (m.count > 0) {
 								autoOpened = true
 								try { betterSidebar.openTab({ type: 'ego-browser:watch' }) } catch (e) {}
-								return // stop probing after auto-open
 							}
+							return
+						}
+						if (m.count > baseline) {
+							autoOpened = true
+							try { betterSidebar.openTab({ type: 'ego-browser:watch' }) } catch (e) {}
+							// Auto-opened: close the probe stream (no longer needed).
+							try { probeSse.close() } catch (e) {}
 						}
 					} catch (e) {}
-					scheduleProbe()
-				})()
+				})
 			}
-			var scheduleProbe = function () {
-				if (probeDisposed || autoOpened) return
-				if (probeTimer) window.clearTimeout(probeTimer)
-				// Poll at the active cadence so the Tab opens promptly after
-				// the first tool call; the probe stops itself after firing, so
-				// the cadence is only paid while waiting for the first call.
-				// Uses runtimePoll.active (live-updated from refreshInterval).
-				probeTimer = window.setTimeout(probe, runtimePoll.active)
-			}
-			// Kick off the first probe shortly after mount (give the host a
-			// moment to be ready; avoids a startup spike if multiple plugins
-			// fire at once).
-			probeTimer = window.setTimeout(probe, 1500)
 
 			return function () {
 				probeDisposed = true
-				if (probeTimer) window.clearTimeout(probeTimer)
+				try { if (probeSse) probeSse.close() } catch (e) {}
 				disposeTab()
 				styleEl.remove()
 			}

--- a/lib/client.js
+++ b/lib/client.js
@@ -52,8 +52,10 @@ window.__ModuleLoader__.load({
 			chromePath: 'Browser binary path',
 			chromePathHint: 'Absolute path to chrome.exe / chromium. Leave empty to auto-detect.',
 			refreshInterval: 'Watch panel refresh interval',
-			refreshIntervalHint: 'Poll cadence (ms) while the agent is actively browsing. Idle = 4×. Range 100–30000.',
+			refreshIntervalHint: 'Poll cadence (ms) while the agent is actively browsing. Idle = refreshInterval × idleMultiplier. Range 100–30000.',
 			refreshIntervalUnit: 'ms',
+			idleMultiplier: 'Idle multiplier',
+			idleMultiplierHint: 'Idle cadence = refreshInterval × this. 1 = no slowdown; 4 = idle polls every 4× the active interval. Range 1–20.',
 			save: 'Save', saving: 'Saving…', discard: 'Discard',
 			unsaved: 'Unsaved', readOnly: 'Settings are read-only in this deployment.',
 			namespaceUnavailable: 'The ego-browser configuration channel is unavailable. Please retry later.',
@@ -66,8 +68,10 @@ window.__ModuleLoader__.load({
 			chromePath: '浏览器路径',
 			chromePathHint: 'chrome.exe / chromium 的绝对路径。留空则自动检测。',
 			refreshInterval: '实时面板刷新间隔',
-			refreshIntervalHint: 'agent 活跃浏览时的轮询间隔（毫秒）。空闲时为 4 倍。范围 100–30000。',
+			refreshIntervalHint: 'agent 活跃浏览时的轮询间隔（毫秒）。空闲时为 refreshInterval × idleMultiplier。范围 100–30000。',
 			refreshIntervalUnit: '毫秒',
+			idleMultiplier: '空闲倍率',
+			idleMultiplierHint: '空闲轮询间隔 = 刷新间隔 × 此值。1 = 不降速；4 = 空闲时每 4 倍间隔轮询一次。范围 1–20。',
 			save: '保存', saving: '保存中…', discard: '放弃',
 			unsaved: '未保存', readOnly: '当前部署下设置只读。',
 			namespaceUnavailable: 'ego-browser 配置通道不可用，请稍后重试。',
@@ -82,8 +86,12 @@ window.__ModuleLoader__.load({
 				? config.refreshInterval
 				: 2000
 			if (!Number.isFinite(n) || n < 100 || n > 30000) n = 2000
+			var m = config && typeof config.idleMultiplier === 'number'
+				? config.idleMultiplier
+				: 4
+			if (!Number.isFinite(m) || m < 1 || m > 20) m = 4
 			runtimePoll.active = n
-			runtimePoll.idle = n * 4
+			runtimePoll.idle = n * m
 		}
 
 		function initialSettingsState() {
@@ -91,7 +99,7 @@ window.__ModuleLoader__.load({
 				status: 'idle',        // 'idle' | 'loading' | 'ready'
 				available: false,      // true after a successful /ego/api/get
 				writable: false,       // false when settings service is absent
-				draft: { chromePath: '', refreshInterval: '2000' },
+				draft: { chromePath: '', refreshInterval: '2000', idleMultiplier: '4' },
 				dirty: false,
 				applyState: { kind: 'idle' }, // 'idle' | 'saving' | 'saved' | 'error'
 				errorMessage: undefined,
@@ -138,6 +146,7 @@ window.__ModuleLoader__.load({
 					s.draft = {
 						chromePath: config.chromePath || '',
 						refreshInterval: String(config.refreshInterval ?? 2000),
+						idleMultiplier: String(config.idleMultiplier ?? 4),
 					}
 					s.dirty = false
 					s.applyState = { kind: 'idle' }
@@ -177,13 +186,17 @@ window.__ModuleLoader__.load({
 			var gen = ++this.generation
 			var patch = {}
 			this.staged.forEach(function (v, k) {
-				if (k === 'refreshInterval') {
+				if (k === 'refreshInterval' || k === 'idleMultiplier') {
 					// Convert the text-box string to a clamped number for the
 					// gateway (extractPatch accepts numbers, not strings, for
-					// this key).
+					// these keys).
 					var n = parseInt(v, 10)
-					if (!Number.isFinite(n)) n = 2000
-					patch[k] = Math.max(100, Math.min(30000, n))
+					if (!Number.isFinite(n)) n = k === 'refreshInterval' ? 2000 : 4
+					if (k === 'refreshInterval') {
+						patch[k] = Math.max(100, Math.min(30000, n))
+					} else {
+						patch[k] = Math.max(1, Math.min(20, n))
+					}
 				} else {
 					patch[k] = v
 				}
@@ -220,6 +233,7 @@ window.__ModuleLoader__.load({
 					s.draft = {
 						chromePath: config.chromePath || '',
 						refreshInterval: String(config.refreshInterval ?? 2000),
+						idleMultiplier: String(config.idleMultiplier ?? 4),
 					}
 					s.dirty = false
 				})
@@ -389,6 +403,17 @@ window.__ModuleLoader__.load({
 							min: 100, max: 30000, step: 100,
 							disabled: busy,
 							onEdit: function (v) { controller.edit('refreshInterval', v) },
+						}),
+						h(SettingsField, {
+							id: 'plugin-config-ego-browser-idle-multiplier',
+							label: t('idleMultiplier'),
+							hint: t('idleMultiplierHint'),
+							value: state.draft.idleMultiplier || '',
+							placeholder: '4',
+							numeric: true, narrow: true,
+							min: 1, max: 20, step: 1,
+							disabled: busy,
+							onEdit: function (v) { controller.edit('idleMultiplier', v) },
 						}),
 					),
 					h('div', { className: 'dsh-ego-card__footer' },

--- a/lib/client.js
+++ b/lib/client.js
@@ -52,7 +52,7 @@ window.__ModuleLoader__.load({
 			chromePath: 'Browser binary path',
 			chromePathHint: 'Absolute path to chrome.exe / chromium. Leave empty to auto-detect.',
 			refreshInterval: 'Watch panel refresh interval',
-			refreshIntervalHint: 'Poll cadence (ms) while the agent is actively browsing. Idle = 4×. Range 500–30000.',
+			refreshIntervalHint: 'Poll cadence (ms) while the agent is actively browsing. Idle = 4×. Range 100–30000.',
 			refreshIntervalUnit: 'ms',
 			save: 'Save', saving: 'Saving…', discard: 'Discard',
 			unsaved: 'Unsaved', readOnly: 'Settings are read-only in this deployment.',
@@ -66,7 +66,7 @@ window.__ModuleLoader__.load({
 			chromePath: '浏览器路径',
 			chromePathHint: 'chrome.exe / chromium 的绝对路径。留空则自动检测。',
 			refreshInterval: '实时面板刷新间隔',
-			refreshIntervalHint: 'agent 活跃浏览时的轮询间隔（毫秒）。空闲时为 4 倍。范围 500–30000。',
+			refreshIntervalHint: 'agent 活跃浏览时的轮询间隔（毫秒）。空闲时为 4 倍。范围 100–30000。',
 			refreshIntervalUnit: '毫秒',
 			save: '保存', saving: '保存中…', discard: '放弃',
 			unsaved: '未保存', readOnly: '当前部署下设置只读。',
@@ -81,7 +81,7 @@ window.__ModuleLoader__.load({
 			var n = config && typeof config.refreshInterval === 'number'
 				? config.refreshInterval
 				: 2000
-			if (!Number.isFinite(n) || n < 500 || n > 30000) n = 2000
+			if (!Number.isFinite(n) || n < 100 || n > 30000) n = 2000
 			runtimePoll.active = n
 			runtimePoll.idle = n * 4
 		}
@@ -183,7 +183,7 @@ window.__ModuleLoader__.load({
 					// this key).
 					var n = parseInt(v, 10)
 					if (!Number.isFinite(n)) n = 2000
-					patch[k] = Math.max(500, Math.min(30000, n))
+					patch[k] = Math.max(100, Math.min(30000, n))
 				} else {
 					patch[k] = v
 				}
@@ -386,7 +386,7 @@ window.__ModuleLoader__.load({
 							value: state.draft.refreshInterval || '',
 							placeholder: '2000',
 							numeric: true, narrow: true, unit: t('refreshIntervalUnit'),
-							min: 500, max: 30000, step: 100,
+							min: 100, max: 30000, step: 100,
 							disabled: busy,
 							onEdit: function (v) { controller.edit('refreshInterval', v) },
 						}),

--- a/lib/client.js
+++ b/lib/client.js
@@ -51,11 +51,11 @@ window.__ModuleLoader__.load({
 			intro: 'Agent browser integration. Configure the Chrome/Chromium binary path below.',
 			chromePath: 'Browser binary path',
 			chromePathHint: 'Absolute path to chrome.exe / chromium. Leave empty to auto-detect.',
-			refreshInterval: 'Watch panel refresh interval',
-			refreshIntervalHint: 'Poll cadence (ms) while the agent is actively browsing. Idle = refreshInterval × idleMultiplier. Range 100–30000.',
+			refreshInterval: 'Auto-open probe interval',
+			refreshIntervalHint: 'Poll cadence (ms) for the sidebar-tab auto-open detector (waits for the first ego_* tool call). The watch panel itself is real-time SSE-driven, so this does NOT affect live-update speed. Idle = refreshInterval × idleMultiplier. Range 100–30000.',
 			refreshIntervalUnit: 'ms',
 			idleMultiplier: 'Idle multiplier',
-			idleMultiplierHint: 'Idle cadence = refreshInterval × this. 1 = no slowdown; 4 = idle polls every 4× the active interval. Range 1–20.',
+			idleMultiplierHint: 'Idle probe cadence = refreshInterval × this. 1 = no slowdown; 4 = idle polls every 4× the active interval. Range 1–20.',
 			save: 'Save', saving: 'Saving…', discard: 'Discard',
 			unsaved: 'Unsaved', readOnly: 'Settings are read-only in this deployment.',
 			namespaceUnavailable: 'The ego-browser configuration channel is unavailable. Please retry later.',
@@ -67,11 +67,11 @@ window.__ModuleLoader__.load({
 			intro: 'Agent 浏览器集成。在下方配置 Chrome/Chromium 浏览器路径。',
 			chromePath: '浏览器路径',
 			chromePathHint: 'chrome.exe / chromium 的绝对路径。留空则自动检测。',
-			refreshInterval: '实时面板刷新间隔',
-			refreshIntervalHint: 'agent 活跃浏览时的轮询间隔（毫秒）。空闲时为 refreshInterval × idleMultiplier。范围 100–30000。',
+			refreshInterval: '自动打开探针间隔',
+			refreshIntervalHint: '侧栏 Tab 自动打开探测器的轮询间隔（毫秒）——等待首次 ego_* 工具调用。实时面板本身是 SSE 驱动，此设置不影响面板的实时刷新速度。空闲时为 refreshInterval × idleMultiplier。范围 100–30000。',
 			refreshIntervalUnit: '毫秒',
 			idleMultiplier: '空闲倍率',
-			idleMultiplierHint: '空闲轮询间隔 = 刷新间隔 × 此值。1 = 不降速；4 = 空闲时每 4 倍间隔轮询一次。范围 1–20。',
+			idleMultiplierHint: '空闲探针间隔 = 刷新间隔 × 此值。1 = 不降速；4 = 空闲时每 4 倍间隔轮询一次。范围 1–20。',
 			save: '保存', saving: '保存中…', discard: '放弃',
 			unsaved: '未保存', readOnly: '当前部署下设置只读。',
 			namespaceUnavailable: 'ego-browser 配置通道不可用，请稍后重试。',
@@ -852,8 +852,11 @@ window.__ModuleLoader__.load({
 					for (const s of list) {
 						const item = document.createElement('div')
 						item.className = 'dsh-ego-hitem'
-						const thumb = s.thumbnail
-							? `<img class="dsh-ego-hthumb" src="${s.thumbnail}" alt="">`
+						// Thumbnails are no longer carried in the spaces payload —
+						// pull the latest cached JPEG from the SSE frame pipeline.
+						const thumbSrc = frameCache.get(s.targetId)
+						const thumb = thumbSrc
+							? `<img class="dsh-ego-hthumb" src="${thumbSrc}" alt="">`
 							: `<div class="dsh-ego-hthumb"></div>`
 						const active = s.targetId === currentActiveId
 						item.innerHTML = `${thumb}
@@ -1167,9 +1170,14 @@ window.__ModuleLoader__.load({
 					const u = document.createElement('div')
 					u.className = 'dsh-ego-liveurl'
 					u.textContent = s.url || ''
-					if (s.thumbnail) {
+					// The thumbnail is no longer in the spaces payload — pull the
+					// latest cached JPEG from the SSE frame pipeline. attachLiveImg
+					// wires up the live <img> so future SSE frame events for this
+					// target swap its src in place.
+					const cached = frameCache.get(s.targetId)
+					if (cached) {
 						const img = makeZoomImage(u)
-						img.src = s.thumbnail
+						img.src = cached
 						img.alt = 'live'
 						attachLiveImg(s.targetId, img)
 						view.appendChild(img)
@@ -1241,9 +1249,18 @@ window.__ModuleLoader__.load({
 						fab.classList.remove('dsh-ego-live', 'dsh-ego-busy')
 						return
 					}
-					liveCount = lastList.length
-					fab.classList.add('dsh-ego-live')
+				liveCount = lastList.length
+				fab.classList.add('dsh-ego-live')
+				// Busy signal: derived from whether any page was touched recently.
+				// Previously lived in the now-removed polling scheduler; moved
+				// here so the SSE `spaces` event keeps the status dot live.
+				const busy = lastList.some(s => (Date.now() - (s.lastActive || 0)) <= ACTIVE_WINDOW_MS)
+				if (busy !== lastSawActive) {
+					fab.classList.toggle('dsh-ego-busy', busy)
+					lastSawActive = busy
+				} else {
 					fab.classList.remove('dsh-ego-busy')
+				}
 					// If the user picked a tab on the bar, keep showing that tab
 					// (even as the agent opens new pages); else follow the newest.
 					const sel = selectedTabId !== null ? lastList.find(x => x.targetId === selectedTabId) : null
@@ -1290,9 +1307,10 @@ window.__ModuleLoader__.load({
 						else openHere.textContent = '无可打开的地址'
 					})
 					badge.appendChild(openHere)
-					if (current.thumbnail) {
+					const cached = frameCache.get(current.targetId)
+					if (cached) {
 						const img = makeZoomImage(u)
-						img.src = current.thumbnail
+						img.src = cached
 						img.alt = 'live'
 						attachLiveImg(current.targetId, img)
 						view.appendChild(img)
@@ -1307,56 +1325,45 @@ window.__ModuleLoader__.load({
 					body.appendChild(view)
 				}
 
-				// Dynamic scheduler: after each refresh, decide how soon to poll
-				// again based on whether the agent has recently interacted with any
-				// page. Active → fast (runtimePoll.active); quiet → slow
-				// (runtimePoll.idle). The values are live-updated from the
-				// `refreshInterval` setting.
-				let pollTimer = null
+				// ── spaces loading ────────────────────────────────────────────
+				// The watch panel is now pure SSE-driven (spaces + frame events
+				// from /api/ego/stream). This `refresh` is NO LONGER called on a
+				// timer — it is only used as a one-shot fallback when:
+				//   • the SSE stream errors / reconnects (to re-sync the tab list),
+				//   • the user manually clicks the refresh button,
+				//   • the user closes a tab (to re-sync),
+				//   • initial mount (the SSE `spaces` event on connect covers this
+				//     too, but we do an explicit fetch to surface any error early).
+				// The response carries NO thumbnail bytes (worker /api/spaces is
+				// pure metadata now); thumbnails come from the SSE frame cache.
 				let lastSawActive = false
-				const scheduleNext = (spaces) => {
-					if (disposed) return
-					// Never let two poll timers accumulate: a manual refresh (or an
-					// earlier pending tick) would otherwise stack extra timers and
-					// double-fetch on every cycle.
-					if (pollTimer) window.clearTimeout(pollTimer)
-					const active = Array.isArray(spaces) && spaces.some(s => (Date.now() - (s.lastActive || 0)) <= ACTIVE_WINDOW_MS)
-					const delay = active ? runtimePoll.active : runtimePoll.idle
-					if (active !== lastSawActive) {
-						// Reflect the speed change on the status dot (busy=agent active now).
-						fab.classList.toggle('dsh-ego-busy', active)
-						lastSawActive = active
-					}
-					pollTimer = window.setTimeout(() => { if (!disposed && !panel.hidden) refresh() }, delay)
-				}
-
 				const refresh = () => {
 					void (async () => {
 						try {
 							const res = await fetch(SPACES_ROUTE, { cache: 'no-store' })
-							if (disposed || !res.ok) { renderEmptyAndSchedule(); return }
+							if (disposed || !res.ok) { renderEmpty(); return }
 							const data = await res.json()
-							if (!data || data.ok !== true) { renderEmptyAndSchedule(); return }
+							if (!data || data.ok !== true) { renderEmpty(); return }
 							renderSpaces(data.spaces)
-							scheduleNext(data.spaces)
 						} catch {
-							renderEmptyAndSchedule()
+							renderEmpty()
 						}
 					})()
 				}
-				// On failure, keep polling but at the idle rate (no flapping).
-				const renderEmptyAndSchedule = () => {
+				const renderEmpty = () => {
 					if (body.children.length === 0) renderSpaces([])
-					scheduleNext(undefined)
 				}
 
 				// ── realtime SSE: live frames + active-page auto-follow ──
-				// The cast worker pushes a `frame` event per repaint of any live
-				// page (browser-native cadence, far faster than the polled snapshot
-				// which costs a ~700ms captureScreenshot per request). The panel
-				// swaps the shown <img> in place and, in live-follow mode, tracks
-				// the page the agent is actively repainting. Polling is kept as a
-				// metadata/backstop channel.
+				// The cast worker pushes two kinds of events on /api/ego/stream:
+				//   • `frame`  — per-repaint JPEG for any page (real-time video)
+				//   • `spaces` — pure metadata (url/title/active/viewport/humanCheck),
+				//                broadcast on every keepalive tick (~500ms) and on
+				//                tab churn, so the tab bar + main view stay in sync
+				//                WITHOUT any client-side polling.
+				// The panel no longer polls /api/ego/spaces on a timer. A one-shot
+				// `refresh()` is only called on initial mount and on SSE reconnect
+				// (via the `onerror` debouncer below) to re-sync after a stream gap.
 				let sse = null
 				let lastFrameAt = 0
 				const FRAME_FOLLOW_MIN_MS = 350 // throttle live-follow view swaps
@@ -1417,7 +1424,7 @@ window.__ModuleLoader__.load({
 								const meta = pageMeta.get(targetId)
 								if (!meta) return
 								currentActiveId = targetId
-								renderLiveMain({ ...meta, targetId, thumbnail: dataUrl }, false)
+								renderLiveMain({ ...meta, targetId }, false)
 							}, 0)
 						}
 					}
@@ -1441,29 +1448,37 @@ window.__ModuleLoader__.load({
 							applyFrame(m.targetId, `data:image/jpeg;base64,${m.data}`, m.vw, m.vh)
 						} catch {}
 					})
-					// The worker also sends the live list on open (and on tab
-					// churn); treat it as a metadata refresh for the tab bar.
-					sse.addEventListener('spaces', (ev) => {
+				// The worker also sends the live list on open (and on tab
+				// churn); treat it as the authoritative tab-list + main-view
+				// update. This replaces the old /api/ego/spaces polling loop.
+				sse.addEventListener('spaces', (ev) => {
+					if (disposed) return
+					try {
+						const list = JSON.parse(ev.data)
+						if (Array.isArray(list)) {
+							// Even for an empty list, we want to call renderSpaces
+							// so the "no live browser" placeholder shows up.
+							renderSpaces(list)
+						}
+					} catch {}
+				})
+				// Debounced reconnect fallback: when the SSE stream drops,
+				// EventSource auto-reconnects, but we also kick off a one-shot
+				// /api/ego/spaces fetch so the panel re-syncs immediately on the
+				// next successful connect (without waiting for the worker's next
+				// keepalive broadcast). The 1.5s delay gives EventSource room to
+				// reconnect cleanly first, avoiding a redundant fetch on a
+				// momentary blip.
+				let reconnectFallbackTimer = null
+				sse.onerror = () => {
+					doConnected = false
+					if (reconnectFallbackTimer) return
+					reconnectFallbackTimer = window.setTimeout(() => {
+						reconnectFallbackTimer = null
 						if (disposed) return
-						try {
-							const list = JSON.parse(ev.data)
-							if (Array.isArray(list) && list.length) {
-								// Update the follow map so a frame-first new page is
-								// still followable even before the next poll lands.
-								for (const s of list) {
-									const cur = pageMeta.get(s.targetId) || { targetId: s.targetId }
-									pageMeta.set(s.targetId, { url: s.url, title: s.title, targetId: s.targetId, ...(Number.isFinite(s.viewportW) ? { vw: s.viewportW } : {}), ...(Number.isFinite(s.viewportH) ? { vh: s.viewportH } : {}) })
-									if (s.active === true) agentActiveId = s.targetId
-								}
-								renderTabs(list)
-							}
-						} catch {}
-					})
-					sse.onerror = () => {
-						// EventSource auto-reconnects; just flag so the status dot
-						// doesn't claim "live" while the stream is down.
-						doConnected = false
-					}
+						refresh()
+					}, 1500)
+				}
 				}
 				let doConnected = false
 
@@ -1657,7 +1672,7 @@ window.__ModuleLoader__.load({
 					disposed = true
 					if (liveFlushRaf != null) try { window.cancelAnimationFrame(liveFlushRaf) } catch {}
 					if (followTimer) window.clearTimeout(followTimer)
-					if (pollTimer) window.clearTimeout(pollTimer)
+					if (reconnectFallbackTimer) window.clearTimeout(reconnectFallbackTimer)
 					try { if (sse) sse.close() } catch {}
 					fab.remove()
 					panel.remove()
@@ -1857,8 +1872,8 @@ window.__ModuleLoader__.load({
 			this.liveCount = 0
 			this.disposed = false
 			this.visible = true
-			this.pollTimer = null
 			this.sse = null
+			this.reconnectFallbackTimer = null
 			this.lastSawActive = false
 			this.lastFrameAt = 0
 			this.followTimer = null
@@ -1905,7 +1920,9 @@ window.__ModuleLoader__.load({
 			} else if (this.selectedTabId !== null) {
 				currentSpace = this.lastList.find(function (s) { return s.targetId === self.selectedTabId }) || null
 				currentTargetId = this.selectedTabId
-				// Fall back to cached frame if the poll hasn't got a thumbnail
+				// spaces payloads no longer carry thumbnails; pull the latest
+				// cached JPEG from the SSE frame pipeline so the view shows
+				// something instead of "no screenshot yet".
 				if (currentSpace && !currentSpace.thumbnail) {
 					var cached = this.frameCache.get(currentTargetId)
 					if (cached) currentSpace = Object.assign({}, currentSpace, { thumbnail: cached })
@@ -1950,7 +1967,7 @@ window.__ModuleLoader__.load({
 			this.disposed = true
 			if (this.liveFlushRaf != null) try { window.cancelAnimationFrame(this.liveFlushRaf) } catch (e) {}
 			if (this.followTimer) window.clearTimeout(this.followTimer)
-			if (this.pollTimer) window.clearTimeout(this.pollTimer)
+			if (this.reconnectFallbackTimer) window.clearTimeout(this.reconnectFallbackTimer)
 			if (this._zoomHintTimer) window.clearTimeout(this._zoomHintTimer)
 			this.closeStream()
 		}
@@ -1958,11 +1975,13 @@ window.__ModuleLoader__.load({
 			if (this.visible === v) return
 			this.visible = v
 			if (v) {
+				// On becoming visible again, do a one-shot fallback fetch to
+				// re-sync immediately (the SSE `spaces` event will also catch
+				// up on the next keepalive tick, but this avoids a blank gap).
 				this.refresh()
 				this.openStream()
 			} else {
 				this.closeStream()
-				if (this.pollTimer) { window.clearTimeout(this.pollTimer); this.pollTimer = null }
 			}
 		}
 		LivePreviewController.prototype.setLiveImg = function (img, targetId) {
@@ -1975,24 +1994,26 @@ window.__ModuleLoader__.load({
 				}
 			}
 		}
+		// `refresh` is NOT a polling loop anymore. It is a one-shot fallback
+		// used at start / setVisible(true) / SSE reconnect to re-sync the tab
+		// list immediately. The authoritative metadata source is the SSE
+		// `spaces` event broadcast by the worker every ~500ms.
 		LivePreviewController.prototype.refresh = function () {
 			var self = this
 			void (async function () {
 				try {
 					var res = await fetch(SPACES_ROUTE, { cache: 'no-store' })
-					if (self.disposed || !res.ok) { self._renderEmptyAndSchedule(); return }
+					if (self.disposed || !res.ok) { self._renderEmpty(); return }
 					var data = await res.json()
-					if (!data || data.ok !== true) { self._renderEmptyAndSchedule(); return }
+					if (!data || data.ok !== true) { self._renderEmpty(); return }
 					self._processSpaces(data.spaces)
-					self._scheduleNext(data.spaces)
 				} catch (e) {
-					self._renderEmptyAndSchedule()
+					self._renderEmpty()
 				}
 			})()
 		}
-		LivePreviewController.prototype._renderEmptyAndSchedule = function () {
+		LivePreviewController.prototype._renderEmpty = function () {
 			if (this.lastList.length === 0) this._processSpaces([])
-			this._scheduleNext(undefined)
 		}
 		LivePreviewController.prototype._processSpaces = function (spaces) {
 			if (this.disposed) return
@@ -2020,20 +2041,12 @@ window.__ModuleLoader__.load({
 			var activeMarked = this.lastList.find(function (s) { return s.active === true })
 			if (activeMarked) this.agentActiveId = activeMarked.targetId
 			this.liveCount = this.lastList.length
+			// Busy signal: derived from whether any page was touched recently.
+			// Previously this lived in the now-removed polling scheduler; moved
+			// here so the SSE `spaces` event keeps the status dot live.
+			var busy = this.lastList.some(function (s) { return (Date.now() - (s.lastActive || 0)) <= ACTIVE_WINDOW_MS })
+			if (busy !== this.lastSawActive) this.lastSawActive = busy
 			this._recompute()
-		}
-		LivePreviewController.prototype._scheduleNext = function (spaces) {
-			if (this.disposed) return
-			if (this.pollTimer) window.clearTimeout(this.pollTimer)
-			var active = Array.isArray(spaces) && spaces.some(function (s) { return (Date.now() - (s.lastActive || 0)) <= ACTIVE_WINDOW_MS })
-			if (active !== this.lastSawActive) {
-				this.lastSawActive = active
-				this._recompute()
-			}
-			if (!this.visible) return
-			var delay = active ? runtimePoll.active : runtimePoll.idle
-			var self = this
-			this.pollTimer = window.setTimeout(function () { if (!self.disposed && self.visible) self.refresh() }, delay)
 		}
 		LivePreviewController.prototype.openStream = function () {
 			if (this.disposed || !this.visible) return
@@ -2057,22 +2070,30 @@ window.__ModuleLoader__.load({
 				if (self.disposed) return
 				try {
 					var list = JSON.parse(ev.data)
-					if (Array.isArray(list) && list.length) {
-						for (var i = 0; i < list.length; i++) {
-							var s = list[i]
-							var cur = self.pageMeta.get(s.targetId) || { targetId: s.targetId }
-							var meta = { url: s.url, title: s.title, targetId: s.targetId }
-							if (Number.isFinite(s.viewportW)) meta.vw = s.viewportW
-							if (Number.isFinite(s.viewportH)) meta.vh = s.viewportH
-							self.pageMeta.set(s.targetId, Object.assign({}, cur, meta))
-							if (s.active === true) self.agentActiveId = s.targetId
-						}
-						self.lastList = list
-						self._recompute()
+					if (Array.isArray(list)) {
+						// _processSpaces is the authoritative path: it merges
+						// pageMeta, prunes dead tabs from the caches, recomputes
+						// the active page, and pushes a store snapshot. The
+						// worker broadcasts this every keepalive tick (~500ms)
+						// and on tab churn, replacing the old polling loop.
+						self._processSpaces(list)
 					}
 				} catch (e) {}
 			})
-			this.sse.onerror = function () {}
+			// Debounced reconnect fallback: EventSource auto-reconnects on
+			// error; we also kick off a one-shot /api/ego/spaces fetch so the
+			// panel re-syncs immediately after a successful reconnect, without
+			// waiting for the worker's next keepalive broadcast. The 1.5s
+			// delay lets EventSource reconnect first, avoiding a redundant
+			// fetch on a momentary blip.
+			this.sse.onerror = function () {
+				if (self.reconnectFallbackTimer) return
+				self.reconnectFallbackTimer = window.setTimeout(function () {
+					self.reconnectFallbackTimer = null
+					if (self.disposed || !self.visible) return
+					self.refresh()
+				}, 1500)
+			}
 		}
 		LivePreviewController.prototype.closeStream = function () {
 			try { if (this.sse) this.sse.close() } catch (e) {}

--- a/lib/client.js
+++ b/lib/client.js
@@ -235,9 +235,88 @@ window.__ModuleLoader__.load({
 		}
 
 		// ── Settings card: component ─────────────────────────────────────
-		// Plain React.createElement (no JSX) — keeps the single-file plain-JS
-		// pattern. Root is <li> per the settings.plugin.item slot contract.
+		// Design follows `dsh-plugin-interpreters`: a bordered DSW token card
+		// (var(--dsw-alias-*)) that adapts to light/dark themes, a header button
+		// with name + description + pending pill + chevron, a body split by a
+		// border-top from the footer. Fields use the shared Field helper so the
+		// label/input/hint rhythm matches other plugin cards.
 		var h = React.createElement
+
+		// Card CSS (scoped under .dsh-ego-card). Uses the host design-system
+		// aliases so the card picks up theme changes automatically. Injected
+		// once by apply(); idempotent (guarded by a data attribute).
+		var SETTINGS_CARD_STYLE_ID = 'dsh-ego-card-css'
+		var SETTINGS_CARD_CSS = `
+.dsh-ego-card{border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-3);border-radius:12px;list-style:none;transition:border-color .16s,background .16s}
+.dsh-ego-card:hover{border-color:var(--dsw-alias-label-dimmed)}
+.dsh-ego-card--open{background:var(--dsw-alias-bg-layer-2);border-color:var(--dsw-alias-label-dimmed)}
+.dsh-ego-card__header{appearance:none;width:100%;font:inherit;color:inherit;text-align:left;cursor:pointer;background:0 0;border:0;border-radius:12px;align-items:center;gap:12px;padding:14px 16px;display:flex}
+.dsh-ego-card__header:focus-visible{outline:2px solid var(--dsw-alias-brand-primary);outline-offset:-2px}
+.dsh-ego-card__head-text{flex-direction:column;flex:1;gap:4px;min-width:0;display:flex}
+.dsh-ego-card__name{color:var(--dsw-alias-label-primary);font-size:15px;font-weight:600;line-height:1.4}
+.dsh-ego-card__desc{color:var(--dsw-alias-label-tertiary);font-size:13px;line-height:1.5}
+.dsh-ego-card__pending{white-space:nowrap;background:var(--dsw-alias-bg-module-platform);color:var(--dsw-alias-label-secondary);border-radius:999px;flex:none;padding:1px 8px;font-size:11px;font-weight:500;line-height:17px}
+.dsh-ego-card__chevron{color:var(--dsw-alias-label-tertiary);flex:none;transition:transform .16s;display:inline-flex;align-items:center}
+.dsh-ego-card__chevron--open{transform:rotate(180deg)}
+.dsh-ego-card__body{border-top:1px solid var(--dsw-alias-border-l2);margin:0 16px;padding:12px 0 4px}
+.dsh-ego-card__notice{color:var(--dsw-alias-label-tertiary);margin:0 0 8px;font-size:12px;line-height:1.5}
+.dsh-ego-card__saved{color:var(--dsw-alias-state-success-primary);margin:0 0 12px;font-size:12px;line-height:1.5}
+.dsh-ego-card__failed{color:var(--dsw-alias-label-error);margin:0 0 12px;font-size:12px;line-height:1.5;min-width:0}
+.dsh-ego-card__form{display:flex;flex-direction:column;gap:12px}
+.dsh-ego-card__field{display:flex;flex-direction:column;gap:4px}
+.dsh-ego-card__field-label{display:block;font-size:13px;font-weight:500;color:var(--dsw-alias-label-primary)}
+.dsh-ego-card__field-row{display:flex;align-items:center;gap:8px}
+.dsh-ego-card__input{width:100%;padding:6px 10px;font-size:13px;border-radius:8px;border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-3);color:var(--dsw-alias-label-primary);box-sizing:border-box;font-family:inherit}
+.dsh-ego-card__input:focus{outline:2px solid var(--dsw-alias-brand-primary);outline-offset:-2px;border-color:var(--dsw-alias-brand-primary)}
+.dsh-ego-card__input:disabled{opacity:.55;cursor:not-allowed}
+.dsh-ego-card__input--narrow{width:120px;flex:none}
+.dsh-ego-card__unit{font-size:12px;color:var(--dsw-alias-label-tertiary);flex:none}
+.dsh-ego-card__hint{font-size:12px;color:var(--dsw-alias-label-tertiary);margin:0;line-height:1.5}
+.dsh-ego-card__footer{border-top:1px solid var(--dsw-alias-border-l2);justify-content:flex-end;align-items:center;gap:8px;padding:12px 0 4px;display:flex}
+.dsh-ego-card__btn{appearance:none;font:inherit;cursor:pointer;border:1px solid #0000;border-radius:8px;padding:5px 14px;font-size:13px;font-weight:500;line-height:20px;color:var(--dsw-alias-label-primary);background:var(--dsw-alias-bg-module-platform);transition:background .16s,opacity .16s}
+.dsh-ego-card__btn:disabled{cursor:not-allowed;opacity:.5}
+.dsh-ego-card__btn--primary{background:var(--dsw-alias-brand-primary);color:var(--dsw-alias-bg-layer-1)}
+.dsh-ego-card__btn--primary:disabled{background:var(--dsw-alias-bg-module-platform);color:var(--dsw-alias-label-tertiary)}
+.dsh-ego-card__btn:focus-visible{outline:2px solid var(--dsw-alias-brand-primary);outline-offset:-2px}
+`
+
+		// Chevron icon (inline SVG — matches dsh-client-ui-primitives
+		// IconChevronDownOutline14 silhouette so the visual stays consistent
+		// without adding a new peer dep just for one glyph).
+		var CHEVRON_SVG = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>'
+
+		// Field helper — mirrors the interpreters' Field component: label +
+		// input + hint, with an optional `narrow` + unit suffix for numeric
+		// fields that don't need to span the full width.
+		function SettingsField(props) {
+			var id = props.id
+			var label = props.label
+			var hint = props.hint
+			var value = props.value
+			var disabled = props.disabled
+			var onEdit = props.onEdit
+			var numeric = props.numeric
+			var narrow = props.narrow
+			var unit = props.unit
+			var inputEl = h('input', {
+				id: id,
+				className: 'dsh-ego-card__input' + (narrow ? ' dsh-ego-card__input--narrow' : ''),
+				type: numeric ? 'number' : 'text',
+				...(numeric ? { inputMode: 'numeric', min: props.min, max: props.max, step: props.step } : {}),
+				value: value,
+				disabled: disabled,
+				placeholder: props.placeholder,
+				onChange: function (e) { onEdit(e.target.value) },
+			})
+			return h('div', { className: 'dsh-ego-card__field' },
+				h('label', { className: 'dsh-ego-card__field-label', htmlFor: id }, label),
+				narrow
+					? h('div', { className: 'dsh-ego-card__field-row' }, inputEl, unit ? h('span', { className: 'dsh-ego-card__unit' }, unit) : null)
+					: inputEl,
+				hint ? h('p', { className: 'dsh-ego-card__hint' }, hint) : null,
+			)
+		}
+
 		function EgoBrowserCard(props) {
 			var t = props.t
 			var controller = props.controller
@@ -253,92 +332,86 @@ window.__ModuleLoader__.load({
 
 			var header = h('button', {
 				type: 'button',
-				onClick: function () { controller.toggle() },
-				style: { width: '100%', display: 'flex', alignItems: 'center', gap: '8px', padding: '12px 16px', background: 'none', border: 'none', cursor: 'pointer', textAlign: 'left', color: 'inherit', fontSize: '14px' },
+				className: 'dsh-ego-card__header',
+				'aria-expanded': open,
+				'aria-label': t(open ? 'collapse' : 'expand') + ': ' + t('title'),
+				onClick: function () { if (!degraded) controller.toggle() },
 			},
-				h('span', { style: { flex: 1 } },
-					h('span', { style: { fontWeight: 600 } }, t('title')),
-					h('span', { style: { display: 'block', fontSize: '12px', opacity: 0.6, marginTop: '2px' } }, t('intro')),
+				h('span', { className: 'dsh-ego-card__head-text' },
+					h('span', { className: 'dsh-ego-card__name' }, t('title')),
+					h('span', { className: 'dsh-ego-card__desc' }, t('intro')),
 				),
-				state.dirty ? h('span', { style: { fontSize: '11px', opacity: 0.7, fontStyle: 'italic' } }, t('unsaved')) : null,
-				h('span', { style: { transform: open ? 'rotate(180deg)' : 'none', transition: 'transform 0.15s', fontSize: '12px', opacity: 0.6 } }, '▾'),
+				state.dirty ? h('span', { className: 'dsh-ego-card__pending' }, t('unsaved')) : null,
+				h('span', {
+					className: 'dsh-ego-card__chevron' + (open ? ' dsh-ego-card__chevron--open' : ''),
+					dangerouslySetInnerHTML: { __html: CHEVRON_SVG },
+				}),
 			)
 
 			var body = null
 			if (!open) {
 				body = null
 			} else if (!state.available) {
-				body = h('div', { style: { padding: '12px 16px' } },
-					h('p', { role: 'status', style: { fontSize: '13px', opacity: 0.7, margin: '0 0 8px' } }, t('namespaceUnavailable')),
-					h('div', { style: { display: 'flex', gap: '8px' } },
+				body = h('div', { className: 'dsh-ego-card__body' },
+					h('p', { className: 'dsh-ego-card__notice', role: 'status' }, t('namespaceUnavailable')),
+					h('div', { className: 'dsh-ego-card__footer' },
 						h('button', {
 							type: 'button',
+							className: 'dsh-ego-card__btn',
 							onClick: function () { controller.load() },
-							style: btnStyle(false),
 						}, t('retry')),
 					),
 				)
 			} else {
-				var footerItems = []
-				if (errorText !== undefined) {
-					footerItems.push(h('p', { role: 'status', style: { color: '#ff6b6b', fontSize: '12px', margin: '0' } }, errorText))
-				} else if (saved) {
-					footerItems.push(h('p', { role: 'status', style: { color: '#30d158', fontSize: '12px', margin: '0' } }, t('save')))
-				}
-				footerItems.push(h('div', { style: { display: 'flex', gap: '8px', marginLeft: 'auto' } },
-					h('button', {
-						type: 'button',
-						onClick: function () { controller.discard() },
-						disabled: !state.dirty || saving,
-						style: btnStyle(state.dirty && !saving),
-					}, t('discard')),
-					h('button', {
-						type: 'button',
-						onClick: function () { controller.save() },
-						disabled: !state.dirty || saving,
-						style: btnStyle(state.dirty && !saving),
-					}, saving ? t('saving') : t('save')),
-				))
-				body = h('div', { style: { padding: '4px 16px 16px' } },
-					!state.writable ? h('p', { role: 'status', style: { fontSize: '12px', opacity: 0.6, margin: '0 0 8px' } }, t('readOnly')) : null,
-					h('label', { style: { display: 'block', fontSize: '13px', fontWeight: 500, marginBottom: '4px' } }, t('chromePath')),
-					h('input', {
-						type: 'text',
-						value: state.draft.chromePath || '',
-						disabled: !state.writable || saving,
-						placeholder: 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
-						onChange: function (e) { controller.edit('chromePath', e.target.value) },
-						style: { width: '100%', padding: '6px 10px', fontSize: '13px', borderRadius: '6px', border: '1px solid rgba(128,128,128,0.3)', background: 'rgba(128,128,128,0.1)', color: 'inherit', boxSizing: 'border-box' },
-					}),
-					h('p', { style: { fontSize: '12px', opacity: 0.5, margin: '4px 0 12px' } }, t('chromePathHint')),
-					h('label', { style: { display: 'block', fontSize: '13px', fontWeight: 500, marginBottom: '4px' } }, t('refreshInterval')),
-					h('div', { style: { display: 'flex', alignItems: 'center', gap: '6px' } },
-						h('input', {
-							type: 'number',
-							min: 500, max: 30000, step: 100,
-							value: state.draft.refreshInterval || '',
-							disabled: !state.writable || saving,
-							placeholder: '2000',
-							onChange: function (e) { controller.edit('refreshInterval', e.target.value) },
-							style: { width: '120px', padding: '6px 10px', fontSize: '13px', borderRadius: '6px', border: '1px solid rgba(128,128,128,0.3)', background: 'rgba(128,128,128,0.1)', color: 'inherit', boxSizing: 'border-box' },
+				var busy = !state.writable || saving
+				var saveDisabled = !state.dirty || saving || !state.writable
+				var discardDisabled = !state.dirty || saving
+				body = h('div', { className: 'dsh-ego-card__body' },
+					!state.writable ? h('p', { className: 'dsh-ego-card__notice', role: 'status' }, t('readOnly')) : null,
+					saved ? h('p', { className: 'dsh-ego-card__saved', role: 'status' }, t('save')) : null,
+					h('div', { className: 'dsh-ego-card__form' },
+						h(SettingsField, {
+							id: 'plugin-config-ego-browser-chromepath',
+							label: t('chromePath'),
+							hint: t('chromePathHint'),
+							value: state.draft.chromePath || '',
+							placeholder: 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+							disabled: busy,
+							onEdit: function (v) { controller.edit('chromePath', v) },
 						}),
-						h('span', { style: { fontSize: '12px', opacity: 0.6 } }, t('refreshIntervalUnit')),
+						h(SettingsField, {
+							id: 'plugin-config-ego-browser-refresh',
+							label: t('refreshInterval'),
+							hint: t('refreshIntervalHint'),
+							value: state.draft.refreshInterval || '',
+							placeholder: '2000',
+							numeric: true, narrow: true, unit: t('refreshIntervalUnit'),
+							min: 500, max: 30000, step: 100,
+							disabled: busy,
+							onEdit: function (v) { controller.edit('refreshInterval', v) },
+						}),
 					),
-					h('p', { style: { fontSize: '12px', opacity: 0.5, margin: '4px 0 12px' } }, t('refreshIntervalHint')),
-					h('div', { style: { display: 'flex', alignItems: 'center', gap: '8px', flexWrap: 'wrap' } }, footerItems),
+					h('div', { className: 'dsh-ego-card__footer' },
+						errorText !== undefined ? h('p', { className: 'dsh-ego-card__failed', role: 'status' }, errorText) : null,
+						h('button', {
+							type: 'button',
+							className: 'dsh-ego-card__btn',
+							disabled: discardDisabled,
+							onClick: function () { controller.discard() },
+						}, t('discard')),
+						h('button', {
+							type: 'button',
+							className: 'dsh-ego-card__btn dsh-ego-card__btn--primary',
+							disabled: saveDisabled,
+							onClick: function () { controller.save() },
+						}, saving ? t('saving') : t('save')),
+					),
 				)
 			}
 
 			return h('li', {
-				style: { listStyle: 'none', borderBottom: '1px solid rgba(128,128,128,0.15)' },
-			}, header, body)
-		}
-		function btnStyle(active) {
-			return {
-				padding: '5px 14px', fontSize: '13px', borderRadius: '6px', cursor: active ? 'pointer' : 'default',
-				border: '1px solid rgba(128,128,128,0.3)', background: active ? 'rgba(48,209,88,0.15)' : 'none',
-				color: 'inherit', opacity: active ? 1 : 0.5, transition: 'opacity 0.15s',
-			}
+				className: 'dsh-ego-card' + (open ? ' dsh-ego-card--open' : ''),
+			}, header, open ? body : null)
 		}
 
 		const SPACES_ROUTE = '/api/ego/spaces'
@@ -583,6 +656,18 @@ window.__ModuleLoader__.load({
 		function apply(ctx) {
 			// ── Settings card: register locale + slot (always runs) ──────
 			ctx.effect(() => ctx.locale.register(SETTINGS_NS, { zh, en }), 'ego-browser: settings dictionaries')
+			// Inject the settings-card stylesheet once (idempotent — guarded by
+			// a data attribute so HMR / repeated apply() calls don't duplicate).
+			ctx.effect(() => {
+				if (typeof document === 'undefined') return
+				if (document.getElementById(SETTINGS_CARD_STYLE_ID) !== null) return
+				var tag = document.createElement('style')
+				tag.id = SETTINGS_CARD_STYLE_ID
+				tag.dataset.plugin = 'ego-browser'
+				tag.textContent = SETTINGS_CARD_CSS
+				document.head.appendChild(tag)
+				return function () { tag.remove() }
+			}, 'ego-browser: settings card css')
 			var controller = new EgoBrowserSettingsController()
 			var useSnapshot = bindSnapshotSelector(controller.store)
 			ctx.effect(() => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -48,9 +48,17 @@ window.__ModuleLoader__.load({
 		var SETTINGS_NS = 'ego-browser'
 		var en = {
 			title: 'ego-browser',
-			intro: 'Agent browser integration. Configure the Chrome/Chromium binary path below.',
+			intro: 'Agent browser integration. Configure the Chrome/Chromium binary path and cast parameters below.',
 			chromePath: 'Browser binary path',
 			chromePathHint: 'Path to the Chrome/Chromium/Edge binary. Empty = auto-detect.',
+			castFpsCap: 'Frame rate cap',
+			castFpsCapHint: 'Max frames/sec pushed to the panel (0 = uncapped, active tab never throttled). Lower to save bandwidth/CPU. Range 0–60.',
+			castFpsCapUnit: 'fps',
+			screencastQuality: 'JPEG quality',
+			screencastQualityHint: 'Quality of pushed screencast frames (1–100). Lower = smaller payload, more artifacts. Range 1–100.',
+			screencastMaxWidth: 'Frame max width',
+			screencastMaxWidthHint: 'Max width of screencast frames in CSS px (320–1920). Lower = smaller payload, less detail.',
+			screencastMaxWidthUnit: 'px',
 			save: 'Save', saving: 'Saving…', discard: 'Discard',
 			unsaved: 'Unsaved', readOnly: 'Settings are read-only in this deployment.',
 			namespaceUnavailable: 'The ego-browser configuration channel is unavailable. Please retry later.',
@@ -59,9 +67,17 @@ window.__ModuleLoader__.load({
 		}
 		var zh = {
 			title: 'ego-browser',
-			intro: 'Agent 浏览器集成。在下方配置 Chrome/Chromium 浏览器路径。',
+			intro: 'Agent 浏览器集成。在下方配置 Chrome/Chromium 浏览器路径及推流参数。',
 			chromePath: '浏览器路径',
 			chromePathHint: 'Chrome/Chromium/Edge 可执行文件路径。留空 = 自动检测。',
+			castFpsCap: '帧率上限',
+			castFpsCapHint: '推送到面板的最大帧率（0 = 不限，活跃标签永不降速）。调低可节省带宽/CPU。范围 0–60。',
+			castFpsCapUnit: 'fps',
+			screencastQuality: 'JPEG 质量',
+			screencastQualityHint: '推送帧的 JPEG 质量（1–100）。越低体积越小、伪影越多。范围 1–100。',
+			screencastMaxWidth: '帧最大宽度',
+			screencastMaxWidthHint: '推流帧的最大 CSS 像素宽度（320–1920）。越低体积越小、细节越少。',
+			screencastMaxWidthUnit: 'px',
 			save: '保存', saving: '保存中…', discard: '放弃',
 			unsaved: '未保存', readOnly: '当前部署下设置只读。',
 			namespaceUnavailable: 'ego-browser 配置通道不可用，请稍后重试。',
@@ -75,7 +91,7 @@ window.__ModuleLoader__.load({
 				status: 'idle',        // 'idle' | 'loading' | 'ready'
 				available: false,      // true after a successful /ego/api/get
 				writable: false,       // false when settings service is absent
-				draft: { chromePath: '' },
+				draft: { chromePath: '', castFpsCap: '0', screencastQuality: '55', screencastMaxWidth: '960' },
 				dirty: false,
 				applyState: { kind: 'idle' }, // 'idle' | 'saving' | 'saved' | 'error'
 				errorMessage: undefined,
@@ -120,6 +136,9 @@ window.__ModuleLoader__.load({
 					s.writable = true
 					s.draft = {
 						chromePath: config.chromePath || '',
+						castFpsCap: String(config.castFpsCap ?? 0),
+						screencastQuality: String(config.screencastQuality ?? 55),
+						screencastMaxWidth: String(config.screencastMaxWidth ?? 960),
 					}
 					s.dirty = false
 					s.applyState = { kind: 'idle' }
@@ -158,8 +177,20 @@ window.__ModuleLoader__.load({
 			var self = this
 			var gen = ++this.generation
 			var patch = {}
+			var NUMERIC_FIELDS = {
+				castFpsCap: { min: 0, max: 60, def: 0 },
+				screencastQuality: { min: 1, max: 100, def: 55 },
+				screencastMaxWidth: { min: 320, max: 1920, def: 960 },
+			}
 			this.staged.forEach(function (v, k) {
-				patch[k] = v
+				var spec = NUMERIC_FIELDS[k]
+				if (spec) {
+					var n = parseInt(v, 10)
+					if (!Number.isFinite(n)) n = spec.def
+					patch[k] = Math.max(spec.min, Math.min(spec.max, n))
+				} else {
+					patch[k] = v
+				}
 			})
 			if (Object.keys(patch).length === 0) {
 				this.staged.clear()
@@ -191,6 +222,9 @@ window.__ModuleLoader__.load({
 					s.applyState = { kind: 'saved' }
 					s.draft = {
 						chromePath: config.chromePath || '',
+						castFpsCap: String(config.castFpsCap ?? 0),
+						screencastQuality: String(config.screencastQuality ?? 55),
+						screencastMaxWidth: String(config.screencastMaxWidth ?? 960),
 					}
 					s.dirty = false
 				})
@@ -349,6 +383,39 @@ window.__ModuleLoader__.load({
 							placeholder: 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
 							disabled: busy,
 							onEdit: function (v) { controller.edit('chromePath', v) },
+						}),
+						h(SettingsField, {
+							id: 'plugin-config-ego-browser-castfps',
+							label: t('castFpsCap'),
+							hint: t('castFpsCapHint'),
+							value: state.draft.castFpsCap || '',
+							placeholder: '0',
+							numeric: true, narrow: true, unit: t('castFpsCapUnit'),
+							min: 0, max: 60, step: 1,
+							disabled: busy,
+							onEdit: function (v) { controller.edit('castFpsCap', v) },
+						}),
+						h(SettingsField, {
+							id: 'plugin-config-ego-browser-quality',
+							label: t('screencastQuality'),
+							hint: t('screencastQualityHint'),
+							value: state.draft.screencastQuality || '',
+							placeholder: '55',
+							numeric: true, narrow: true,
+							min: 1, max: 100, step: 1,
+							disabled: busy,
+							onEdit: function (v) { controller.edit('screencastQuality', v) },
+						}),
+						h(SettingsField, {
+							id: 'plugin-config-ego-browser-maxwidth',
+							label: t('screencastMaxWidth'),
+							hint: t('screencastMaxWidthHint'),
+							value: state.draft.screencastMaxWidth || '',
+							placeholder: '960',
+							numeric: true, narrow: true, unit: t('screencastMaxWidthUnit'),
+							min: 320, max: 1920, step: 40,
+							disabled: busy,
+							onEdit: function (v) { controller.edit('screencastMaxWidth', v) },
 						}),
 					),
 					h('div', { className: 'dsh-ego-card__footer' },

--- a/lib/config.js
+++ b/lib/config.js
@@ -25,18 +25,26 @@ export const Config = z.object({
   /**
    * Base refresh interval (ms) for the realtime watch panel: how often the
    * client polls /api/ego/spaces for live screenshots / tab list while the
-   * agent is actively driving the browser. Idle cadence is derived as
-   * 4× this value. Range 100–30000; default 2000.
+   * agent is actively driving the browser. Idle cadence is
+   * `refreshInterval × idleMultiplier`. Range 100–30000; default 2000.
    */
   refreshInterval: z.number().min(100).max(30000).step(100).default(2000).description(
-    "Watch panel refresh interval in ms (idle = 4×). Default 2000.",
+    "Watch panel refresh interval in ms (active). Default 2000.",
+  ),
+  /**
+   * Multiplier applied to `refreshInterval` to derive the idle poll cadence
+   * (when no page has been touched recently). 1 = no slowdown; 4 = idle polls
+   * every 4× the active interval. Range 1–20; default 4.
+   */
+  idleMultiplier: z.number().min(1).max(20).step(1).default(4).description(
+    "Idle cadence multiplier (idle = refreshInterval × this). Default 4.",
   ),
 });
 
 /**
  * Resolve config with fallbacks for missing / invalid values.
  * @param {Partial<ReturnType<typeof Config>>} config - raw config from cordis.yml or settings scope.
- * @returns {{ chromePath: string, refreshInterval: number }} a fully-populated config view.
+ * @returns {{ chromePath: string, refreshInterval: number, idleMultiplier: number }} a fully-populated config view.
  */
 export function resolveConfig(config) {
   const chromePath =
@@ -47,5 +55,11 @@ export function resolveConfig(config) {
     config.refreshInterval >= 100 && config.refreshInterval <= 30000
       ? config.refreshInterval
       : 2000;
-  return { chromePath, refreshInterval };
+  const idleMultiplier =
+    typeof config?.idleMultiplier === "number" &&
+    Number.isFinite(config.idleMultiplier) &&
+    config.idleMultiplier >= 1 && config.idleMultiplier <= 20
+      ? config.idleMultiplier
+      : 4;
+  return { chromePath, refreshInterval, idleMultiplier };
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -48,12 +48,22 @@ export const Config = z.object({
   screencastMaxWidth: z.number().min(320).max(1920).step(40).default(960).description(
     "Max width of screencast frames in px (320-1920). Default 960.",
   ),
+  /**
+   * How long (ms) a page may go without a pushed screencast frame before the
+   * periodic backstop issues a forced captureScreenshot for it. Also serves
+   * as the minimum interval between forced captures for the same target.
+   * Lower = more frequent backstop frames (higher CPU/CDP load). Range
+   * 200–10000; default 5000.
+   */
+  backstopIntervalMs: z.number().min(200).max(10000).step(100).default(5000).description(
+    "Backstop interval in ms — how long before a stale page gets a forced screenshot. Default 5000.",
+  ),
 });
 
 /**
  * Resolve config with fallbacks for missing / invalid values.
  * @param {Partial<ReturnType<typeof Config>>} config - raw config from cordis.yml or settings scope.
- * @returns {{ chromePath: string, castFpsCap: number, screencastQuality: number, screencastMaxWidth: number }} a fully-populated config view.
+ * @returns {{ chromePath: string, castFpsCap: number, screencastQuality: number, screencastMaxWidth: number, backstopIntervalMs: number }} a fully-populated config view.
  */
 export function resolveConfig(config) {
   const chromePath =
@@ -76,5 +86,11 @@ export function resolveConfig(config) {
     config.screencastMaxWidth >= 320 && config.screencastMaxWidth <= 1920
       ? config.screencastMaxWidth
       : 960;
-  return { chromePath, castFpsCap, screencastQuality, screencastMaxWidth };
+  const backstopIntervalMs =
+    typeof config?.backstopIntervalMs === "number" &&
+    Number.isFinite(config.backstopIntervalMs) &&
+    config.backstopIntervalMs >= 200 && config.backstopIntervalMs <= 10000
+      ? config.backstopIntervalMs
+      : 5000;
+  return { chromePath, castFpsCap, screencastQuality, screencastMaxWidth, backstopIntervalMs };
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -22,48 +22,15 @@ export const Config = z.object({
   chromePath: z.string().default("").description(
     "Path to the Chrome/Chromium binary. Empty = auto-detect.",
   ),
-  /**
-   * Probe interval (ms) for the sidebar-tab auto-open detector. When the
-   * agent has not yet called an ego_* tool this session, a lightweight
-   * standalone probe polls /api/ego/spaces at this cadence to detect the
-   * first tool call and auto-open the watch Tab. The watch panel itself is
-   * pure SSE-driven (real-time `frame` + `spaces` events), so this setting
-   * does NOT affect the panel's live-update speed — only the auto-open
-   * probe's polling rate while waiting for the first tool call. Idle cadence
-   * is `refreshInterval × idleMultiplier`. Range 100–30000; default 2000.
-   */
-  refreshInterval: z.number().min(100).max(30000).step(100).default(2000).description(
-    "Auto-open probe interval in ms (panel is SSE-driven). Default 2000.",
-  ),
-  /**
-   * Multiplier applied to `refreshInterval` to derive the idle probe cadence
-   * (when no tool call has been seen yet). 1 = no slowdown; 4 = idle polls
-   * every 4× the active interval. Range 1–20; default 4.
-   */
-  idleMultiplier: z.number().min(1).max(20).step(1).default(4).description(
-    "Idle probe multiplier (idle = refreshInterval × this). Default 4.",
-  ),
 });
 
 /**
  * Resolve config with fallbacks for missing / invalid values.
  * @param {Partial<ReturnType<typeof Config>>} config - raw config from cordis.yml or settings scope.
- * @returns {{ chromePath: string, refreshInterval: number, idleMultiplier: number }} a fully-populated config view.
+ * @returns {{ chromePath: string }} a fully-populated config view.
  */
 export function resolveConfig(config) {
   const chromePath =
     typeof config?.chromePath === "string" ? config.chromePath : "";
-  const refreshInterval =
-    typeof config?.refreshInterval === "number" &&
-    Number.isFinite(config.refreshInterval) &&
-    config.refreshInterval >= 100 && config.refreshInterval <= 30000
-      ? config.refreshInterval
-      : 2000;
-  const idleMultiplier =
-    typeof config?.idleMultiplier === "number" &&
-    Number.isFinite(config.idleMultiplier) &&
-    config.idleMultiplier >= 1 && config.idleMultiplier <= 20
-      ? config.idleMultiplier
-      : 4;
-  return { chromePath, refreshInterval, idleMultiplier };
+  return { chromePath };
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -26,9 +26,9 @@ export const Config = z.object({
    * Base refresh interval (ms) for the realtime watch panel: how often the
    * client polls /api/ego/spaces for live screenshots / tab list while the
    * agent is actively driving the browser. Idle cadence is derived as
-   * 4× this value. Range 500–30000; default 2000.
+   * 4× this value. Range 100–30000; default 2000.
    */
-  refreshInterval: z.number().min(500).max(30000).step(100).default(2000).description(
+  refreshInterval: z.number().min(100).max(30000).step(100).default(2000).description(
     "Watch panel refresh interval in ms (idle = 4×). Default 2000.",
   ),
 });
@@ -44,7 +44,7 @@ export function resolveConfig(config) {
   const refreshInterval =
     typeof config?.refreshInterval === "number" &&
     Number.isFinite(config.refreshInterval) &&
-    config.refreshInterval >= 500 && config.refreshInterval <= 30000
+    config.refreshInterval >= 100 && config.refreshInterval <= 30000
       ? config.refreshInterval
       : 2000;
   return { chromePath, refreshInterval };

--- a/lib/config.js
+++ b/lib/config.js
@@ -22,15 +22,59 @@ export const Config = z.object({
   chromePath: z.string().default("").description(
     "Path to the Chrome/Chromium binary. Empty = auto-detect.",
   ),
+  /**
+   * Cap on live-frame fan-out (frames/sec) from the cast worker to the watch
+   * panel. 0 = uncapped (full browser repaint cadence). >0 = at most N
+   * frames/sec; the watched (active) tab is never throttled, only background
+   * repainting tabs. Lower this to save bandwidth/CPU on dynamic pages.
+   * Range 0–60; default 0.
+   */
+  castFpsCap: z.number().min(0).max(60).step(1).default(0).description(
+    "Max frames/sec to push (0 = uncapped, active tab never throttled). Default 0.",
+  ),
+  /**
+   * JPEG quality (1–100) for screencast frames and screenshot backstop.
+   * Lower = smaller payload, more compression artifacts. Range 1–100;
+   * default 55.
+   */
+  screencastQuality: z.number().min(1).max(100).step(1).default(55).description(
+    "JPEG quality for screencast frames (1-100). Default 55.",
+  ),
+  /**
+   * Max width (CSS px) of each pushed screencast frame. The browser scales
+   * down to fit. Lower = smaller payload, less detail. Range 320–1920;
+   * default 960.
+   */
+  screencastMaxWidth: z.number().min(320).max(1920).step(40).default(960).description(
+    "Max width of screencast frames in px (320-1920). Default 960.",
+  ),
 });
 
 /**
  * Resolve config with fallbacks for missing / invalid values.
  * @param {Partial<ReturnType<typeof Config>>} config - raw config from cordis.yml or settings scope.
- * @returns {{ chromePath: string }} a fully-populated config view.
+ * @returns {{ chromePath: string, castFpsCap: number, screencastQuality: number, screencastMaxWidth: number }} a fully-populated config view.
  */
 export function resolveConfig(config) {
   const chromePath =
     typeof config?.chromePath === "string" ? config.chromePath : "";
-  return { chromePath };
+  const castFpsCap =
+    typeof config?.castFpsCap === "number" &&
+    Number.isFinite(config.castFpsCap) &&
+    config.castFpsCap >= 0 && config.castFpsCap <= 60
+      ? config.castFpsCap
+      : 0;
+  const screencastQuality =
+    typeof config?.screencastQuality === "number" &&
+    Number.isFinite(config.screencastQuality) &&
+    config.screencastQuality >= 1 && config.screencastQuality <= 100
+      ? config.screencastQuality
+      : 55;
+  const screencastMaxWidth =
+    typeof config?.screencastMaxWidth === "number" &&
+    Number.isFinite(config.screencastMaxWidth) &&
+    config.screencastMaxWidth >= 320 && config.screencastMaxWidth <= 1920
+      ? config.screencastMaxWidth
+      : 960;
+  return { chromePath, castFpsCap, screencastQuality, screencastMaxWidth };
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -23,21 +23,25 @@ export const Config = z.object({
     "Path to the Chrome/Chromium binary. Empty = auto-detect.",
   ),
   /**
-   * Base refresh interval (ms) for the realtime watch panel: how often the
-   * client polls /api/ego/spaces for live screenshots / tab list while the
-   * agent is actively driving the browser. Idle cadence is
-   * `refreshInterval × idleMultiplier`. Range 100–30000; default 2000.
+   * Probe interval (ms) for the sidebar-tab auto-open detector. When the
+   * agent has not yet called an ego_* tool this session, a lightweight
+   * standalone probe polls /api/ego/spaces at this cadence to detect the
+   * first tool call and auto-open the watch Tab. The watch panel itself is
+   * pure SSE-driven (real-time `frame` + `spaces` events), so this setting
+   * does NOT affect the panel's live-update speed — only the auto-open
+   * probe's polling rate while waiting for the first tool call. Idle cadence
+   * is `refreshInterval × idleMultiplier`. Range 100–30000; default 2000.
    */
   refreshInterval: z.number().min(100).max(30000).step(100).default(2000).description(
-    "Watch panel refresh interval in ms (active). Default 2000.",
+    "Auto-open probe interval in ms (panel is SSE-driven). Default 2000.",
   ),
   /**
-   * Multiplier applied to `refreshInterval` to derive the idle poll cadence
-   * (when no page has been touched recently). 1 = no slowdown; 4 = idle polls
+   * Multiplier applied to `refreshInterval` to derive the idle probe cadence
+   * (when no tool call has been seen yet). 1 = no slowdown; 4 = idle polls
    * every 4× the active interval. Range 1–20; default 4.
    */
   idleMultiplier: z.number().min(1).max(20).step(1).default(4).description(
-    "Idle cadence multiplier (idle = refreshInterval × this). Default 4.",
+    "Idle probe multiplier (idle = refreshInterval × this). Default 4.",
   ),
 });
 

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -22,7 +22,7 @@ import { SETTINGS_NAMESPACE } from "./settings.js";
 const API_PREFIX = "/ego/api";
 
 /** Config keys the `set` endpoint accepts (allow-list; unknown keys are dropped). */
-const ALLOWED_KEYS = new Set(["chromePath", "refreshInterval", "idleMultiplier"]);
+const ALLOWED_KEYS = new Set(["chromePath"]);
 
 /**
  * Register the `/ego/api` HTTP route on the host's web server.
@@ -32,7 +32,7 @@ const ALLOWED_KEYS = new Set(["chromePath", "refreshInterval", "idleMultiplier"]
  * when absent, `get` degrades to the entry source and `set` returns a
  * clear error.
  * @param {import("@deepseek-ai/cordis").Context} ctx - host context carrying `webServer`.
- * @param {{ source: () => { chromePath: string, refreshInterval: number, idleMultiplier: number }, onChange: (cb: () => void) => void }} bridge
+ * @param {{ source: () => { chromePath: string }, onChange: (cb: () => void) => void }} bridge
  *   the settings bridge the route reads through.
  */
 export function registerEgoBrowserGateway(ctx, bridge) {
@@ -104,8 +104,7 @@ async function handleSet(body, settings, bridge) {
  *
  * JSON wire boundary: null = "delete" (filtered), undefined never crosses
  * JSON. Unknown keys are dropped (the settings service is non-strict and
- * would otherwise store them). String keys (chromePath) and number keys
- * (refreshInterval) are both accepted.
+ * would otherwise store them). String keys (chromePath) are accepted.
  */
 function extractPatch(body) {
   if (!isObject(body)) return {};

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -22,7 +22,7 @@ import { SETTINGS_NAMESPACE } from "./settings.js";
 const API_PREFIX = "/ego/api";
 
 /** Config keys the `set` endpoint accepts (allow-list; unknown keys are dropped). */
-const ALLOWED_KEYS = new Set(["chromePath"]);
+const ALLOWED_KEYS = new Set(["chromePath", "castFpsCap", "screencastQuality", "screencastMaxWidth"]);
 
 /**
  * Register the `/ego/api` HTTP route on the host's web server.
@@ -32,7 +32,7 @@ const ALLOWED_KEYS = new Set(["chromePath"]);
  * when absent, `get` degrades to the entry source and `set` returns a
  * clear error.
  * @param {import("@deepseek-ai/cordis").Context} ctx - host context carrying `webServer`.
- * @param {{ source: () => { chromePath: string }, onChange: (cb: () => void) => void }} bridge
+ * @param {{ source: () => { chromePath: string, castFpsCap: number, screencastQuality: number, screencastMaxWidth: number }, onChange: (cb: () => void) => void }} bridge
  *   the settings bridge the route reads through.
  */
 export function registerEgoBrowserGateway(ctx, bridge) {

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -22,7 +22,7 @@ import { SETTINGS_NAMESPACE } from "./settings.js";
 const API_PREFIX = "/ego/api";
 
 /** Config keys the `set` endpoint accepts (allow-list; unknown keys are dropped). */
-const ALLOWED_KEYS = new Set(["chromePath", "castFpsCap", "screencastQuality", "screencastMaxWidth"]);
+const ALLOWED_KEYS = new Set(["chromePath", "castFpsCap", "screencastQuality", "screencastMaxWidth", "backstopIntervalMs"]);
 
 /**
  * Register the `/ego/api` HTTP route on the host's web server.

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -22,7 +22,7 @@ import { SETTINGS_NAMESPACE } from "./settings.js";
 const API_PREFIX = "/ego/api";
 
 /** Config keys the `set` endpoint accepts (allow-list; unknown keys are dropped). */
-const ALLOWED_KEYS = new Set(["chromePath", "refreshInterval"]);
+const ALLOWED_KEYS = new Set(["chromePath", "refreshInterval", "idleMultiplier"]);
 
 /**
  * Register the `/ego/api` HTTP route on the host's web server.
@@ -32,7 +32,7 @@ const ALLOWED_KEYS = new Set(["chromePath", "refreshInterval"]);
  * when absent, `get` degrades to the entry source and `set` returns a
  * clear error.
  * @param {import("@deepseek-ai/cordis").Context} ctx - host context carrying `webServer`.
- * @param {{ source: () => { chromePath: string, refreshInterval: number }, onChange: (cb: () => void) => void }} bridge
+ * @param {{ source: () => { chromePath: string, refreshInterval: number, idleMultiplier: number }, onChange: (cb: () => void) => void }} bridge
  *   the settings bridge the route reads through.
  */
 export function registerEgoBrowserGateway(ctx, bridge) {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -95,7 +95,7 @@ export interface Config {
     /**
      * Base refresh interval (ms) for the realtime watch panel: how often the
      * client polls /api/ego/spaces while the agent is actively driving the
-     * browser. Idle cadence is 4× this value. Range 500–30000; default 2000.
+     * browser. Idle cadence is 4× this value. Range 100–30000; default 2000.
      * Set via the DSH settings UI (ego-browser card) or composition layer.
      */
     refreshInterval?: number;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -100,10 +100,13 @@ export interface Config {
      */
     refreshInterval?: number;
     /**
-     * Multiplier applied to `refreshInterval` to derive the idle poll cadence
-     * (when no page has been touched recently). 1 = no slowdown; 4 = idle polls
-     * every 4× the active interval. Range 1–20; default 4. Set via the DSH
-     * settings UI (ego-browser card) or composition layer.
+     * Probe interval (ms) for the sidebar-tab auto-open detector. The watch
+     * panel itself is pure SSE-driven (real-time `frame` + `spaces` events
+     * from /api/ego/stream), so this setting does NOT affect the panel's
+     * live-update speed — only the standalone probe's polling rate while
+     * waiting for the first ego_* tool call (before the Tab auto-opens).
+     * Range 100–30000; default 2000. Set via the DSH settings UI
+     * (ego-browser card) or composition layer.
      */
     idleMultiplier?: number;
     /**

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -93,6 +93,23 @@ export interface Config {
      */
     chromePath?: string;
     /**
+     * Cap on live-frame fan-out (frames/sec) from the cast worker to the
+     * watch panel. 0 = uncapped (full browser repaint cadence). >0 = at
+     * most N frames/sec; the watched (active) tab is never throttled, only
+     * background repainting tabs. Range 0–60; default 0.
+     */
+    castFpsCap?: number;
+    /**
+     * JPEG quality (1–100) for screencast frames and screenshot backstop.
+     * Range 1–100; default 55.
+     */
+    screencastQuality?: number;
+    /**
+     * Max width (CSS px) of each pushed screencast frame. Range 320–1920;
+     * default 960.
+     */
+    screencastMaxWidth?: number;
+    /**
      * Path or command name of the ego-browser CLI.
      * Default: the vendored CLI bundled inside this plugin
      * (`runtime/ego-linux/bin/ego-browser.mjs`), so the plugin works with just

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -100,6 +100,13 @@ export interface Config {
      */
     refreshInterval?: number;
     /**
+     * Multiplier applied to `refreshInterval` to derive the idle poll cadence
+     * (when no page has been touched recently). 1 = no slowdown; 4 = idle polls
+     * every 4× the active interval. Range 1–20; default 4. Set via the DSH
+     * settings UI (ego-browser card) or composition layer.
+     */
+    idleMultiplier?: number;
+    /**
      * Path or command name of the ego-browser CLI.
      * Default: the vendored CLI bundled inside this plugin
      * (`runtime/ego-linux/bin/ego-browser.mjs`), so the plugin works with just

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -110,6 +110,13 @@ export interface Config {
      */
     screencastMaxWidth?: number;
     /**
+     * How long (ms) a page may go without a pushed screencast frame before
+     * the periodic backstop issues a forced captureScreenshot. Also serves
+     * as the minimum interval between forced captures for the same target.
+     * Range 200–10000; default 5000.
+     */
+    backstopIntervalMs?: number;
+    /**
      * Path or command name of the ego-browser CLI.
      * Default: the vendored CLI bundled inside this plugin
      * (`runtime/ego-linux/bin/ego-browser.mjs`), so the plugin works with just

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -93,23 +93,6 @@ export interface Config {
      */
     chromePath?: string;
     /**
-     * Base refresh interval (ms) for the realtime watch panel: how often the
-     * client polls /api/ego/spaces while the agent is actively driving the
-     * browser. Idle cadence is 4× this value. Range 100–30000; default 2000.
-     * Set via the DSH settings UI (ego-browser card) or composition layer.
-     */
-    refreshInterval?: number;
-    /**
-     * Probe interval (ms) for the sidebar-tab auto-open detector. The watch
-     * panel itself is pure SSE-driven (real-time `frame` + `spaces` events
-     * from /api/ego/stream), so this setting does NOT affect the panel's
-     * live-update speed — only the standalone probe's polling rate while
-     * waiting for the first ego_* tool call (before the Tab auto-opens).
-     * Range 100–30000; default 2000. Set via the DSH settings UI
-     * (ego-browser card) or composition layer.
-     */
-    idleMultiplier?: number;
-    /**
      * Path or command name of the ego-browser CLI.
      * Default: the vendored CLI bundled inside this plugin
      * (`runtime/ego-linux/bin/ego-browser.mjs`), so the plugin works with just

--- a/lib/index.js
+++ b/lib/index.js
@@ -537,6 +537,10 @@ export function apply(ctx, config = {}) {
       typeof config.refreshInterval === "number"
         ? config.refreshInterval
         : undefined,
+    idleMultiplier:
+      typeof config.idleMultiplier === "number"
+        ? config.idleMultiplier
+        : undefined,
   });
   const bridge = installEgoBrowserSettings(ctx, entry);
 
@@ -558,6 +562,10 @@ export function apply(ctx, config = {}) {
     // and future host-side consumers.
     get refreshInterval() {
       return bridge.source().refreshInterval ?? 2000;
+    },
+    // Live getter for the idle multiplier (idle = refreshInterval × this).
+    get idleMultiplier() {
+      return bridge.source().idleMultiplier ?? 4;
     },
   };
   const reg = (tool) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -528,11 +528,17 @@ const bool = (v, fallback) => (typeof v === "boolean" ? v : fallback);
 // ── plugin entry ────────────────────────────────────────────────────────────
 export function apply(ctx, config = {}) {
   // Install the settings bridge first: the live config source (composition
-  // entry + user-layer overrides) feeds `chromePath` into cfg via a getter so
-  // every spawn reads the latest value without needing re-registration.
+  // entry + user-layer overrides) feeds `chromePath` + cast settings into cfg
+  // via getters so every spawn reads the latest value without re-registration.
   const entry = resolveConfig({
     chromePath:
       typeof config.chromePath === "string" ? config.chromePath : "",
+    castFpsCap:
+      typeof config.castFpsCap === "number" ? config.castFpsCap : undefined,
+    screencastQuality:
+      typeof config.screencastQuality === "number" ? config.screencastQuality : undefined,
+    screencastMaxWidth:
+      typeof config.screencastMaxWidth === "number" ? config.screencastMaxWidth : undefined,
   });
   const bridge = installEgoBrowserSettings(ctx, entry);
 
@@ -548,6 +554,17 @@ export function apply(ctx, config = {}) {
     // the next spawn without restarting the plugin.
     get chromePath() {
       return bridge.source().chromePath || "";
+    },
+    // Live getters for the cast worker's screencast parameters. The cast
+    // server reads these to push hot-update config to a running worker.
+    get castFpsCap() {
+      return bridge.source().castFpsCap ?? 0;
+    },
+    get screencastQuality() {
+      return bridge.source().screencastQuality ?? 55;
+    },
+    get screencastMaxWidth() {
+      return bridge.source().screencastMaxWidth ?? 960;
     },
   };
   const reg = (tool) => {
@@ -569,7 +586,7 @@ export function apply(ctx, config = {}) {
   // inject resolves through fiber.store and is fully supported by cordis.]
   if (typeof ctx.webServer?.register === "function") {
     try {
-      initCastServer(ctx);
+      initCastServer(ctx, cfg, bridge);
     } catch (err) {
       ctx.logger?.warn?.(
         `ego-browser: cast server init failed: ${err?.message ?? err}`

--- a/lib/index.js
+++ b/lib/index.js
@@ -533,14 +533,6 @@ export function apply(ctx, config = {}) {
   const entry = resolveConfig({
     chromePath:
       typeof config.chromePath === "string" ? config.chromePath : "",
-    refreshInterval:
-      typeof config.refreshInterval === "number"
-        ? config.refreshInterval
-        : undefined,
-    idleMultiplier:
-      typeof config.idleMultiplier === "number"
-        ? config.idleMultiplier
-        : undefined,
   });
   const bridge = installEgoBrowserSettings(ctx, entry);
 
@@ -556,16 +548,6 @@ export function apply(ctx, config = {}) {
     // the next spawn without restarting the plugin.
     get chromePath() {
       return bridge.source().chromePath || "";
-    },
-    // Live getter for the watch-panel refresh interval (ms). The client reads
-    // this through /ego/api/get; the host-side cfg mirror is here for symmetry
-    // and future host-side consumers.
-    get refreshInterval() {
-      return bridge.source().refreshInterval ?? 2000;
-    },
-    // Live getter for the idle multiplier (idle = refreshInterval × this).
-    get idleMultiplier() {
-      return bridge.source().idleMultiplier ?? 4;
     },
   };
   const reg = (tool) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -539,6 +539,8 @@ export function apply(ctx, config = {}) {
       typeof config.screencastQuality === "number" ? config.screencastQuality : undefined,
     screencastMaxWidth:
       typeof config.screencastMaxWidth === "number" ? config.screencastMaxWidth : undefined,
+    backstopIntervalMs:
+      typeof config.backstopIntervalMs === "number" ? config.backstopIntervalMs : undefined,
   });
   const bridge = installEgoBrowserSettings(ctx, entry);
 
@@ -565,6 +567,9 @@ export function apply(ctx, config = {}) {
     },
     get screencastMaxWidth() {
       return bridge.source().screencastMaxWidth ?? 960;
+    },
+    get backstopIntervalMs() {
+      return bridge.source().backstopIntervalMs ?? 5000;
     },
   };
   const reg = (tool) => {

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -41,7 +41,7 @@ function isUnloading(ctx) {
  * namespace.
  * @param {import("@deepseek-ai/cordis").Context} ctx - host context.
  * @param {{ chromePath: string }} entry - composition-layer config (cordis.patch.yml seed).
- * @returns {{ source: () => { chromePath: string, refreshInterval: number }, onChange: (cb: () => void) => void }}
+ * @returns {{ source: () => { chromePath: string, refreshInterval: number, idleMultiplier: number }, onChange: (cb: () => void) => void }}
  */
 export function installEgoBrowserSettings(ctx, entry) {
   const listeners = new Set();

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -41,7 +41,7 @@ function isUnloading(ctx) {
  * namespace.
  * @param {import("@deepseek-ai/cordis").Context} ctx - host context.
  * @param {{ chromePath: string }} entry - composition-layer config (cordis.patch.yml seed).
- * @returns {{ source: () => { chromePath: string, castFpsCap: number, screencastQuality: number, screencastMaxWidth: number }, onChange: (cb: () => void) => void }}
+ * @returns {{ source: () => { chromePath: string, castFpsCap: number, screencastQuality: number, screencastMaxWidth: number, backstopIntervalMs: number }, onChange: (cb: () => void) => void }}
  */
 export function installEgoBrowserSettings(ctx, entry) {
   const listeners = new Set();

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -41,7 +41,7 @@ function isUnloading(ctx) {
  * namespace.
  * @param {import("@deepseek-ai/cordis").Context} ctx - host context.
  * @param {{ chromePath: string }} entry - composition-layer config (cordis.patch.yml seed).
- * @returns {{ source: () => { chromePath: string, refreshInterval: number, idleMultiplier: number }, onChange: (cb: () => void) => void }}
+ * @returns {{ source: () => { chromePath: string }, onChange: (cb: () => void) => void }}
  */
 export function installEgoBrowserSettings(ctx, entry) {
   const listeners = new Set();

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -41,7 +41,7 @@ function isUnloading(ctx) {
  * namespace.
  * @param {import("@deepseek-ai/cordis").Context} ctx - host context.
  * @param {{ chromePath: string }} entry - composition-layer config (cordis.patch.yml seed).
- * @returns {{ source: () => { chromePath: string }, onChange: (cb: () => void) => void }}
+ * @returns {{ source: () => { chromePath: string, castFpsCap: number, screencastQuality: number, screencastMaxWidth: number }, onChange: (cb: () => void) => void }}
  */
 export function installEgoBrowserSettings(ctx, entry) {
   const listeners = new Set();


### PR DESCRIPTION
## Summary

A series of changes to the watch panel and cast worker, focused on eliminating HTTP polling and making the screencast pipeline tunable by the user.

## Changes

### Pure SSE-driven watch panel (no more polling)
- Removed all `/api/ego/spaces` periodic polling from the client (`pollTimer` / `scheduleNext` / `_scheduleNext` / `_renderEmptyAndSchedule`).
- The cast worker now broadcasts `spaces` events every 500ms tick (250ms throttle) via `scheduleSpacesBroadcast()`.
- `cast-server`'s `proxyWorkerStream` maintains an `sseClients` Set and can inject SSE events directly; `markEgoToolCall()` broadcasts a `tool-call` SSE event immediately so the auto-open probe triggers without any periodic fetch.
- Client SSE `spaces` event drives full render; `onerror` triggers a 1.5s debounced fallback `refresh()`.
- Auto-open probe rewritten to one-shot baseline fetch + SSE `tool-call` listener (zero periodic fetches).

### User-configurable cast worker parameters
Four new settings exposed in the settings card (zh/en locale):

| Setting | Range | Default | Effect |
|---|---|---|---|
| `castFpsCap` | 0–60 | 0 | Max frames/sec pushed to panel (0 = uncapped). Active tab never throttled; only background tabs are rate-limited. |
| `screencastQuality` | 1–100 | 55 | JPEG quality for `Page.startScreencast` + `captureScreenshot` backstop. |
| `screencastMaxWidth` | 320–1920 | 960 | Max CSS px width of each pushed frame. |
| `backstopIntervalMs` | 200–10000 | 5000 | How long a page may go without a screencast frame before a forced screenshot. Also the min interval between forced captures (was hardcoded 500ms). |

**Config plumbing** runs through all layers: schema (`config.js`), types (`index.d.ts`), gateway `ALLOWED_KEYS`, settings bridge, entry resolution + live getters (`index.js`), cast-server spawn seed + push config, worker argv parse + `/api/config` handler, client locale/draft/load/save/UI.

**Hot-update architecture** (no worker restart needed):
1. **Spawn seed**: `makeEnsureWorker` passes current values as a JSON argv arg (`process.argv[2]`) so a fresh worker starts with the right params.
2. **Hot push**: settings bridge `onChange` → `makePushConfig` POSTs `/api/config` to the running worker.
3. **Worker endpoint**: `POST /api/config` validates + mutates the live `castConfig` object. `castFpsCap` + `backstopIntervalMs` take effect on the next tick; `screencastQuality`/`screencastMaxWidth` trigger a `restartScreencasts()` call (stop + start) on every active stream because Chrome only honors new params on a fresh `Page.startScreencast` call.

### Force-repaint animation for static/video pages
`Page.screencastFrame` only fires when Chrome's compositor produces a new frame. Pages with hardware-accelerated `<video>` (e.g. bilibili), canvas animations, or simply static pages never trigger compositor repaints, so the screencast stream freezes.

Fix: inject a 1px transparent div with an infinite opacity animation into every page target via `Page.addScriptToEvaluateOnNewDocument` (survives navigation) + `Runtime.evaluate` (covers current page). The opacity animation forces the compositor to recomposite every frame, which triggers `Page.screencastFrame` events at the browser's native cadence.

Also added explicit `Page.enable` before `startScreencast`.

### Settings card redesign
- `SETTINGS_CARD_CSS` injected idempotently in `apply()` via a `<style>` tag.
- Uses `--dsh-alias-*` CSS tokens and a `SettingsField` helper component.
- Matches the `dsh-plugin-interpreters` card style.

## Test plan
- [x] `pnpm run build` passes
- [x] `pnpm test` — 20 pass / 0 fail
- [ ] Manual: open watch panel, verify SSE `spaces` + `frame` events arrive with no `/api/ego/spaces` polling in network tab
- [ ] Manual: change each of the 4 cast settings, verify hot-update takes effect without worker restart
- [ ] Manual: open a bilibili video page, verify screencast frames still push (force-repaint animation)
- [ ] Manual: lower `backstopIntervalMs` to 300, verify forced-capture rate increases
