### PR TITLE
WIP: add resilient dual capture pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,18 @@
 
 ## [Unreleased]
 
-性能与稳定性：观察窗推流做了低开销优化。**不做**激进改动（见下），避免为了帧率牺牲整机 CPU。
+观察窗落地双画面管线：修复 CDP 协议根因，并加入可选 FFmpeg H.264/fMP4 后端。
 
 ### 新增 / 优化
-- **可选的观察窗推流帧率上限 `EGO_CAST_FPS_CAP`**（默认 0 = 关闭，即原行为）：设为 N 时，后台重绘标签最多以 N 帧/秒推流，**正在看的那一页永不节流**，仅对后台动画/视频标签限流，降低高动态页面的带宽与 CPU；默认路径完全同步、零额外开销。
-- **前端合帧 `requestAnimationFrame`**：高帧率突发时只解最新的帧（一个演示帧一次解码，而非逐源帧解码），降低 CPU 并让跳帧更顺。
+- `CaptureManager` + watcher lease：同时只有一个活动后端和一个观看 target；面板隐藏后停止 capture。
+- CDP 后端正确区分 frame ACK ID 与 flattened target session，协议错误可见；默认 20 FPS、latest-frame 限流、单 target backstop，删除透明动画强制重绘。
+- FFmpeg 后端：`ffmpeg-static` 延迟解析，系统窗口 crop 编码 H.264 fragmented MP4，经二进制 HTTP 与 MediaSource 播放；generation 隔离旧进程数据。
+- 新设置：`captureBackend`、画质档位、CDP/FFmpeg FPS、最大宽度和编码器；旧字段集中迁移。
+- 新增 MP4 parser、CDP ACK、CaptureManager、配置迁移和平台 argv 单元测试。
 
-### 权衡说明（诚实）
-- **`--disable-frame-rate-limit` 已改为可选项 `EGO_FRAME_RATE_UNCAP=1`（默认关）**：实测该旗标（尤其配 `--disable-gpu-vsync`）会让 Chromium 合成器在静态页面也空转，约 **250% CPU**——为换动态页帧率烧静态页整机，得不偿失。已保留为显式开关，需要更高帧率且接受耗电时可开启。
+### 平台限制
+- Windows 首版 `gdigrab`、Linux X11 `x11grab`、macOS `avfoundation` display crop；遮挡/最小化和系统权限会影响结果。
+- Wayland 随包 FFmpeg 无可用 Portal/PipeWire 输入时明确报 `unsupported-ffmpeg-pipewire`，不使用 root `kmsgrab`，不静默切换整个桌面或伪装成功。
 
 ### 修复
 - **登录态跨 DSH 重启保持（复刻原版 ego-lite 哲学）**：此前手动重启 / 强杀 DSH 后需重新登录——worker 收到 SIGTERM/SIGINT 时只 detach 不落盘，且插件卸载的 `--stop` 宽限 4s 不够、常落到 SIGTERM crash 兜底。现在 worker 退场前先对浏览器发 CDP `Browser.close`（优雅关闭，Cookie journal 合并进磁盘 profile），插件 teardown 宽限提到 8s 足够优雅关完。**实测**：优雅重启登录完全保留；强杀（SIGKILL）长期登录态也已落盘、重启能读回。
@@ -106,5 +110,4 @@ sidebar Tab 集成：当 `dsh-better-sidebar` 可用时，实时查看窗注册�
 - 缩放/拖拽/复位、动态轮询（活跃 2s / 静止 8s）、导航复用 tab。
 - `bin/ego-cast-worker.mjs`：attach 到 agent 正在用的浏览器，CDP 实时推帧，崩溃自动重启。
 - 开箱即用：`bin/ego-chrome-wrapper.sh` 随包自带，root/无头自动 `--no-sandbox`。
-
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 观察窗落地双画面管线：修复 CDP 协议根因，并加入可选 FFmpeg H.264/fMP4 后端。
 
 ### 新增 / 优化
+- FFmpeg 改为显式按需安装：CDP 不再依赖或安装 `ffmpeg-static`。设置页优先检测自定义路径、系统 PATH 和托管缓存，兼容性检查完成前禁用 FFmpeg 选项，并提供固定版本、SHA-256 校验的一键下载。
+- 新增 `githubMirror`，用用户填写的 HTTPS 基址替换 `https://github.com`；Windows/Linux 固定 BtbN release tag，macOS 固定平台资产。下载进入 `~/.dsh/cache/ego-browser/ffmpeg/` 临时目录，校验、解压和能力探测全部成功后才原子发布。
 - 观察画面新增局部键盘输入代理：普通文本和粘贴走 `Input.insertText`，中文 IME 在 composition 完成后一次发送，控制键和快捷键走 `Input.dispatchKeyEvent`。只在点击观察画面后聚焦，不抢 DSH 自身输入。
 - 新增 `ffmpegBitrateKbps` 设置（500-20000 kbps）；低/平衡/高档默认 2000/4000/8000 kbps。编码器使用目标码率、峰值码率与 VBV buffer，替代 `h264_mf` 的约 200 kbps 默认值和 `libx264 crf=28`。
 - DSH 窗口进入后台时保持 watch/SSE/video 连续；lease TTL 提高到 120 秒，并对 start/switch/renew 请求做单飞去重，避免后台定时器节流造成 capture 过期和反复 `starting`。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,28 @@
 观察窗落地双画面管线：修复 CDP 协议根因，并加入可选 FFmpeg H.264/fMP4 后端。
 
 ### 新增 / 优化
+- 观察画面新增局部键盘输入代理：普通文本和粘贴走 `Input.insertText`，中文 IME 在 composition 完成后一次发送，控制键和快捷键走 `Input.dispatchKeyEvent`。只在点击观察画面后聚焦，不抢 DSH 自身输入。
+- 新增 `ffmpegBitrateKbps` 设置（500-20000 kbps）；低/平衡/高档默认 2000/4000/8000 kbps。编码器使用目标码率、峰值码率与 VBV buffer，替代 `h264_mf` 的约 200 kbps 默认值和 `libx264 crf=28`。
+- DSH 窗口进入后台时保持 watch/SSE/video 连续；lease TTL 提高到 120 秒，并对 start/switch/renew 请求做单飞去重，避免后台定时器节流造成 capture 过期和反复 `starting`。
 - `CaptureManager` + watcher lease：同时只有一个活动后端和一个观看 target；面板隐藏后停止 capture。
 - CDP 后端正确区分 frame ACK ID 与 flattened target session，协议错误可见；默认 20 FPS、latest-frame 限流、单 target backstop，删除透明动画强制重绘。
-- FFmpeg 后端：`ffmpeg-static` 延迟解析，系统窗口 crop 编码 H.264 fragmented MP4，经二进制 HTTP 与 MediaSource 播放；generation 隔离旧进程数据。
+- FFmpeg 后端：Windows 使用 `gfxcapture(hwnd)` 直接采集 Chrome 的 D3D11 窗口 surface，其他平台保留显示来源 crop；编码为 H.264 fragmented MP4，经二进制 HTTP 与 MediaSource 播放，generation 隔离旧进程数据。
 - 新设置：`captureBackend`、画质档位、CDP/FFmpeg FPS、最大宽度和编码器；旧字段集中迁移。
 - 新增 MP4 parser、CDP ACK、CaptureManager、配置迁移和平台 argv 单元测试。
 
 ### 平台限制
-- Windows 首版 `gdigrab`、Linux X11 `x11grab`、macOS `avfoundation` display crop；遮挡/最小化和系统权限会影响结果。
+- Windows 要求 FFmpeg 包含 `gfxcapture`；按 browser PID、target title 和 CDP window bounds 匹配 HWND，窗口被遮挡或移动时仍采集目标页面，且禁止回退到 `gdigrab desktop`。最小化行为仍由 Windows Graphics Capture 决定。
+- Linux X11 使用 `x11grab`、macOS 使用 `avfoundation` display crop；遮挡和系统权限仍会影响这两个平台。
 - Wayland 随包 FFmpeg 无可用 Portal/PipeWire 输入时明确报 `unsupported-ffmpeg-pipewire`，不使用 root `kmsgrab`，不静默切换整个桌面或伪装成功。
 
 ### 修复
+- **偶发鼠标完全无请求 / 键盘始终不可用**：控制面不再依赖 `streamState` 或 spaces 同步，只按当前画面 target 发送；worker 继续做最终 stale-target 校验。此前前端没有任何键盘监听或协议支持，本次补齐 text/keyDown/keyUp 全链路。
+- **FFmpeg 实际运行但 Tab 显示 CDP**：capture 状态统一从 SSE、watch 响应、spaces capture 和 watch/status 收敛；缺少 backend 时保留当前值，禁止默认覆盖为 CDP。
+- **`space_open` 后遗留 about:blank 窗口**：成功打开的 task space 成为最近活动空间；后续省略 `space` 的 navigate/click/fill 等工具复用该空间，不再回退到固定 `dsh-agent` 创建第二个窗口。关闭活动空间后恢复配置默认值。
+- **watch/start 502 与 input 500**：FFmpeg 二进制和 `gfxcapture` 能力探针改为异步子进程，启动期间 worker health 不再被阻塞；watch start/switch 的 worker 代理超时提高到 30 秒，覆盖窗口、编码器和 MP4 init 的完整上限。host 原样透传 worker HTTP 状态和 JSON 错误，仅在 worker 真不可达时返回 502。输入在客户端和 worker 双侧校验 target，失效 target 返回 409 `capture-target-stale`，不再包装成 500。
+- **设置已选 FFmpeg 但 Tab 仍显示 CDP**：多 fiber 同时加载插件时，后注册的 settings bridge 遇到 namespace 重复后错误地退回空 composition config，cast worker 因而收到 `captureBackend:auto`。现在同一 settings 服务共享唯一 scope；设置卡、gateway 和 cast-server 始终读取同一持久化配置。空闲 worker 收到配置更新时也会立即发布新的 backend 状态，不再保留旧 CDP 标签。
+- **Windows FFmpeg 不再录到用户前台窗口**：此前参数固定为 `gdigrab ... -i desktop`，只在启动时按页面坐标裁剪，Chrome 进入后台后会把覆盖区域中的 DSH 或其他应用串流出去。现在 target 先经 `Browser.getWindowForTarget` 和 Win32 顶层窗口枚举解析到 HWND，再用 `gfxcapture` 捕获独立窗口 surface；多任务空间的不同 Chrome 窗口分别绑定不同 HWND。同一窗口中的后台 tab 会报 `ffmpeg-target-not-visible`，不会展示错误 tab 或主动抢焦点。
+- Windows 编码优先 `h264_mf` D3D11 硬件路径；编码器探针使用真实 HWND 管线，避免软件测试帧误判硬件编码不可用。显式 `fps/setpts` 固定 30 FPS，fMP4 分片降为 100ms，并用 `skip_trailer` 避免优雅停止时的 `mfra` parser 错误。
 - **登录态跨 DSH 重启保持（复刻原版 ego-lite 哲学）**：此前手动重启 / 强杀 DSH 后需重新登录——worker 收到 SIGTERM/SIGINT 时只 detach 不落盘，且插件卸载的 `--stop` 宽限 4s 不够、常落到 SIGTERM crash 兜底。现在 worker 退场前先对浏览器发 CDP `Browser.close`（优雅关闭，Cookie journal 合并进磁盘 profile），插件 teardown 宽限提到 8s 足够优雅关完。**实测**：优雅重启登录完全保留；强杀（SIGKILL）长期登录态也已落盘、重启能读回。
 
 ## [v0.8.0] - 2026-08
@@ -110,4 +121,3 @@ sidebar Tab 集成：当 `dsh-better-sidebar` 可用时，实时查看窗注册�
 - 缩放/拖拽/复位、动态轮询（活跃 2s / 静止 8s）、导航复用 tab。
 - `bin/ego-cast-worker.mjs`：attach 到 agent 正在用的浏览器，CDP 实时推帧，崩溃自动重启。
 - 开箱即用：`bin/ego-chrome-wrapper.sh` 随包自带，root/无头自动 `--no-sandbox`。
-

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 | 能力 | ego-browser（本仓库） | 同类插件（Da1dr1em/dsh-ego-browser） |
 |---|---|---|
 | 结构化工具数 | **32 个**，职责单一、可确定性调用 | **3 个**（`run`/`help`/`status`） |
-| 实时观察窗（SSE screencast 推流 + 标签条 + 历史抽屉） | ✅ 有 | ❌ 无 |
+| 实时观察窗（CDP JPEG / FFmpeg H.264 双后端 + 标签条 + 历史抽屉） | ✅ 有 | ❌ 无 |
 | 监控窗鼠标**直接操作**真实浏览器（点击/拖拽/滚动回传 CDP） | ✅ 有 | ❌ 无 |
 | worker 单实例守卫 + 崩溃/重复自愈 | ✅ 有 | ❌ 无 |
 | 下载捕获 `ego_download` / 人机验证检测 `ego_captcha`/`ego_page_info` | ✅ 有 | ❌ 无 |
@@ -95,7 +95,7 @@ dshx install ego-browser <ego-browser.tgz>                             # tarball
 dshx list                                                # 应显示：[on] ego-browser
 ```
 
-可选配置（`~/.dsh/config.yaml` 该插件条目下）：`egoBin`、`defaultSpace`、`maxOutputBytes`、`graceMs`。
+观察窗设置中可选 `captureBackend=auto|cdp|ffmpeg`（默认 `auto`，当前解析为 CDP）、画质档位、CDP FPS/JPEG 质量/最大宽度，以及 FFmpeg FPS/最大宽度/编码器/自定义路径。旧的 `castFpsCap`、`screencastQuality`、`screencastMaxWidth`、`backstopIntervalMs` 会读取迁移一个版本周期，保存时只写新字段。
 
 无需宿主侧任何配置：`resolveEgoEnv` 自动探测 root / 无显示器并兜底。观察窗 host 路由（`/api/ego/spaces` 等）仅在有 HTTP server 时注册，headless 是安全 no-op。
 
@@ -120,13 +120,21 @@ dshx list                                                # 应显示：[on] ego-
 - **标签页条**：顶部横排，点选切换，`×` 关闭。
 - **历史抽屉**（🕘）：按时间回看访问轨迹。
 - 操作时下方网址行就地显示提示，2 秒后恢复。
+- 面板关闭、sidebar Tab 隐藏或页面进入后台后，1.5 秒宽限结束即停止昂贵的画面生产；异常关闭由 worker lease 超时兜底。
+
+### 画面后端
+
+- `cdp`：`Page.startScreencast` JPEG，默认 20 FPS。每个源帧立即按 Chrome 提供的帧 ID ACK，只保留最新待发帧；仅捕获当前观看标签，静态页恢复截图默认 3 秒一次。
+- `ffmpeg`：系统窗口/显示 crop → H.264 fragmented MP4 → HTTP 二进制 chunk → MediaSource `<video>`。不经过 Base64/SSE，generation 变化时播放器完整重建。
+- `auto`：默认选择 CDP。显式选择 FFmpeg 后若二进制、编码器、窗口来源或权限不可用，会展示明确失败，不静默伪装成 FFmpeg 成功。
+- FFmpeg 捕获属于系统屏幕捕获：Windows 桌面 crop 会受遮挡/最小化影响；macOS 首次使用需要“屏幕录制”权限；X11 需要 Chromium 与 FFmpeg 共享 `DISPLAY`；随包 FFmpeg 在 Wayland 不保证 Portal/PipeWire 输入，缺失时会提示切回 CDP。
 
 > 登录态说明：多任务空间 Cookie 相互隔离，请在对应空间内登录。重启 DSH 后运行期登录态被清空（Chrome 运行期 Cookie 仅优雅关闭时落盘），需重登——扫码很快。
 
 ## 工作原理
 
 - **工具层**：每个工具把参数拼成 JS 脚本，经 `ctx.subprocess` 用 `ego-browser nodejs` 喂给 stdin 运行，宿主经 CDP 驱动共享 Chromium。结果以 `@@DSH_RESULT@@` 哨兵行解析。所有 `ego_*` 经进程内互斥锁串行化，错误统一归一。
-- **观察窗**（三层）：`lib/client.js`（前端）+ `lib/cast-server.js`（host 路由转发，懒启动、崩溃自动重启）+ `bin/ego-cast-worker.mjs`（attach 到 agent 正在用的浏览器，推实时帧）。worker 只读/见控，绝不动宿主环境。
+- **观察窗**：`lib/client.js` 管理 watcher lease、JPEG `<img>` 与 MSE `<video>`；`lib/cast-server.js` 代理元数据 SSE、watch API 和带背压的二进制视频；worker 中 `CaptureManager` 保证同时只有一个活动后端和一个当前 target。CDP 控制面（标签、viewport、输入、验证码）独立于画面后端。
 
 ## 开发
 
@@ -141,6 +149,8 @@ npm run build   # node --check lib/*.js（lib/ 为唯一权威源，不复编译
 ## 已知限制（诚实说明）
 
 - **Windows**：插件层已做 v0.4.0 适配；底层 ego-lite 宿主仍是非 Windows 官方支持的社区移植，复杂多步流程稳定性可能弱于 macOS。
+- **FFmpeg 平台捕获**：首版 Windows 使用 `gdigrab`、Linux 使用 `x11grab`、macOS 使用 `avfoundation` display crop。遮挡时仍正确的单窗口捕获、Windows `ddagrab`/HWND、macOS ScreenCaptureKit、Wayland Portal helper 属后续增强。
+- **安装环境**：本仓库的 DSH peer 包不全在公共 npm registry。普通 `pnpm install` 可能在解析 `@deepseek-ai/*` peer 时失败；DSH profile 安装应提供这些 peer。`ffmpeg-static` 延迟加载，缺失不会影响 CDP 后端。
 - **快照质量**：Linux 用 CDP `DOMSnapshot` 重建语义树，非 macOS 内核级，复杂 iframe/画布场景可能降级。
 - **宿主可靠性（Linux）**：未合并的社区 PR，跨 CLI 调用间可能丢 tab/空间状态；插件已内置防御，简单流程稳定，复杂流程可能需重试。
 - **登录态持久化**：Chrome 运行期 Cookie 仅优雅关闭时落盘，强杀重启需重登。
@@ -148,7 +158,7 @@ npm run build   # node --check lib/*.js（lib/ 为唯一权威源，不复编译
 
 ## 许可与署名
 
-插件本体 MIT。内置运行时嵌入 [CitroLabs/ego-lite](https://github.com/CitroLabs/ego-lite) 的 MIT 代码（含 [PR #234](https://github.com/citrolabs/ego-lite/pull/234) 的 Linux 移植）及一处本地代理补丁——详见 [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)。
+插件本体 MIT。内置运行时嵌入 ego-lite 的 MIT 代码；FFmpeg 后端依赖 `ffmpeg-static`，其 npm 包与分发二进制涉及 GPL-3.0-or-later 义务。分发前必须保留对应许可证与源码获取信息，详见 [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ dshx install ego-browser <ego-browser.tgz>                             # tarball
 dshx list                                                # 应显示：[on] ego-browser
 ```
 
-观察窗设置中可选 `captureBackend=auto|cdp|ffmpeg`（默认 `auto`，当前解析为 CDP）、画质档位、CDP FPS/JPEG 质量/最大宽度，以及 FFmpeg FPS/最大宽度/编码器/自定义路径。旧的 `castFpsCap`、`screencastQuality`、`screencastMaxWidth`、`backstopIntervalMs` 会读取迁移一个版本周期，保存时只写新字段。
+观察窗设置中可选 `captureBackend=auto|cdp|ffmpeg`（默认 `auto`，当前解析为 CDP）、画质档位、CDP FPS/JPEG 质量/最大宽度，以及 FFmpeg FPS/最大宽度/码率/编码器/自定义路径。FFmpeg 码率范围为 500-20000 kbps，低/平衡/高档默认 2000/4000/8000 kbps。旧的 `castFpsCap`、`screencastQuality`、`screencastMaxWidth`、`backstopIntervalMs` 会读取迁移一个版本周期，保存时只写新字段。
 
 无需宿主侧任何配置：`resolveEgoEnv` 自动探测 root / 无显示器并兜底。观察窗 host 路由（`/api/ego/spaces` 等）仅在有 HTTP server 时注册，headless 是安全 no-op。
 
@@ -116,18 +116,18 @@ dshx list                                                # 应显示：[on] ego-
 
 右下角 **🌐 常驻小球** → 点开：
 
-- **主画面**：agent 当前页面实况；滚轮缩放、按住拖动、双击复位；Ctrl+滚轮缩放视图、Ctrl+拖动平移（v0.5.0）。
+- **主画面**：agent 当前页面实况；点击/拖动/滚轮直接操作页面，Ctrl+滚轮缩放视图、Ctrl+拖动平移，双击复位。点击画面后可直接键盘输入，支持中文 IME、粘贴、Tab/Enter/方向键及 Ctrl/Cmd 快捷键。
 - **标签页条**：顶部横排，点选切换，`×` 关闭。
 - **历史抽屉**（🕘）：按时间回看访问轨迹。
 - 操作时下方网址行就地显示提示，2 秒后恢复。
-- 面板关闭、sidebar Tab 隐藏或页面进入后台后，1.5 秒宽限结束即停止昂贵的画面生产；异常关闭由 worker lease 超时兜底。
+- 面板关闭、sidebar Tab 隐藏或组件卸载后，1.5 秒宽限结束即停止画面生产。仅把 DSH 窗口切到后台不会停止串流，避免回前台时反复重建 WGC/FFmpeg；异常关闭由 120 秒 worker lease 超时兜底。
 
 ### 画面后端
 
 - `cdp`：`Page.startScreencast` JPEG，默认 20 FPS。每个源帧立即按 Chrome 提供的帧 ID ACK，只保留最新待发帧；仅捕获当前观看标签，静态页恢复截图默认 3 秒一次。
-- `ffmpeg`：系统窗口/显示 crop → H.264 fragmented MP4 → HTTP 二进制 chunk → MediaSource `<video>`。不经过 Base64/SSE，generation 变化时播放器完整重建。
+- `ffmpeg`：Windows 以 `gfxcapture(hwnd)` 直接采集目标 Chrome 窗口的 D3D11 surface；其他平台使用显示来源 crop。随后编码 H.264 fragmented MP4 → HTTP 二进制 chunk → MediaSource `<video>`，不经过 Base64/SSE。
 - `auto`：默认选择 CDP。显式选择 FFmpeg 后若二进制、编码器、窗口来源或权限不可用，会展示明确失败，不静默伪装成 FFmpeg 成功。
-- FFmpeg 捕获属于系统屏幕捕获：Windows 桌面 crop 会受遮挡/最小化影响；macOS 首次使用需要“屏幕录制”权限；X11 需要 Chromium 与 FFmpeg 共享 `DISPLAY`；随包 FFmpeg 在 Wayland 不保证 Portal/PipeWire 输入，缺失时会提示切回 CDP。
+- Windows FFmpeg 必须包含 `gfxcapture`。插件按 browser PID、target title 和 CDP window bounds 匹配 HWND；窗口移动或被遮挡时仍捕获目标页面，并且不允许回退到桌面录制。若 target 是同一 Chrome 窗口里的后台 tab，会明确报错而不是展示当前可见 tab 或抢用户焦点。macOS 首次使用需要“屏幕录制”权限；X11 需要 Chromium 与 FFmpeg 共享 `DISPLAY`；Wayland 缺少 Portal/PipeWire 输入时会提示切回 CDP。
 
 > 登录态说明：多任务空间 Cookie 相互隔离，请在对应空间内登录。重启 DSH 后运行期登录态被清空（Chrome 运行期 Cookie 仅优雅关闭时落盘），需重登——扫码很快。
 
@@ -149,7 +149,7 @@ npm run build   # node --check lib/*.js（lib/ 为唯一权威源，不复编译
 ## 已知限制（诚实说明）
 
 - **Windows**：插件层已做 v0.4.0 适配；底层 ego-lite 宿主仍是非 Windows 官方支持的社区移植，复杂多步流程稳定性可能弱于 macOS。
-- **FFmpeg 平台捕获**：首版 Windows 使用 `gdigrab`、Linux 使用 `x11grab`、macOS 使用 `avfoundation` display crop。遮挡时仍正确的单窗口捕获、Windows `ddagrab`/HWND、macOS ScreenCaptureKit、Wayland Portal helper 属后续增强。
+- **FFmpeg 平台捕获**：Windows 已使用 `gfxcapture(HWND)`，需要 2025-08 之后且编译了该 filter 的 FFmpeg；旧 `ffmpeg-static` 或 PATH 中的旧 FFmpeg 会明确失败。Linux 使用 `x11grab`、macOS 使用 `avfoundation` display crop；macOS ScreenCaptureKit、Wayland Portal helper 属后续增强。
 - **安装环境**：本仓库的 DSH peer 包不全在公共 npm registry。普通 `pnpm install` 可能在解析 `@deepseek-ai/*` peer 时失败；DSH profile 安装应提供这些 peer。`ffmpeg-static` 延迟加载，缺失不会影响 CDP 后端。
 - **快照质量**：Linux 用 CDP `DOMSnapshot` 重建语义树，非 macOS 内核级，复杂 iframe/画布场景可能降级。
 - **宿主可靠性（Linux）**：未合并的社区 PR，跨 CLI 调用间可能丢 tab/空间状态；插件已内置防御，简单流程稳定，复杂流程可能需重试。

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ dshx install ego-browser <ego-browser.tgz>                             # tarball
 dshx list                                                # 应显示：[on] ego-browser
 ```
 
-观察窗设置中可选 `captureBackend=auto|cdp|ffmpeg`（默认 `auto`，当前解析为 CDP）、画质档位、CDP FPS/JPEG 质量/最大宽度，以及 FFmpeg FPS/最大宽度/码率/编码器/自定义路径。FFmpeg 码率范围为 500-20000 kbps，低/平衡/高档默认 2000/4000/8000 kbps。旧的 `castFpsCap`、`screencastQuality`、`screencastMaxWidth`、`backstopIntervalMs` 会读取迁移一个版本周期，保存时只写新字段。
+观察窗设置中可选 `captureBackend=auto|cdp|ffmpeg`（默认 `auto`，当前解析为 CDP）、画质档位、CDP FPS/JPEG 质量/最大宽度，以及 FFmpeg FPS/最大宽度/码率/编码器/自定义路径。插件先检测自定义路径、系统 PATH 和托管缓存；检测到兼容 FFmpeg 前，设置页禁止选择 FFmpeg，并提供固定版本的一键下载。GitHub 下载可用 `githubMirror` 替换 `https://github.com`，例如 `https://gh-proxy.com/github.com`。FFmpeg 码率范围为 500-20000 kbps，低/平衡/高档默认 2000/4000/8000 kbps。
 
 无需宿主侧任何配置：`resolveEgoEnv` 自动探测 root / 无显示器并兜底。观察窗 host 路由（`/api/ego/spaces` 等）仅在有 HTTP server 时注册，headless 是安全 no-op。
 
@@ -126,8 +126,10 @@ dshx list                                                # 应显示：[on] ego-
 
 - `cdp`：`Page.startScreencast` JPEG，默认 20 FPS。每个源帧立即按 Chrome 提供的帧 ID ACK，只保留最新待发帧；仅捕获当前观看标签，静态页恢复截图默认 3 秒一次。
 - `ffmpeg`：Windows 以 `gfxcapture(hwnd)` 直接采集目标 Chrome 窗口的 D3D11 surface；其他平台使用显示来源 crop。随后编码 H.264 fragmented MP4 → HTTP 二进制 chunk → MediaSource `<video>`，不经过 Base64/SSE。
-- `auto`：默认选择 CDP。显式选择 FFmpeg 后若二进制、编码器、窗口来源或权限不可用，会展示明确失败，不静默伪装成 FFmpeg 成功。
+- `auto`：默认选择 CDP，不检测成功也不会自动下载 FFmpeg。FFmpeg 安装并通过能力检查后才可选择；已保存的 FFmpeg 后端若后来失效，本次观察会回退 CDP 并展示原因。
 - Windows FFmpeg 必须包含 `gfxcapture`。插件按 browser PID、target title 和 CDP window bounds 匹配 HWND；窗口移动或被遮挡时仍捕获目标页面，并且不允许回退到桌面录制。若 target 是同一 Chrome 窗口里的后台 tab，会明确报错而不是展示当前可见 tab 或抢用户焦点。macOS 首次使用需要“屏幕录制”权限；X11 需要 Chromium 与 FFmpeg 共享 `DISPLAY`；Wayland 缺少 Portal/PipeWire 输入时会提示切回 CDP。
+
+托管 FFmpeg 安装到 `~/.dsh/cache/ego-browser/ffmpeg/`，不会写入插件目录。Windows/Linux 使用固定 BtbN release tag；macOS 使用固定的 `ffmpeg-static` GitHub release 资产（其 Intel/Apple Silicon 二进制分别来源于 Evermeet/OSXExperts）。所有下载均固定资源 SHA-256，只提取 FFmpeg 主程序，不安装 `ffprobe` 或 `ffplay`。Windows/Linux 解包使用系统 `tar`；缺少时会在下载前明确报错。
 
 > 登录态说明：多任务空间 Cookie 相互隔离，请在对应空间内登录。重启 DSH 后运行期登录态被清空（Chrome 运行期 Cookie 仅优雅关闭时落盘），需重登——扫码很快。
 
@@ -149,8 +151,8 @@ npm run build   # node --check lib/*.js（lib/ 为唯一权威源，不复编译
 ## 已知限制（诚实说明）
 
 - **Windows**：插件层已做 v0.4.0 适配；底层 ego-lite 宿主仍是非 Windows 官方支持的社区移植，复杂多步流程稳定性可能弱于 macOS。
-- **FFmpeg 平台捕获**：Windows 已使用 `gfxcapture(HWND)`，需要 2025-08 之后且编译了该 filter 的 FFmpeg；旧 `ffmpeg-static` 或 PATH 中的旧 FFmpeg 会明确失败。Linux 使用 `x11grab`、macOS 使用 `avfoundation` display crop；macOS ScreenCaptureKit、Wayland Portal helper 属后续增强。
-- **安装环境**：本仓库的 DSH peer 包不全在公共 npm registry。普通 `pnpm install` 可能在解析 `@deepseek-ai/*` peer 时失败；DSH profile 安装应提供这些 peer。`ffmpeg-static` 延迟加载，缺失不会影响 CDP 后端。
+- **FFmpeg 平台捕获**：Windows 已使用 `gfxcapture(HWND)`，需要包含该 filter 的新构建；PATH 中的旧 FFmpeg 会被跳过并提示下载兼容版本。Linux 使用 `x11grab`、macOS 使用 `avfoundation` display crop；macOS ScreenCaptureKit、Wayland Portal helper 属后续增强。
+- **安装环境**：本仓库的 DSH peer 包不全在公共 npm registry。普通 `pnpm install` 可能在解析 `@deepseek-ai/*` peer 时失败；DSH profile 安装应提供这些 peer。CDP 不依赖 FFmpeg，也不会在插件安装阶段下载二进制。
 - **快照质量**：Linux 用 CDP `DOMSnapshot` 重建语义树，非 macOS 内核级，复杂 iframe/画布场景可能降级。
 - **宿主可靠性（Linux）**：未合并的社区 PR，跨 CLI 调用间可能丢 tab/空间状态；插件已内置防御，简单流程稳定，复杂流程可能需重试。
 - **登录态持久化**：Chrome 运行期 Cookie 仅优雅关闭时落盘，强杀重启需重登。
@@ -158,7 +160,7 @@ npm run build   # node --check lib/*.js（lib/ 为唯一权威源，不复编译
 
 ## 许可与署名
 
-插件本体 MIT。内置运行时嵌入 ego-lite 的 MIT 代码；FFmpeg 后端依赖 `ffmpeg-static`，其 npm 包与分发二进制涉及 GPL-3.0-or-later 义务。分发前必须保留对应许可证与源码获取信息，详见 [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)。
+插件本体 MIT。内置运行时嵌入 ego-lite 的 MIT 代码；可选下载的 FFmpeg 构建涉及 GPL-3.0-or-later 义务。使用或再分发前请阅读构建来源的许可证与源码获取信息，详见 [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)。
 
 ---
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -10,6 +10,25 @@ including the Linux port work in [PR #234](https://github.com/citrolabs/ego-lite
 | `runtime/ego-browser/dist/out/index.js` | shared ego-browser harness build (`package/ego-browser`) | MIT |
 | `runtime/ego-linux/*` | Linux CDP host (`package/ego-linux`, PR #234) + local proxy patch | MIT |
 | `runtime/skills/ego-browser/*` | agent skill package (`skills/ego-browser`) | MIT |
+| `ffmpeg-static` | https://github.com/eugeneware/ffmpeg-static | GPL-3.0-or-later |
+| FFmpeg static executable distributed by `ffmpeg-static` | https://ffmpeg.org/ | GPL-3.0-or-later for the selected static build; see the package's bundled license/build metadata |
+
+## FFmpeg distribution notice
+
+The optional FFmpeg capture backend resolves the executable from the
+`ffmpeg-static` npm dependency unless the user supplies `ffmpegPath`. The binary
+is not copied into this repository, but package/profile distribution may install
+and redistribute it. Distributors must comply with the GPL terms that accompany
+the actual `ffmpeg-static` package and binary, preserve copyright/license
+notices, and provide the corresponding source or a valid written/source offer as
+required by that license. The upstream source locations are:
+
+- `ffmpeg-static`: https://github.com/eugeneware/ffmpeg-static
+- FFmpeg: https://git.ffmpeg.org/ffmpeg.git
+- GPL v3 text: https://www.gnu.org/licenses/gpl-3.0.html
+
+Using a user-supplied FFmpeg binary may carry different licensing obligations;
+the user/distributor is responsible for the selected build.
 
 Additional local modifications on top of upstream (see `runtime/ego-linux/src/chrome.mjs`):
 - `EGO_LINUX_PROXY` support: injects `--proxy-server` / `--proxy-bypass-list` into the

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -10,20 +10,22 @@ including the Linux port work in [PR #234](https://github.com/citrolabs/ego-lite
 | `runtime/ego-browser/dist/out/index.js` | shared ego-browser harness build (`package/ego-browser`) | MIT |
 | `runtime/ego-linux/*` | Linux CDP host (`package/ego-linux`, PR #234) + local proxy patch | MIT |
 | `runtime/skills/ego-browser/*` | agent skill package (`skills/ego-browser`) | MIT |
-| `ffmpeg-static` | https://github.com/eugeneware/ffmpeg-static | GPL-3.0-or-later |
-| FFmpeg static executable distributed by `ffmpeg-static` | https://ffmpeg.org/ | GPL-3.0-or-later for the selected static build; see the package's bundled license/build metadata |
+| BtbN FFmpeg builds (optional download) | https://github.com/BtbN/FFmpeg-Builds | GPL-3.0-or-later for the selected GPL build |
+| `ffmpeg-static` macOS release assets (optional download) | https://github.com/eugeneware/ffmpeg-static | GPL-3.0-or-later; upstream binaries originate from Evermeet/OSXExperts |
+| FFmpeg | https://ffmpeg.org/ | GPL-3.0-or-later for the selected builds |
 
 ## FFmpeg distribution notice
 
-The optional FFmpeg capture backend resolves the executable from the
-`ffmpeg-static` npm dependency unless the user supplies `ffmpegPath`. The binary
-is not copied into this repository, but package/profile distribution may install
-and redistribute it. Distributors must comply with the GPL terms that accompany
-the actual `ffmpeg-static` package and binary, preserve copyright/license
-notices, and provide the corresponding source or a valid written/source offer as
-required by that license. The upstream source locations are:
+The CDP backend does not require FFmpeg. The optional FFmpeg backend first checks
+the user path and system PATH, then offers an explicit managed download into the
+user cache. No FFmpeg executable is included in this repository or npm package.
+Users and distributors must comply with the license attached to the selected
+build, preserve notices, and provide corresponding source as required. Sources:
 
-- `ffmpeg-static`: https://github.com/eugeneware/ffmpeg-static
+- BtbN builds: https://github.com/BtbN/FFmpeg-Builds
+- macOS release assets: https://github.com/eugeneware/ffmpeg-static/releases/tag/b6.1.1
+- Evermeet macOS Intel builds: https://evermeet.cx/ffmpeg/
+- OSXExperts Apple Silicon builds: https://www.osxexperts.net/
 - FFmpeg: https://git.ffmpeg.org/ffmpeg.git
 - GPL v3 text: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/bin/capture-cdp.mjs
+++ b/bin/capture-cdp.mjs
@@ -56,6 +56,25 @@ export class TargetSessions {
       await this.call(targetId, "Input.dispatchMouseEvent", { type, x, y, button, buttons, clickCount, modifiers });
     } else if (type === "mouseWheel") {
       await this.call(targetId, "Input.dispatchMouseEvent", { type, x, y, deltaX, deltaY });
+    } else if (type === "insertText") {
+      const text = typeof payload.text === "string" ? payload.text : "";
+      if (text === "" || text.length > 10000) return { ok: false, error: "text must contain 1-10000 characters" };
+      await this.call(targetId, "Input.insertText", { text });
+    } else if (type === "keyDown" || type === "keyUp") {
+      const key = typeof payload.key === "string" ? payload.key.slice(0, 64) : "";
+      const code = typeof payload.code === "string" ? payload.code.slice(0, 64) : "";
+      if (!key) return { ok: false, error: "key is required" };
+      const virtualKeyCode = Number.isInteger(payload.windowsVirtualKeyCode) ? payload.windowsVirtualKeyCode : 0;
+      await this.call(targetId, "Input.dispatchKeyEvent", {
+        type,
+        key,
+        code,
+        modifiers,
+        autoRepeat: !!payload.autoRepeat,
+        windowsVirtualKeyCode: virtualKeyCode,
+        nativeVirtualKeyCode: virtualKeyCode,
+        ...(type === "keyDown" && key === "Enter" ? { text: "\r", unmodifiedText: "\r" } : {}),
+      });
     } else {
       return { ok: false, error: `unsupported input type: ${type}` };
     }

--- a/bin/capture-cdp.mjs
+++ b/bin/capture-cdp.mjs
@@ -1,0 +1,219 @@
+export class TargetSessions {
+  constructor(cdp) {
+    this.cdp = cdp;
+    this.sessions = new Map();
+    this.detachDestroyed = cdp.on("Target.targetDestroyed", ({ targetId }) => {
+      this.sessions.delete(targetId);
+      for (const handler of this.destroyedHandlers || []) handler(targetId);
+    });
+    this.destroyedHandlers = new Set();
+  }
+
+  async ensure(targetId) {
+    if (this.sessions.has(targetId)) return this.sessions.get(targetId);
+    const result = await this.cdp.call("Target.attachToTarget", { targetId, flatten: true });
+    if (!result.sessionId) throw new Error(`CDP did not return a session for ${targetId}`);
+    const session = { targetId, sessionId: result.sessionId, viewportW: null, viewportH: null };
+    this.sessions.set(targetId, session);
+    await Promise.allSettled([
+      this.cdp.call("Page.enable", {}, session.sessionId),
+      this.cdp.call("Runtime.enable", {}, session.sessionId),
+    ]);
+    await this.updateViewport(targetId);
+    return session;
+  }
+
+  get(targetId) {
+    return this.sessions.get(targetId) || null;
+  }
+
+  onDestroyed(handler) {
+    this.destroyedHandlers.add(handler);
+    return () => this.destroyedHandlers.delete(handler);
+  }
+
+  async updateViewport(targetId) {
+    const session = await this.ensure(targetId);
+    try {
+      const result = await this.cdp.call("Page.getLayoutMetrics", {}, session.sessionId);
+      const viewport = result.cssLayoutViewport || result.cssViewport || {};
+      if (Number.isFinite(viewport.clientWidth ?? viewport.width)) session.viewportW = viewport.clientWidth ?? viewport.width;
+      if (Number.isFinite(viewport.clientHeight ?? viewport.height)) session.viewportH = viewport.clientHeight ?? viewport.height;
+    } catch {}
+    return session;
+  }
+
+  async call(targetId, method, params = {}, timeoutMs = 6000) {
+    const session = await this.ensure(targetId);
+    return this.cdp.call(method, params, session.sessionId, timeoutMs);
+  }
+
+  async sendInput(targetId, payload) {
+    const { type, x, y, button = "left", buttons = 0, deltaX = 0, deltaY = 0, clickCount = 0, modifiers = 0 } = payload || {};
+    if (type === "mouseMoved") {
+      await this.call(targetId, "Input.dispatchMouseEvent", { type, x, y, buttons });
+    } else if (type === "mousePressed" || type === "mouseReleased") {
+      await this.call(targetId, "Input.dispatchMouseEvent", { type, x, y, button, buttons, clickCount, modifiers });
+    } else if (type === "mouseWheel") {
+      await this.call(targetId, "Input.dispatchMouseEvent", { type, x, y, deltaX, deltaY });
+    } else {
+      return { ok: false, error: `unsupported input type: ${type}` };
+    }
+    return { ok: true };
+  }
+
+  async dispose() {
+    this.detachDestroyed?.();
+    const current = [...this.sessions.values()];
+    this.sessions.clear();
+    await Promise.allSettled(current.map((session) =>
+      this.cdp.call("Target.detachFromTarget", { sessionId: session.sessionId }),
+    ));
+  }
+}
+
+export class CdpCaptureBackend {
+  constructor({ cdp, sessions, getConfig, onStatus, onJpegFrame, now = Date.now, setTimer = setTimeout, clearTimer = clearTimeout }) {
+    this.cdp = cdp;
+    this.sessions = sessions;
+    this.getConfig = getConfig;
+    this.onStatus = onStatus;
+    this.onJpegFrame = onJpegFrame;
+    this.now = now;
+    this.setTimer = setTimer;
+    this.clearTimer = clearTimer;
+    this.current = null;
+    this.pendingFrame = null;
+    this.sendTimer = null;
+    this.backstopTimer = null;
+    this.metrics = { sourceFrames: 0, sentFrames: 0, droppedFrames: 0, ackErrors: 0 };
+    this.offFrame = cdp.on("Page.screencastFrame", (params, targetSessionId) => this.#onFrame(params, targetSessionId));
+    this.offDestroyed = sessions.onDestroyed?.((targetId) => {
+      if (this.current?.targetId !== targetId) return;
+      this.stop("target-destroyed").then(() => this.onStatus({ backend: "cdp", state: "failed", targetId, code: "capture-target-destroyed", message: "The watched target was closed" })).catch(() => {});
+    });
+  }
+
+  async start({ targetId }) {
+    await this.stop("restart");
+    const session = await this.sessions.ensure(targetId);
+    const config = this.getConfig();
+    this.current = { targetId, sessionId: session.sessionId, lastFrameAt: 0, startedAt: this.now() };
+    this.onStatus({ backend: "cdp", state: "starting", targetId });
+    try {
+      await this.cdp.call("Page.startScreencast", {
+        format: "jpeg",
+        quality: config.cdpQuality,
+        maxWidth: config.cdpMaxWidth,
+        everyNthFrame: 1,
+      }, session.sessionId);
+      this.onStatus({ backend: "cdp", state: "streaming", targetId, metrics: this.metrics });
+      this.#scheduleBackstop();
+    } catch (error) {
+      this.current = null;
+      this.onStatus({ backend: "cdp", state: "failed", targetId, code: "cdp-start-failed", message: error.message });
+      throw error;
+    }
+  }
+
+  async switchTarget({ targetId }) {
+    this.onStatus({ backend: "cdp", state: "switching", targetId });
+    await this.start({ targetId });
+  }
+
+  async updateConfig() {
+    if (this.current) await this.start({ targetId: this.current.targetId });
+  }
+
+  async stop(reason = "stopped") {
+    this.clearTimer(this.sendTimer);
+    this.clearTimer(this.backstopTimer);
+    this.sendTimer = null;
+    this.backstopTimer = null;
+    this.pendingFrame = null;
+    const current = this.current;
+    this.current = null;
+    if (current) {
+      await this.cdp.call("Page.stopScreencast", {}, current.sessionId).catch(() => {});
+      this.onStatus({ backend: "cdp", state: "idle", targetId: null, message: reason, metrics: this.metrics });
+    }
+  }
+
+  status() {
+    return { backend: "cdp", state: this.current ? "streaming" : "idle", targetId: this.current?.targetId || null, metrics: { ...this.metrics } };
+  }
+
+  dispose() {
+    this.offFrame?.();
+    this.offFrame = null;
+    this.offDestroyed?.();
+    this.offDestroyed = null;
+  }
+
+  async #onFrame(params, targetSessionId) {
+    const current = this.current;
+    if (!current || current.sessionId !== targetSessionId) return;
+    this.metrics.sourceFrames += 1;
+    if (params.sessionId === undefined || params.sessionId === null) {
+      this.metrics.ackErrors += 1;
+    } else {
+      this.cdp.call("Page.screencastFrameAck", { sessionId: params.sessionId }, targetSessionId).catch((error) => {
+        this.metrics.ackErrors += 1;
+        this.onStatus({ backend: "cdp", state: "streaming", targetId: current.targetId, code: "cdp-ack-failed", message: error.message, metrics: this.metrics });
+      });
+    }
+    if (!params.data) return;
+    const metadata = params.metadata || {};
+    const session = this.sessions.get(current.targetId);
+    if (session) {
+      if (Number.isFinite(metadata.visibleViewportWidth)) session.viewportW = metadata.visibleViewportWidth;
+      if (Number.isFinite(metadata.visibleViewportHeight)) session.viewportH = metadata.visibleViewportHeight;
+    }
+    this.pendingFrame = {
+      targetId: current.targetId,
+      data: params.data,
+      vw: session?.viewportW || null,
+      vh: session?.viewportH || null,
+      ts: this.now(),
+    };
+    current.lastFrameAt = this.now();
+    const minGap = 1000 / this.getConfig().cdpFps;
+    const delay = Math.max(0, minGap - (this.now() - (this.lastSentAt || 0)));
+    if (delay === 0) this.#flushLatest();
+    else if (!this.sendTimer) this.sendTimer = this.setTimer(() => this.#flushLatest(), delay);
+    if (delay > 0) this.metrics.droppedFrames += 1;
+  }
+
+  #flushLatest() {
+    this.sendTimer = null;
+    const frame = this.pendingFrame;
+    this.pendingFrame = null;
+    if (!frame || !this.current || frame.targetId !== this.current.targetId) return;
+    this.lastSentAt = this.now();
+    this.metrics.sentFrames += 1;
+    this.onJpegFrame(frame);
+  }
+
+  #scheduleBackstop() {
+    this.clearTimer(this.backstopTimer);
+    const interval = this.getConfig().cdpBackstopIntervalMs;
+    this.backstopTimer = this.setTimer(async () => {
+      const current = this.current;
+      if (!current) return;
+      if (this.now() - current.lastFrameAt >= interval) {
+        try {
+          const session = await this.sessions.updateViewport(current.targetId);
+          const scale = session.viewportW > this.getConfig().cdpMaxWidth ? this.getConfig().cdpMaxWidth / session.viewportW : 1;
+          const result = await this.cdp.call("Page.captureScreenshot", {
+            format: "jpeg",
+            quality: this.getConfig().cdpQuality,
+            captureBeyondViewport: false,
+            ...(session.viewportW && session.viewportH ? { clip: { x: 0, y: 0, width: session.viewportW, height: session.viewportH, scale } } : {}),
+          }, current.sessionId);
+          if (result.data) this.onJpegFrame({ targetId: current.targetId, data: result.data, vw: session.viewportW, vh: session.viewportH, ts: this.now(), backstop: true });
+        } catch {}
+      }
+      this.#scheduleBackstop();
+    }, interval);
+  }
+}

--- a/bin/capture-ffmpeg.mjs
+++ b/bin/capture-ffmpeg.mjs
@@ -36,13 +36,7 @@ function runProbe(path, argv, spawn, timeoutMs, captureOutput = false) {
 }
 
 export async function resolveFfmpegPath(configuredPath = "", spawn = nodeSpawn) {
-  let path = configuredPath;
-  if (!path) {
-    try {
-      path = (await import("ffmpeg-static")).default;
-    } catch {}
-  }
-  const candidates = configuredPath ? [path] : [path, "ffmpeg"].filter(Boolean);
+  const candidates = configuredPath ? [configuredPath] : ["ffmpeg"];
   for (const candidate of candidates) {
     try {
       if (candidate !== "ffmpeg") await access(candidate, process.platform === "win32" ? constants.F_OK : constants.X_OK);
@@ -50,7 +44,7 @@ export async function resolveFfmpegPath(configuredPath = "", spawn = nodeSpawn) 
       if (probe.ok) return candidate;
     } catch {}
   }
-  const error = new Error(configuredPath ? `FFmpeg is not executable: ${configuredPath}` : "Neither bundled FFmpeg nor a PATH ffmpeg executable is usable");
+  const error = new Error(configuredPath ? `FFmpeg is not executable: ${configuredPath}` : "No usable FFmpeg executable was resolved");
   error.code = configuredPath ? "ffmpeg-not-executable" : "ffmpeg-not-installed";
   throw error;
 }
@@ -121,7 +115,7 @@ export class FfmpegCaptureBackend {
     const config = this.getConfig();
     this.onStatus({ backend: "ffmpeg", state: "starting", targetId, message: "Resolving FFmpeg binary" });
     const [path, source] = await Promise.all([
-      this.pathResolver(config.ffmpegPath),
+      this.pathResolver(config.ffmpegResolvedPath || config.ffmpegPath),
       this.sourceResolver({ sessions: this.sessions, targetId, browserPid: this.browserPid }),
     ]);
     await this.supportProbe(path);

--- a/bin/capture-ffmpeg.mjs
+++ b/bin/capture-ffmpeg.mjs
@@ -1,10 +1,41 @@
-import { spawn as nodeSpawn, spawnSync } from "node:child_process";
+import { spawn as nodeSpawn } from "node:child_process";
 import { access } from "node:fs/promises";
 import { constants } from "node:fs";
 import { Mp4FragmentParser } from "./mp4-fragments.mjs";
 import { buildCaptureInput, buildEncoderArgs, resolveCaptureSource } from "./capture-platform.mjs";
 
-export async function resolveFfmpegPath(configuredPath = "") {
+function runProbe(path, argv, spawn, timeoutMs, captureOutput = false) {
+  return new Promise((resolve) => {
+    let child;
+    let output = "";
+    let settled = false;
+    const finish = (ok) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ ok, output });
+    };
+    try {
+      child = spawn(path, argv, {
+        shell: false,
+        windowsHide: true,
+        stdio: captureOutput ? ["ignore", "pipe", "pipe"] : "ignore",
+      });
+    } catch {
+      resolve({ ok: false, output });
+      return;
+    }
+    if (captureOutput) {
+      child.stdout?.on("data", (chunk) => { output += chunk.toString(); });
+      child.stderr?.on("data", (chunk) => { output += chunk.toString(); });
+    }
+    const timer = setTimeout(() => { try { child.kill("SIGTERM"); } catch {}; finish(false); }, timeoutMs);
+    child.once("error", () => finish(false));
+    child.once("exit", (code) => finish(code === 0));
+  });
+}
+
+export async function resolveFfmpegPath(configuredPath = "", spawn = nodeSpawn) {
   let path = configuredPath;
   if (!path) {
     try {
@@ -15,8 +46,8 @@ export async function resolveFfmpegPath(configuredPath = "") {
   for (const candidate of candidates) {
     try {
       if (candidate !== "ffmpeg") await access(candidate, process.platform === "win32" ? constants.F_OK : constants.X_OK);
-      const probe = spawnSync(candidate, ["-version"], { shell: false, windowsHide: true, stdio: "ignore", timeout: 3000 });
-      if (!probe.error && probe.status === 0) return candidate;
+      const probe = await runProbe(candidate, ["-version"], spawn, 3000);
+      if (probe.ok) return candidate;
     } catch {}
   }
   const error = new Error(configuredPath ? `FFmpeg is not executable: ${configuredPath}` : "Neither bundled FFmpeg nor a PATH ffmpeg executable is usable");
@@ -24,22 +55,30 @@ export async function resolveFfmpegPath(configuredPath = "") {
   throw error;
 }
 
-export async function selectEncoder(path, requested, spawn = nodeSpawn) {
+export async function assertCaptureSupport(path, platform = process.platform, spawn = nodeSpawn) {
+  if (platform !== "win32") return;
+  const result = await runProbe(path, ["-hide_banner", "-h", "filter=gfxcapture"], spawn, 3000, true);
+  if (!result.ok || !/Filter gfxcapture\b/.test(result.output)) {
+    const error = new Error("This FFmpeg build does not support Windows gfxcapture; configure a current FFmpeg build instead of desktop capture");
+    error.code = "ffmpeg-gfxcapture-unavailable";
+    throw error;
+  }
+}
+
+export async function selectEncoder(path, requested, spawn = nodeSpawn, capture = null, platform = process.platform) {
   if (requested === "software") return "libx264";
-  const candidates = requested !== "auto" ? [requested] : process.platform === "win32"
-    ? ["h264_nvenc", "h264_qsv", "h264_amf", "libx264"]
+  const candidates = requested !== "auto" ? [requested] : platform === "win32"
+    ? ["h264_mf", "h264_nvenc", "h264_qsv", "h264_amf", "libx264"]
     : process.platform === "darwin" ? ["h264_videotoolbox", "libx264"] : ["h264_nvenc", "h264_vaapi", "h264_qsv", "libx264"];
   for (const encoder of candidates) {
-    const ok = await new Promise((resolve) => {
-      let child;
-      try {
-        child = spawn(path, ["-hide_banner", "-loglevel", "error", "-f", "lavfi", "-i", "color=size=64x64:rate=1", "-frames:v", "1", "-c:v", encoder, "-f", "null", "-"], { shell: false, windowsHide: true, stdio: "ignore" });
-      } catch { resolve(false); return; }
-      const timer = setTimeout(() => { try { child.kill("SIGTERM"); } catch {}; resolve(false); }, 3000);
-      child.once("error", () => { clearTimeout(timer); resolve(false); });
-      child.once("exit", (code) => { clearTimeout(timer); resolve(code === 0); });
-    });
-    if (ok) return encoder;
+    const encoderArgs = encoder === "h264_mf"
+      ? ["-c:v", encoder, "-hw_encoding", "1", "-scenario", "display_remoting"]
+      : ["-c:v", encoder];
+    const inputArgs = platform === "win32" && capture?.source
+      ? buildCaptureInput({ source: capture.source, fps: capture.fps, maxWidth: capture.maxWidth, encoder })
+      : ["-f", "lavfi", "-i", "color=size=64x64:rate=1"];
+    const probe = await runProbe(path, ["-hide_banner", "-loglevel", "error", ...inputArgs, "-frames:v", "1", ...encoderArgs, "-f", "null", "-"], spawn, 2000);
+    if (probe.ok) return encoder;
   }
   const error = new Error(`FFmpeg encoder is unavailable: ${requested}`);
   error.code = "ffmpeg-encoder-unavailable";
@@ -53,8 +92,9 @@ export function codecFromAvcInit(buffer) {
 }
 
 export class FfmpegCaptureBackend {
-  constructor({ sessions, getConfig, generation, onStatus, onVideoInit, onVideoChunk, onVideoEnd, spawn = nodeSpawn, sourceResolver = resolveCaptureSource, pathResolver = resolveFfmpegPath }) {
+  constructor({ sessions, browserPid, getConfig, generation, onStatus, onVideoInit, onVideoChunk, onVideoEnd, spawn = nodeSpawn, sourceResolver = resolveCaptureSource, pathResolver = resolveFfmpegPath, supportProbe = assertCaptureSupport }) {
     this.sessions = sessions;
+    this.browserPid = browserPid;
     this.getConfig = getConfig;
     this.generation = generation;
     this.onStatus = onStatus;
@@ -64,6 +104,7 @@ export class FfmpegCaptureBackend {
     this.spawn = spawn;
     this.sourceResolver = sourceResolver;
     this.pathResolver = pathResolver;
+    this.supportProbe = supportProbe;
     this.child = null;
     this.stopping = null;
     this.termination = null;
@@ -81,12 +122,15 @@ export class FfmpegCaptureBackend {
     this.onStatus({ backend: "ffmpeg", state: "starting", targetId, message: "Resolving FFmpeg binary" });
     const [path, source] = await Promise.all([
       this.pathResolver(config.ffmpegPath),
-      this.sourceResolver({ sessions: this.sessions, targetId }),
+      this.sourceResolver({ sessions: this.sessions, targetId, browserPid: this.browserPid }),
     ]);
+    await this.supportProbe(path);
     this.onStatus({ backend: "ffmpeg", state: "starting", targetId, message: "Probing H.264 encoder" });
-    const encoder = await selectEncoder(path, config.ffmpegEncoder, this.spawn);
+    const encoder = await selectEncoder(path, config.ffmpegEncoder, this.spawn, {
+      source, fps: config.ffmpegFps, maxWidth: config.ffmpegMaxWidth,
+    });
     this.onStatus({ backend: "ffmpeg", state: "starting", targetId, message: `Starting capture with ${encoder}` });
-    const argv = ["-hide_banner", "-loglevel", "warning", ...buildCaptureInput({ source, fps: config.ffmpegFps }), ...buildEncoderArgs({ encoder, fps: config.ffmpegFps, maxWidth: config.ffmpegMaxWidth, source })];
+    const argv = ["-hide_banner", "-loglevel", "warning", ...buildCaptureInput({ source, fps: config.ffmpegFps, maxWidth: config.ffmpegMaxWidth, encoder }), ...buildEncoderArgs({ encoder, fps: config.ffmpegFps, maxWidth: config.ffmpegMaxWidth, bitrateKbps: config.ffmpegBitrateKbps, source })];
     const child = this.spawn(path, argv, { shell: false, windowsHide: true, stdio: ["pipe", "pipe", "pipe"] });
     this.child = child;
     let initialized = false;
@@ -96,7 +140,7 @@ export class FfmpegCaptureBackend {
         initialized = true;
         const mime = `video/mp4; codecs="${codecFromAvcInit(buffer)}"`;
         this.onVideoInit({ targetId, mime, width: source.contentWidthCss, height: source.contentHeightCss, generation: this.generation, buffer });
-        this.onStatus({ backend: "ffmpeg", state: "streaming", targetId, encoder, mime });
+        this.onStatus({ backend: "ffmpeg", state: "streaming", targetId, encoder, mime, code: null, message: null });
       },
       onFragment: (buffer) => {
         if (this.child === child) this.onVideoChunk({ generation: this.generation, buffer });

--- a/bin/capture-ffmpeg.mjs
+++ b/bin/capture-ffmpeg.mjs
@@ -1,0 +1,184 @@
+import { spawn as nodeSpawn, spawnSync } from "node:child_process";
+import { access } from "node:fs/promises";
+import { constants } from "node:fs";
+import { Mp4FragmentParser } from "./mp4-fragments.mjs";
+import { buildCaptureInput, buildEncoderArgs, resolveCaptureSource } from "./capture-platform.mjs";
+
+export async function resolveFfmpegPath(configuredPath = "") {
+  let path = configuredPath;
+  if (!path) {
+    try {
+      path = (await import("ffmpeg-static")).default;
+    } catch {}
+  }
+  const candidates = configuredPath ? [path] : [path, "ffmpeg"].filter(Boolean);
+  for (const candidate of candidates) {
+    try {
+      if (candidate !== "ffmpeg") await access(candidate, process.platform === "win32" ? constants.F_OK : constants.X_OK);
+      const probe = spawnSync(candidate, ["-version"], { shell: false, windowsHide: true, stdio: "ignore", timeout: 3000 });
+      if (!probe.error && probe.status === 0) return candidate;
+    } catch {}
+  }
+  const error = new Error(configuredPath ? `FFmpeg is not executable: ${configuredPath}` : "Neither bundled FFmpeg nor a PATH ffmpeg executable is usable");
+  error.code = configuredPath ? "ffmpeg-not-executable" : "ffmpeg-not-installed";
+  throw error;
+}
+
+export async function selectEncoder(path, requested, spawn = nodeSpawn) {
+  if (requested === "software") return "libx264";
+  const candidates = requested !== "auto" ? [requested] : process.platform === "win32"
+    ? ["h264_nvenc", "h264_qsv", "h264_amf", "libx264"]
+    : process.platform === "darwin" ? ["h264_videotoolbox", "libx264"] : ["h264_nvenc", "h264_vaapi", "h264_qsv", "libx264"];
+  for (const encoder of candidates) {
+    const ok = await new Promise((resolve) => {
+      let child;
+      try {
+        child = spawn(path, ["-hide_banner", "-loglevel", "error", "-f", "lavfi", "-i", "color=size=64x64:rate=1", "-frames:v", "1", "-c:v", encoder, "-f", "null", "-"], { shell: false, windowsHide: true, stdio: "ignore" });
+      } catch { resolve(false); return; }
+      const timer = setTimeout(() => { try { child.kill("SIGTERM"); } catch {}; resolve(false); }, 3000);
+      child.once("error", () => { clearTimeout(timer); resolve(false); });
+      child.once("exit", (code) => { clearTimeout(timer); resolve(code === 0); });
+    });
+    if (ok) return encoder;
+  }
+  const error = new Error(`FFmpeg encoder is unavailable: ${requested}`);
+  error.code = "ffmpeg-encoder-unavailable";
+  throw error;
+}
+
+export function codecFromAvcInit(buffer) {
+  const index = Buffer.from(buffer).indexOf(Buffer.from("avcC"));
+  if (index < 0 || index + 8 > buffer.length) return "avc1.42E01E";
+  return `avc1.${[buffer[index + 5], buffer[index + 6], buffer[index + 7]].map((value) => value.toString(16).padStart(2, "0")).join("").toUpperCase()}`;
+}
+
+export class FfmpegCaptureBackend {
+  constructor({ sessions, getConfig, generation, onStatus, onVideoInit, onVideoChunk, onVideoEnd, spawn = nodeSpawn, sourceResolver = resolveCaptureSource, pathResolver = resolveFfmpegPath }) {
+    this.sessions = sessions;
+    this.getConfig = getConfig;
+    this.generation = generation;
+    this.onStatus = onStatus;
+    this.onVideoInit = onVideoInit;
+    this.onVideoChunk = onVideoChunk;
+    this.onVideoEnd = onVideoEnd;
+    this.spawn = spawn;
+    this.sourceResolver = sourceResolver;
+    this.pathResolver = pathResolver;
+    this.child = null;
+    this.stopping = null;
+    this.termination = null;
+    this.offDestroyed = sessions.onDestroyed?.((targetId) => {
+      if (this.targetId !== targetId) return;
+      this.onStatus({ backend: "ffmpeg", state: "failed", targetId, code: "capture-target-destroyed", message: "The watched target was closed" });
+      this.stop("target-destroyed").catch(() => {});
+    });
+    this.stderr = Buffer.alloc(0);
+  }
+
+  async start({ targetId }) {
+    this.targetId = targetId;
+    const config = this.getConfig();
+    this.onStatus({ backend: "ffmpeg", state: "starting", targetId, message: "Resolving FFmpeg binary" });
+    const [path, source] = await Promise.all([
+      this.pathResolver(config.ffmpegPath),
+      this.sourceResolver({ sessions: this.sessions, targetId }),
+    ]);
+    this.onStatus({ backend: "ffmpeg", state: "starting", targetId, message: "Probing H.264 encoder" });
+    const encoder = await selectEncoder(path, config.ffmpegEncoder, this.spawn);
+    this.onStatus({ backend: "ffmpeg", state: "starting", targetId, message: `Starting capture with ${encoder}` });
+    const argv = ["-hide_banner", "-loglevel", "warning", ...buildCaptureInput({ source, fps: config.ffmpegFps }), ...buildEncoderArgs({ encoder, fps: config.ffmpegFps, maxWidth: config.ffmpegMaxWidth, source })];
+    const child = this.spawn(path, argv, { shell: false, windowsHide: true, stdio: ["pipe", "pipe", "pipe"] });
+    this.child = child;
+    let initialized = false;
+    const parser = new Mp4FragmentParser({
+      onInit: (buffer) => {
+        if (this.child !== child) return;
+        initialized = true;
+        const mime = `video/mp4; codecs="${codecFromAvcInit(buffer)}"`;
+        this.onVideoInit({ targetId, mime, width: source.contentWidthCss, height: source.contentHeightCss, generation: this.generation, buffer });
+        this.onStatus({ backend: "ffmpeg", state: "streaming", targetId, encoder, mime });
+      },
+      onFragment: (buffer) => {
+        if (this.child === child) this.onVideoChunk({ generation: this.generation, buffer });
+      },
+    });
+    child.stdout.on("data", (chunk) => {
+      try { parser.push(chunk); }
+      catch (error) { this.#fail(child, targetId, "video-stream-corrupt", error); }
+    });
+    child.stdout.once("end", () => {
+      try { parser.end(); }
+      catch (error) { if (this.child === child) this.#fail(child, targetId, "video-stream-corrupt", error); }
+    });
+    child.stderr.on("data", (chunk) => {
+      this.stderr = Buffer.concat([this.stderr, Buffer.from(chunk)]).subarray(-65536);
+    });
+    child.once("error", (error) => this.#fail(child, targetId, "ffmpeg-not-executable", error));
+    child.once("exit", (code, signal) => {
+      if (this.child !== child) return;
+      this.child = null;
+      this.onVideoEnd({ generation: this.generation });
+      this.onStatus({ backend: "ffmpeg", state: "failed", targetId, code: "ffmpeg-capture-failed", message: this.stderr.toString("utf8") || `FFmpeg exited unexpectedly (${code ?? signal})` });
+    });
+    await new Promise((resolve, reject) => {
+      const finish = (callback, value) => { clearTimeout(timer); clearInterval(check); callback(value); };
+      const timer = setTimeout(() => finish(reject, new Error("FFmpeg did not produce an MP4 init segment within 8 seconds")), 8000);
+      const check = setInterval(() => {
+        if (initialized) finish(resolve);
+        else if (this.child !== child) finish(reject, new Error("FFmpeg exited before the MP4 init segment"));
+      }, 20);
+    }).catch(async (error) => { await this.stop("startup-failed"); throw error; });
+  }
+
+  async switchTarget({ targetId }) {
+    await this.stop("target-switch");
+    await this.start({ targetId });
+  }
+
+  async updateConfig() {}
+
+  async stop(reason = "stopped") {
+    if (this.termination) return this.termination;
+    const child = this.child;
+    this.child = null;
+    if (!child) return;
+    this.termination = (async () => {
+      this.stopping = child;
+      try { child.stdin.write("q\n"); } catch {}
+      await Promise.race([
+        new Promise((resolve) => child.once("exit", resolve)),
+        new Promise((resolve) => setTimeout(resolve, 1500)),
+      ]);
+      if (child.exitCode === null) {
+        try { child.kill("SIGTERM"); } catch {}
+        await Promise.race([
+          new Promise((resolve) => child.once("exit", resolve)),
+          new Promise((resolve) => setTimeout(resolve, 1000)),
+        ]);
+      }
+      if (child.exitCode === null) {
+        try { child.kill("SIGKILL"); } catch {}
+        await new Promise((resolve) => child.once("exit", resolve));
+      }
+      this.stopping = null;
+      this.onVideoEnd({ generation: this.generation, reason });
+    })();
+    try { await this.termination; }
+    finally { this.termination = null; }
+  }
+
+  status() {
+    return { backend: "ffmpeg", state: this.child ? "streaming" : "idle", generation: this.generation };
+  }
+
+  #fail(child, targetId, code, error) {
+    if (this.child !== child) return;
+    this.onStatus({ backend: "ffmpeg", state: "failed", targetId, code, message: error.message });
+    this.stop(code).catch(() => {})
+  }
+
+  dispose() {
+    this.offDestroyed?.();
+    this.offDestroyed = null;
+  }
+}

--- a/bin/capture-manager.mjs
+++ b/bin/capture-manager.mjs
@@ -1,0 +1,151 @@
+export class CaptureManager {
+  constructor({ backendFactories, getConfig, onStatus, now = Date.now, setTimer = setTimeout, clearTimer = clearTimeout, leaseTtlMs = 15000, idleGraceMs = 1500 }) {
+    this.backendFactories = backendFactories;
+    this.getConfig = getConfig;
+    this.onStatus = onStatus;
+    this.now = now;
+    this.setTimer = setTimer;
+    this.clearTimer = clearTimer;
+    this.leaseTtlMs = leaseTtlMs;
+    this.idleGraceMs = idleGraceMs;
+    this.leases = new Map();
+    this.backend = null;
+    this.backendName = null;
+    this.targetId = null;
+    this.generation = 0;
+    this.statusValue = { backend: this.#resolvedBackend(), state: "idle", targetId: null, generation: 0 };
+    this.transition = Promise.resolve();
+    this.stopTimer = null;
+    this.sweepTimer = this.setTimer(() => this.#sweep(), Math.min(5000, leaseTtlMs));
+  }
+
+  #resolvedBackend(requested) {
+    const value = requested || this.getConfig().captureBackend;
+    return value === "auto" ? "cdp" : value;
+  }
+
+  async startWatch({ clientId, backend, targetId }) {
+    if (!clientId || !targetId) throw new Error("clientId and targetId are required");
+    this.clearTimer(this.stopTimer);
+    this.stopTimer = null;
+    const requestedBackend = backend || this.getConfig().captureBackend;
+    const existing = this.leases.get(clientId);
+    this.leases.set(clientId, { clientId, backend: requestedBackend, targetId, expiresAt: this.now() + this.leaseTtlMs });
+    if (existing && existing.backend === requestedBackend && existing.targetId === targetId) return this.status();
+    return this.#enqueue(async () => { await this.#activate(this.#resolvedBackend(backend), targetId); return this.status(); });
+  }
+
+  async switchWatch({ clientId, targetId }) {
+    const lease = this.leases.get(clientId);
+    if (!lease) throw new Error("watch lease not found");
+    lease.targetId = targetId;
+    lease.expiresAt = this.now() + this.leaseTtlMs;
+    return this.#enqueue(async () => { await this.#activate(this.#resolvedBackend(lease.backend), targetId); return this.status(); });
+  }
+
+  async stopWatch({ clientId }) {
+    this.leases.delete(clientId);
+    if (this.leases.size === 0 && !this.stopTimer) {
+      this.stopTimer = this.setTimer(() => {
+        this.stopTimer = null;
+        if (this.leases.size === 0) this.stop("no-watchers").catch(() => {});
+      }, this.idleGraceMs);
+    }
+    return this.status();
+  }
+
+  async updateConfig() {
+    if (!this.backend) return;
+    const desired = this.#resolvedBackend();
+    return this.#enqueue(() => this.#activate(desired, this.targetId, true));
+  }
+
+  async browserDisconnected() {
+    return this.#enqueue(async () => {
+      await this.#stopBackend("browser-disconnected");
+      this.#setStatus({ backend: this.#resolvedBackend(), state: "failed", targetId: null, code: "browser-disconnected", message: "Browser disconnected" });
+    });
+  }
+
+  async browserConnected() {
+    const lease = [...this.leases.values()].sort((a, b) => b.expiresAt - a.expiresAt)[0];
+    if (lease) return this.#enqueue(() => this.#activate(this.#resolvedBackend(lease.backend), lease.targetId));
+  }
+
+  async #activate(backendName, targetId, force = false) {
+    if (!force && this.backend && this.backendName === backendName && this.targetId === targetId) return;
+    await this.#stopBackend("backend-change");
+    const factory = this.backendFactories[backendName];
+    if (!factory) {
+      this.#setStatus({ backend: backendName, state: "failed", targetId, code: "capture-backend-unavailable", message: `${backendName} backend is unavailable` });
+      return;
+    }
+    try {
+      this.backendName = backendName;
+      this.targetId = targetId;
+      this.generation += 1;
+      const generation = this.generation;
+      this.#setStatus({ backend: backendName, state: "starting", targetId, generation });
+      let candidate;
+      candidate = factory({ generation, onStatus: (status) => {
+        if (this.backend !== candidate || this.generation !== generation) return;
+        this.#setStatus({ ...status, generation });
+      } });
+      this.backend = candidate;
+      await candidate.start({ targetId, generation });
+    } catch (error) {
+      const failed = this.backend;
+      this.backend = null;
+      if (failed) {
+        await failed.stop?.("start-failed").catch(() => {});
+        await failed.dispose?.().catch(() => {});
+      }
+      this.#setStatus({ backend: backendName, state: "failed", targetId, generation: this.generation, message: error.message });
+    }
+  }
+
+  async #stopBackend(reason = "stopped") {
+    const backend = this.backend;
+    this.backend = null;
+    this.backendName = null;
+    this.targetId = null;
+    if (backend) {
+      await backend.stop(reason);
+      await backend.dispose?.();
+    }
+    this.#setStatus({ backend: this.#resolvedBackend(), state: "idle", targetId: null, generation: this.generation, message: reason });
+  }
+
+  stop(reason = "stopped") {
+    return this.#enqueue(() => this.#stopBackend(reason));
+  }
+
+  #enqueue(work) {
+    const run = this.transition.then(work, work);
+    this.transition = run.catch(() => {});
+    return run;
+  }
+
+  status() {
+    return { ...this.statusValue, watchers: this.leases.size };
+  }
+
+  #setStatus(status) {
+    this.statusValue = { ...this.statusValue, ...status };
+    this.onStatus(this.status());
+  }
+
+  #sweep() {
+    const now = this.now();
+    for (const [clientId, lease] of this.leases) if (lease.expiresAt <= now) this.leases.delete(clientId);
+    if (this.leases.size === 0 && this.backend) this.stop("lease-expired").catch(() => {});
+    this.sweepTimer = this.setTimer(() => this.#sweep(), Math.min(5000, this.leaseTtlMs));
+  }
+
+  async dispose() {
+    this.clearTimer(this.stopTimer);
+    this.clearTimer(this.sweepTimer);
+    this.leases.clear();
+    await this.stop("disposed");
+  }
+}

--- a/bin/capture-manager.mjs
+++ b/bin/capture-manager.mjs
@@ -1,5 +1,5 @@
 export class CaptureManager {
-  constructor({ backendFactories, getConfig, onStatus, now = Date.now, setTimer = setTimeout, clearTimer = clearTimeout, leaseTtlMs = 15000, idleGraceMs = 1500 }) {
+  constructor({ backendFactories, getConfig, onStatus, now = Date.now, setTimer = setTimeout, clearTimer = clearTimeout, leaseTtlMs = 120000, idleGraceMs = 1500 }) {
     this.backendFactories = backendFactories;
     this.getConfig = getConfig;
     this.onStatus = onStatus;
@@ -31,7 +31,11 @@ export class CaptureManager {
     const requestedBackend = backend || this.getConfig().captureBackend;
     const existing = this.leases.get(clientId);
     this.leases.set(clientId, { clientId, backend: requestedBackend, targetId, expiresAt: this.now() + this.leaseTtlMs });
-    if (existing && existing.backend === requestedBackend && existing.targetId === targetId) return this.status();
+    if (existing && existing.backend === requestedBackend && existing.targetId === targetId) {
+      const resolved = this.#resolvedBackend(requestedBackend);
+      if (this.targetId !== targetId || (this.backendName && this.backendName !== resolved)) return this.status();
+      if (this.backend && this.backendName === resolved) return this.status();
+    }
     return this.#enqueue(async () => { await this.#activate(this.#resolvedBackend(backend), targetId); return this.status(); });
   }
 
@@ -55,8 +59,13 @@ export class CaptureManager {
   }
 
   async updateConfig() {
-    if (!this.backend) return;
     const desired = this.#resolvedBackend();
+    if (!this.backend) {
+      const lease = [...this.leases.values()].sort((a, b) => b.expiresAt - a.expiresAt)[0];
+      if (lease) return this.#enqueue(() => this.#activate(this.#resolvedBackend(lease.backend), lease.targetId, true));
+      this.#setStatus({ backend: desired, state: "idle", targetId: null, code: null, message: "config-updated" });
+      return;
+    }
     return this.#enqueue(() => this.#activate(desired, this.targetId, true));
   }
 
@@ -85,7 +94,7 @@ export class CaptureManager {
       this.targetId = targetId;
       this.generation += 1;
       const generation = this.generation;
-      this.#setStatus({ backend: backendName, state: "starting", targetId, generation });
+      this.#setStatus({ backend: backendName, state: "starting", targetId, generation, code: null, message: null });
       let candidate;
       candidate = factory({ generation, onStatus: (status) => {
         if (this.backend !== candidate || this.generation !== generation) return;
@@ -100,7 +109,7 @@ export class CaptureManager {
         await failed.stop?.("start-failed").catch(() => {});
         await failed.dispose?.().catch(() => {});
       }
-      this.#setStatus({ backend: backendName, state: "failed", targetId, generation: this.generation, message: error.message });
+      this.#setStatus({ backend: backendName, state: "failed", targetId, generation: this.generation, code: error.code, message: error.message });
     }
   }
 

--- a/bin/capture-manager.mjs
+++ b/bin/capture-manager.mjs
@@ -13,7 +13,8 @@ export class CaptureManager {
     this.backendName = null;
     this.targetId = null;
     this.generation = 0;
-    this.statusValue = { backend: this.#resolvedBackend(), state: "idle", targetId: null, generation: 0 };
+    const fallbackReason = this.getConfig().ffmpegFallbackReason;
+    this.statusValue = { backend: this.#resolvedBackend(), state: "idle", targetId: null, generation: 0, ...(fallbackReason ? { code: "ffmpeg-fallback-cdp", message: fallbackReason } : {}) };
     this.transition = Promise.resolve();
     this.stopTimer = null;
     this.sweepTimer = this.setTimer(() => this.#sweep(), Math.min(5000, leaseTtlMs));
@@ -63,7 +64,8 @@ export class CaptureManager {
     if (!this.backend) {
       const lease = [...this.leases.values()].sort((a, b) => b.expiresAt - a.expiresAt)[0];
       if (lease) return this.#enqueue(() => this.#activate(this.#resolvedBackend(lease.backend), lease.targetId, true));
-      this.#setStatus({ backend: desired, state: "idle", targetId: null, code: null, message: "config-updated" });
+      const fallbackReason = this.getConfig().ffmpegFallbackReason;
+      this.#setStatus({ backend: desired, state: "idle", targetId: null, code: fallbackReason ? "ffmpeg-fallback-cdp" : null, message: fallbackReason || "config-updated" });
       return;
     }
     return this.#enqueue(() => this.#activate(desired, this.targetId, true));
@@ -86,7 +88,12 @@ export class CaptureManager {
     await this.#stopBackend("backend-change");
     const factory = this.backendFactories[backendName];
     if (!factory) {
-      this.#setStatus({ backend: backendName, state: "failed", targetId, code: "capture-backend-unavailable", message: `${backendName} backend is unavailable` });
+      const message = `${backendName} backend is unavailable`;
+      this.#setStatus({ backend: backendName, state: "failed", targetId, code: "capture-backend-unavailable", message });
+      if (backendName === "ffmpeg" && this.backendFactories.cdp) {
+        await this.#activate("cdp", targetId, true);
+        if (this.backend && this.backendName === "cdp") this.#setStatus({ backend: "cdp", code: "ffmpeg-fallback-cdp", message: `FFmpeg unavailable; using CDP: ${message}` });
+      }
       return;
     }
     try {
@@ -94,7 +101,8 @@ export class CaptureManager {
       this.targetId = targetId;
       this.generation += 1;
       const generation = this.generation;
-      this.#setStatus({ backend: backendName, state: "starting", targetId, generation, code: null, message: null });
+      const fallbackReason = backendName === "cdp" ? this.getConfig().ffmpegFallbackReason : null;
+      this.#setStatus({ backend: backendName, state: "starting", targetId, generation, code: fallbackReason ? "ffmpeg-fallback-cdp" : null, message: fallbackReason || null });
       let candidate;
       candidate = factory({ generation, onStatus: (status) => {
         if (this.backend !== candidate || this.generation !== generation) return;
@@ -110,6 +118,10 @@ export class CaptureManager {
         await failed.dispose?.().catch(() => {});
       }
       this.#setStatus({ backend: backendName, state: "failed", targetId, generation: this.generation, code: error.code, message: error.message });
+      if (backendName === "ffmpeg" && this.backendFactories.cdp) {
+        await this.#activate("cdp", targetId, true);
+        if (this.backend && this.backendName === "cdp") this.#setStatus({ backend: "cdp", code: "ffmpeg-fallback-cdp", message: `FFmpeg unavailable; using CDP: ${error.message}` });
+      }
     }
   }
 

--- a/bin/capture-platform.mjs
+++ b/bin/capture-platform.mjs
@@ -1,6 +1,34 @@
-export function buildCaptureInput({ platform = process.platform, env = process.env, source, fps }) {
+import { execFile as nodeExecFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFile = promisify(nodeExecFile);
+
+export function buildCaptureInput({ platform = process.platform, env = process.env, source, fps, maxWidth, encoder }) {
   if (platform === "win32") {
-    return ["-f", "gdigrab", "-framerate", String(fps), "-offset_x", String(source.captureX), "-offset_y", String(source.captureY), "-video_size", `${source.captureWidth}x${source.captureHeight}`, "-i", "desktop"];
+    if (source.sourceType !== "window-hwnd" || !source.hwnd) {
+      const error = new Error("Windows FFmpeg capture requires a Chrome window handle");
+      error.code = "ffmpeg-window-hwnd-missing";
+      throw error;
+    }
+    const outputWidth = Math.max(2, Math.floor(Math.min(maxWidth, source.captureWidth) / 2) * 2);
+    const outputHeight = Math.max(2, Math.floor((source.captureHeight * outputWidth / source.captureWidth) / 2) * 2);
+    const options = [
+      `hwnd=${source.hwnd}`,
+      `max_framerate=${fps}`,
+      "capture_cursor=false",
+      "capture_border=false",
+      "display_border=false",
+      `crop_left=${source.cropLeft || 0}`,
+      `crop_top=${source.cropTop || 0}`,
+      `crop_right=${source.cropRight || 0}`,
+      `crop_bottom=${source.cropBottom || 0}`,
+      `width=${outputWidth}`,
+      `height=${outputHeight}`,
+      "resize_mode=scale_aspect",
+    ];
+    const filters = [`gfxcapture=${options.join(":")}`, `fps=${fps}`, `setpts=N/(${fps}*TB)`];
+    if (encoder === "libx264") filters.push("hwdownload", "format=bgra", "format=yuv420p");
+    return ["-filter_complex", filters.join(",")];
   }
   if (platform === "darwin") {
     return ["-f", "avfoundation", "-framerate", String(fps), "-i", `${source.displayIndex || 1}:none`];
@@ -14,19 +42,111 @@ export function buildCaptureInput({ platform = process.platform, env = process.e
   return ["-f", "x11grab", "-framerate", String(fps), "-video_size", `${source.captureWidth}x${source.captureHeight}`, "-i", `${display}+${source.captureX},${source.captureY}`];
 }
 
-export function buildEncoderArgs({ encoder, fps, maxWidth, source, platform = process.platform }) {
+export function buildEncoderArgs({ encoder, fps, maxWidth, bitrateKbps = 4000, source, platform = process.platform }) {
+  const maxrateKbps = Math.round(bitrateKbps * 1.25);
+  const bufsizeKbps = bitrateKbps * 2;
+  const rateArgs = ["-b:v", `${bitrateKbps}k`, "-maxrate", `${maxrateKbps}k`, "-bufsize", `${bufsizeKbps}k`];
+  if (platform === "win32" && source?.sourceType === "window-hwnd") {
+    const common = ["-an", "-g", String(fps), "-bf", "0", ...rateArgs];
+    if (encoder === "h264_mf") {
+      common.push("-c:v", encoder, "-hw_encoding", "1", "-scenario", "display_remoting", "-rate_control", "ld_vbr");
+    } else if (encoder === "libx264") {
+      common.push("-c:v", encoder, "-preset", "ultrafast", "-tune", "zerolatency", "-profile:v", "baseline", "-pix_fmt", "yuv420p");
+    } else {
+      common.push("-c:v", encoder);
+    }
+    return [...common, "-movflags", "empty_moov+default_base_moof+frag_keyframe+skip_trailer", "-frag_duration", "100000", "-f", "mp4", "pipe:1"];
+  }
   const filters = [];
   if (platform === "darwin" && source) filters.push(`crop=${source.captureWidth}:${source.captureHeight}:${source.captureX}:${source.captureY}`);
   filters.push(`scale='min(${maxWidth},iw)':-2`);
-  const common = ["-an", "-vf", filters.join(","), "-pix_fmt", "yuv420p", "-g", String(fps), "-keyint_min", String(fps), "-sc_threshold", "0", "-bf", "0", "-profile:v", "baseline"];
-  if (encoder === "libx264") common.push("-c:v", "libx264", "-preset", "ultrafast", "-tune", "zerolatency", "-crf", "28");
+  const common = ["-an", "-vf", filters.join(","), "-pix_fmt", "yuv420p", "-g", String(fps), "-keyint_min", String(fps), "-sc_threshold", "0", "-bf", "0", "-profile:v", "baseline", ...rateArgs];
+  if (encoder === "libx264") common.push("-c:v", "libx264", "-preset", "ultrafast", "-tune", "zerolatency");
   else common.push("-c:v", encoder);
   return [...common, "-movflags", "empty_moov+default_base_moof+frag_keyframe", "-frag_duration", "500000", "-f", "mp4", "pipe:1"];
 }
 
-export async function resolveCaptureSource({ sessions, targetId }) {
+export function selectWindowCandidate(windows, bounds, targetTitle = "") {
+  const candidates = windows.filter((window) => window.hwnd && window.width > 0 && window.height > 0);
+  if (candidates.length === 0) return null;
+  const normalizedTitle = targetTitle.trim().toLocaleLowerCase();
+  const ranked = candidates.map((window) => {
+    const geometryScore = bounds
+      ? Math.abs(window.x - bounds.left) + Math.abs(window.y - bounds.top)
+        + Math.abs(window.width - bounds.width) + Math.abs(window.height - bounds.height)
+      : 0;
+    return { window, geometryScore };
+  }).sort((a, b) => a.geometryScore - b.geometryScore);
+  const closest = ranked.filter((entry) => entry.geometryScore <= ranked[0].geometryScore + 8);
+  if (normalizedTitle) {
+    const titleMatch = closest.find(({ window }) => String(window.title || "").toLocaleLowerCase().includes(normalizedTitle));
+    if (titleMatch) return titleMatch.window;
+  }
+  return ranked[0].window;
+}
+
+export async function enumerateWindowsForPid(browserPid, run = execFile) {
+  if (!Number.isInteger(browserPid) || browserPid <= 0) return [];
+  const script = `
+Add-Type -TypeDefinition @'
+using System;
+using System.Text;
+using System.Runtime.InteropServices;
+public static class EgoWindowProbe {
+  public delegate bool EnumProc(IntPtr hwnd, IntPtr lParam);
+  [DllImport("user32.dll")] public static extern bool SetProcessDPIAware();
+  [DllImport("user32.dll")] public static extern bool SetProcessDpiAwarenessContext(IntPtr dpiContext);
+  [DllImport("user32.dll")] public static extern bool EnumWindows(EnumProc callback, IntPtr lParam);
+  [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint processId);
+  [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr hwnd);
+  [DllImport("user32.dll")] public static extern bool IsIconic(IntPtr hwnd);
+  [DllImport("user32.dll", CharSet=CharSet.Unicode)] public static extern int GetWindowText(IntPtr hwnd, StringBuilder text, int maxCount);
+  [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr hwnd, out RECT rect);
+  [DllImport("user32.dll")] public static extern bool GetClientRect(IntPtr hwnd, out RECT rect);
+  public struct RECT { public int Left, Top, Right, Bottom; }
+}
+'@
+[Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
+if (-not [EgoWindowProbe]::SetProcessDpiAwarenessContext([IntPtr](-4))) { [void][EgoWindowProbe]::SetProcessDPIAware() }
+$items = [System.Collections.Generic.List[object]]::new()
+[void][EgoWindowProbe]::EnumWindows({
+  param($hwnd, $lParam)
+  $ownerPid = 0
+  [void][EgoWindowProbe]::GetWindowThreadProcessId($hwnd, [ref]$ownerPid)
+  if ($ownerPid -eq ${browserPid} -and [EgoWindowProbe]::IsWindowVisible($hwnd)) {
+    $rect = [EgoWindowProbe+RECT]::new()
+    $client = [EgoWindowProbe+RECT]::new()
+    $title = [Text.StringBuilder]::new(2048)
+    [void][EgoWindowProbe]::GetWindowRect($hwnd, [ref]$rect)
+    [void][EgoWindowProbe]::GetClientRect($hwnd, [ref]$client)
+    [void][EgoWindowProbe]::GetWindowText($hwnd, $title, $title.Capacity)
+    $items.Add([pscustomobject]@{
+      hwnd = $hwnd.ToInt64()
+      title = $title.ToString()
+      x = $rect.Left
+      y = $rect.Top
+      width = $rect.Right - $rect.Left
+      height = $rect.Bottom - $rect.Top
+      clientWidth = $client.Right - $client.Left
+      clientHeight = $client.Bottom - $client.Top
+      minimized = [EgoWindowProbe]::IsIconic($hwnd)
+    })
+  }
+  return $true
+}, [IntPtr]::Zero)
+ConvertTo-Json -Compress -InputObject @($items)
+`;
+  const encoded = Buffer.from(script, "utf16le").toString("base64");
+  const { stdout } = await run("powershell.exe", ["-NoProfile", "-NonInteractive", "-EncodedCommand", encoded], {
+    encoding: "utf8", windowsHide: true, timeout: 5000, maxBuffer: 1024 * 1024,
+  });
+  const parsed = JSON.parse(stdout.trim() || "[]");
+  return Array.isArray(parsed) ? parsed : [parsed];
+}
+
+export async function resolveCaptureSource({ sessions, targetId, browserPid, platform = process.platform, windowEnumerator = enumerateWindowsForPid }) {
   const result = await sessions.call(targetId, "Runtime.evaluate", {
-    expression: "({screenX,screenY,outerWidth,outerHeight,innerWidth,innerHeight,devicePixelRatio})",
+    expression: "({screenX,screenY,outerWidth,outerHeight,innerWidth,innerHeight,devicePixelRatio,title:document.title})",
     returnByValue: true,
   });
   const value = result.result?.value || {};
@@ -36,6 +156,55 @@ export async function resolveCaptureSource({ sessions, targetId }) {
     throw error;
   }
   const dpr = Number(value.devicePixelRatio) || 1;
+  if (platform === "win32") {
+    let bounds = null;
+    try {
+      const window = await sessions.cdp.call("Browser.getWindowForTarget", { targetId });
+      bounds = (await sessions.cdp.call("Browser.getWindowBounds", { windowId: window.windowId })).bounds || window.bounds || null;
+    } catch {}
+    const windows = await windowEnumerator(browserPid);
+    const selected = selectWindowCandidate(windows, bounds, value.title || "");
+    if (!selected) {
+      const error = new Error(`Chrome window not found for browser PID ${browserPid || "unknown"}`);
+      error.code = "ffmpeg-window-not-found";
+      throw error;
+    }
+    const targetTitle = String(value.title || "").trim().toLocaleLowerCase();
+    const windowTitle = String(selected.title || "").toLocaleLowerCase();
+    if (targetTitle && !windowTitle.includes(targetTitle)) {
+      const error = new Error("The requested target is not the visible tab in its Chrome window");
+      error.code = "ffmpeg-target-not-visible";
+      throw error;
+    }
+    if (selected.minimized) {
+      const error = new Error("The target Chrome window is minimized");
+      error.code = "capture-source-not-visible";
+      throw error;
+    }
+    const contentWidth = Math.max(2, Math.round(Number(value.innerWidth) * dpr));
+    const contentHeight = Math.max(2, Math.round(Number(value.innerHeight) * dpr));
+    const clientWidth = Number(selected.clientWidth) || contentWidth;
+    const clientHeight = Number(selected.clientHeight) || contentHeight;
+    const cropLeft = Math.max(0, Math.floor((clientWidth - contentWidth) / 2));
+    const cropRight = Math.max(0, clientWidth - contentWidth - cropLeft);
+    const cropTop = Math.max(0, clientHeight - contentHeight);
+    return {
+      sourceType: "window-hwnd",
+      hwnd: String(selected.hwnd),
+      captureX: 0,
+      captureY: 0,
+      captureWidth: contentWidth,
+      captureHeight: contentHeight,
+      cropLeft,
+      cropTop,
+      cropRight,
+      cropBottom: 0,
+      contentWidthCss: Number(value.innerWidth),
+      contentHeightCss: Number(value.innerHeight),
+      scaleFactor: dpr,
+      minimized: !!selected.minimized,
+    };
+  }
   const chromeX = Math.max(0, (Number(value.outerWidth) - Number(value.innerWidth)) / 2);
   const chromeY = Math.max(0, Number(value.outerHeight) - Number(value.innerHeight) - chromeX);
   return {

--- a/bin/capture-platform.mjs
+++ b/bin/capture-platform.mjs
@@ -1,0 +1,51 @@
+export function buildCaptureInput({ platform = process.platform, env = process.env, source, fps }) {
+  if (platform === "win32") {
+    return ["-f", "gdigrab", "-framerate", String(fps), "-offset_x", String(source.captureX), "-offset_y", String(source.captureY), "-video_size", `${source.captureWidth}x${source.captureHeight}`, "-i", "desktop"];
+  }
+  if (platform === "darwin") {
+    return ["-f", "avfoundation", "-framerate", String(fps), "-i", `${source.displayIndex || 1}:none`];
+  }
+  if (env.XDG_SESSION_TYPE === "wayland" || env.WAYLAND_DISPLAY) {
+    const error = new Error("The bundled FFmpeg does not provide a guaranteed Wayland Portal capture input");
+    error.code = "unsupported-ffmpeg-pipewire";
+    throw error;
+  }
+  const display = env.DISPLAY || ":0";
+  return ["-f", "x11grab", "-framerate", String(fps), "-video_size", `${source.captureWidth}x${source.captureHeight}`, "-i", `${display}+${source.captureX},${source.captureY}`];
+}
+
+export function buildEncoderArgs({ encoder, fps, maxWidth, source, platform = process.platform }) {
+  const filters = [];
+  if (platform === "darwin" && source) filters.push(`crop=${source.captureWidth}:${source.captureHeight}:${source.captureX}:${source.captureY}`);
+  filters.push(`scale='min(${maxWidth},iw)':-2`);
+  const common = ["-an", "-vf", filters.join(","), "-pix_fmt", "yuv420p", "-g", String(fps), "-keyint_min", String(fps), "-sc_threshold", "0", "-bf", "0", "-profile:v", "baseline"];
+  if (encoder === "libx264") common.push("-c:v", "libx264", "-preset", "ultrafast", "-tune", "zerolatency", "-crf", "28");
+  else common.push("-c:v", encoder);
+  return [...common, "-movflags", "empty_moov+default_base_moof+frag_keyframe", "-frag_duration", "500000", "-f", "mp4", "pipe:1"];
+}
+
+export async function resolveCaptureSource({ sessions, targetId }) {
+  const result = await sessions.call(targetId, "Runtime.evaluate", {
+    expression: "({screenX,screenY,outerWidth,outerHeight,innerWidth,innerHeight,devicePixelRatio})",
+    returnByValue: true,
+  });
+  const value = result.result?.value || {};
+  if (![value.screenX, value.screenY, value.outerWidth, value.outerHeight, value.innerWidth, value.innerHeight].every(Number.isFinite)) {
+    const error = new Error("Browser window geometry is unavailable");
+    error.code = "ffmpeg-capture-source-missing";
+    throw error;
+  }
+  const dpr = Number(value.devicePixelRatio) || 1;
+  const chromeX = Math.max(0, (Number(value.outerWidth) - Number(value.innerWidth)) / 2);
+  const chromeY = Math.max(0, Number(value.outerHeight) - Number(value.innerHeight) - chromeX);
+  return {
+    sourceType: "display-crop",
+    captureX: Math.round((Number(value.screenX) + chromeX) * dpr),
+    captureY: Math.round((Number(value.screenY) + chromeY) * dpr),
+    captureWidth: Math.max(2, Math.round(Number(value.innerWidth) * dpr)),
+    captureHeight: Math.max(2, Math.round(Number(value.innerHeight) * dpr)),
+    contentWidthCss: Number(value.innerWidth),
+    contentHeightCss: Number(value.innerHeight),
+    scaleFactor: dpr,
+  };
+}

--- a/bin/cdp-client.mjs
+++ b/bin/cdp-client.mjs
@@ -1,0 +1,77 @@
+export class CdpClient {
+  constructor(ws) {
+    this.ws = ws;
+    this.nextId = 0;
+    this.pending = new Map();
+    this.events = new Map();
+    ws.addEventListener("message", (event) => this.#handleMessage(event));
+    const close = () => this.#rejectPending(new Error("CDP connection closed"));
+    ws.addEventListener("close", close, { once: true });
+    ws.addEventListener("error", close, { once: true });
+  }
+
+  #handleMessage(event) {
+    let message;
+    try {
+      message = JSON.parse(event.data);
+    } catch {
+      return;
+    }
+    if (message.id && this.pending.has(message.id)) {
+      const pending = this.pending.get(message.id);
+      this.pending.delete(message.id);
+      clearTimeout(pending.timer);
+      if (message.error) {
+        const error = new Error(message.error.message || `CDP error ${message.error.code}`);
+        error.code = message.error.code;
+        error.data = message.error.data;
+        pending.reject(error);
+      } else {
+        pending.resolve(message.result || {});
+      }
+      return;
+    }
+    if (!message.method) return;
+    for (const handler of this.events.get(message.method) || []) {
+      try {
+        handler(message.params || {}, message.sessionId);
+      } catch {
+        // A consumer error must not break dispatch for the other handlers.
+      }
+    }
+  }
+
+  #rejectPending(error) {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  call(method, params = {}, sessionId, timeoutMs = 6000) {
+    const id = ++this.nextId;
+    const payload = { id, method, params };
+    if (sessionId) payload.sessionId = sessionId;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`CDP ${method} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.pending.set(id, { resolve, reject, timer });
+      try {
+        this.ws.send(JSON.stringify(payload));
+      } catch (error) {
+        clearTimeout(timer);
+        this.pending.delete(id);
+        reject(error);
+      }
+    });
+  }
+
+  on(method, handler) {
+    if (!this.events.has(method)) this.events.set(method, new Set());
+    this.events.get(method).add(handler);
+    return () => this.events.get(method)?.delete(handler);
+  }
+}

--- a/bin/ego-cast-worker.mjs
+++ b/bin/ego-cast-worker.mjs
@@ -19,7 +19,7 @@ const CAST_STATE_FILE = join(STATE_DIR, "ego-cast.json");
 const DEFAULT_CONFIG = {
   captureBackend: "auto", streamProfile: "balanced",
   cdpFps: 20, cdpQuality: 55, cdpMaxWidth: 960, cdpBackstopIntervalMs: 3000,
-  ffmpegFps: 20, ffmpegMaxWidth: 1280, ffmpegEncoder: "auto", ffmpegPath: "",
+  ffmpegFps: 20, ffmpegMaxWidth: 1280, ffmpegBitrateKbps: 4000, ffmpegEncoder: "auto", ffmpegPath: "",
 };
 let castConfig = { ...DEFAULT_CONFIG };
 try { castConfig = { ...castConfig, ...JSON.parse(process.argv[2] || "{}") }; } catch {}
@@ -45,9 +45,9 @@ function normalizeConfig(input) {
   const numberValue = (key, min, max) => { if (Number.isFinite(input[key]) && input[key] >= min && input[key] <= max) next[key] = input[key]; };
   enumValue("captureBackend", ["auto", "cdp", "ffmpeg"]);
   enumValue("streamProfile", ["low", "balanced", "high"]);
-  enumValue("ffmpegEncoder", ["auto", "software", "h264_nvenc", "h264_qsv", "h264_amf", "h264_videotoolbox", "h264_vaapi"]);
+  enumValue("ffmpegEncoder", ["auto", "software", "h264_mf", "h264_nvenc", "h264_qsv", "h264_amf", "h264_videotoolbox", "h264_vaapi"]);
   numberValue("cdpFps", 5, 30); numberValue("cdpQuality", 1, 100); numberValue("cdpMaxWidth", 320, 1920); numberValue("cdpBackstopIntervalMs", 1000, 10000);
-  numberValue("ffmpegFps", 5, 30); numberValue("ffmpegMaxWidth", 320, 1920);
+  numberValue("ffmpegFps", 5, 30); numberValue("ffmpegMaxWidth", 320, 1920); numberValue("ffmpegBitrateKbps", 500, 20000);
   if (typeof input.ffmpegPath === "string") next.ffmpegPath = input.ffmpegPath;
   return next;
 }
@@ -74,24 +74,31 @@ function writeSse(res, event, payload) {
   return res.write(`event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`);
 }
 
+function queueSse(client, event, payload) {
+  if (event === "frame") client.pendingFrame = payload;
+  else client.pendingEvents.set(event, payload);
+}
+
+function sendSse(client, event, payload) {
+  if (client.blocked) { queueSse(client, event, payload); return; }
+  try {
+    if (!writeSse(client.res, event, payload)) {
+      client.blocked = true;
+      client.res.once("drain", () => {
+        client.blocked = false;
+        const pendingEvents = [...client.pendingEvents];
+        const pendingFrame = client.pendingFrame;
+        client.pendingEvents.clear();
+        client.pendingFrame = null;
+        for (const [pendingEvent, pendingPayload] of pendingEvents) sendSse(client, pendingEvent, pendingPayload);
+        if (pendingFrame) sendSse(client, "frame", pendingFrame);
+      });
+    }
+  } catch { sseClients.delete(client); }
+}
+
 function broadcast(event, payload) {
-  for (const client of sseClients) {
-    if (event === "frame" && client.blocked) { client.pendingFrame = payload; continue; }
-    try {
-      const ok = writeSse(client.res, event, payload);
-      if (!ok) {
-        client.blocked = true;
-        client.res.once("drain", () => {
-          client.blocked = false;
-          if (client.pendingFrame) {
-            const pending = client.pendingFrame;
-            client.pendingFrame = null;
-            try { writeSse(client.res, "frame", pending); } catch { sseClients.delete(client); }
-          }
-        });
-      }
-    } catch { sseClients.delete(client); }
-  }
+  for (const client of sseClients) sendSse(client, event, payload);
 }
 
 function publishStatus(status) {
@@ -159,7 +166,7 @@ const manager = new CaptureManager({
     },
     ffmpeg: ({ generation, onStatus }) => {
       if (!active) throw new Error("no live browser");
-      return new FfmpegCaptureBackend({ sessions: active.sessions, getConfig: () => castConfig, generation, onStatus, onVideoInit: publishVideoInit, onVideoChunk: publishVideoChunk, onVideoEnd: endVideo });
+      return new FfmpegCaptureBackend({ sessions: active.sessions, browserPid: active.pid, getConfig: () => castConfig, generation, onStatus, onVideoInit: publishVideoInit, onVideoChunk: publishVideoChunk, onVideoEnd: endVideo });
     },
   },
 });
@@ -272,13 +279,26 @@ async function main() {
       if (req.method === "POST" && url.pathname === "/api/watch/start") { if (!active) return sendJson(res, 409, { ok: false, error: "no live browser" }); return sendJson(res, 200, { ok: true, ...await manager.startWatch(await readJson(req)) }); }
       if (req.method === "POST" && url.pathname === "/api/watch/switch") return sendJson(res, 200, { ok: true, ...await manager.switchWatch(await readJson(req)) });
       if (req.method === "POST" && url.pathname === "/api/watch/stop") return sendJson(res, 200, { ok: true, ...await manager.stopWatch(await readJson(req)) });
-      if (req.method === "POST" && url.pathname === "/api/input") { const body = await readJson(req); if (!active) return sendJson(res, 409, { ok: false, error: "no live browser" }); return sendJson(res, 200, await active.sessions.sendInput(body.targetId, body)); }
+      if (req.method === "POST" && url.pathname === "/api/input") {
+        const body = await readJson(req);
+        if (!active) return sendJson(res, 409, { ok: false, code: "browser-disconnected", error: "no live browser" });
+        if (!body.targetId) return sendJson(res, 400, { ok: false, code: "target-required", error: "targetId required" });
+        const targets = await listTargets();
+        if (!targets.some((target) => target.targetId === body.targetId)) {
+          return sendJson(res, 409, { ok: false, code: "capture-target-stale", error: "target is no longer available" });
+        }
+        try {
+          return sendJson(res, 200, await active.sessions.sendInput(body.targetId, body));
+        } catch (error) {
+          return sendJson(res, 503, { ok: false, code: "input-dispatch-failed", error: error.message || String(error) });
+        }
+      }
       if (req.method === "POST" && url.pathname === "/api/close") { const { targetId } = await readJson(req); if (!active || !targetId) return sendJson(res, 400, { ok: false, error: "targetId required" }); await active.cdp.call("Target.closeTarget", { targetId }); return sendJson(res, 200, { ok: true }); }
       if (req.method === "POST" && url.pathname === "/api/flush") { if (!active) return sendJson(res, 409, { ok: false, error: "no live browser" }); await active.cdp.call("Storage.flushCookies").catch(() => {}); return sendJson(res, 200, { ok: true }); }
       if (req.method === "GET" && url.pathname === "/api/stream") {
         res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive", "x-accel-buffering": "no" });
         res.write(":ok\n\n");
-        const client = { res, blocked: false, pendingFrame: null };
+        const client = { res, blocked: false, pendingFrame: null, pendingEvents: new Map() };
         sseClients.add(client);
         writeSse(res, "capture-status", manager.status());
         snapshotSpaces().then((spaces) => { if (sseClients.has(client)) writeSse(res, "spaces", spaces); }).catch(() => {});

--- a/bin/ego-cast-worker.mjs
+++ b/bin/ego-cast-worker.mjs
@@ -1,1061 +1,319 @@
 #!/usr/bin/env node
-/**
- * ego-cast-worker — DSH-owned realtime view source for the ego-browser panel.
- *
- * Unlike the first-cut design, this worker does NOT launch its own Chromium.
- * The agent's browser is the ONLY instance that matters (it is the one the
- * ego_* tools drive, on ~/.local/{share,state}/ego-lite-linux, and Chromium is
- * single-instance per profile anyway — a second Chrome would just hand control
- * back to the running one). Instead this worker ATTACHES to that same live
- * browser via its browser-level CDP WebSocket:
- *
- *   1. read BROWSER_STATE_FILE (~/.local/state/ego-lite-linux/browser.json)
- *      -> { port }
- *   2. probe http://127.0.0.1:<port>/json/version -> webSocketDebuggerUrl
- *   3. open the browser WS, keep one Page.startScreencast stream per page
- *      target, cache the newest JPEG frame (push mode, not polled capture)
- *   4. expose a loopback HTTP api the host route forwards:
- *        GET /api/spaces   -> [{targetId,url,title,thumbnail(dataURL)}]
- *        GET /api/health   -> { ok }
- *   5. write { port, pid } to a small state file the plugin finds it by
- *
- * It only EVER reads from the shared browser (attach + screencast); it never
- * navigates, never writes, never opens a window, never touches the host env.
- * If no agent browser is up yet it reports an empty spaces list and waits; the
- * plugin's host route surfaces that as "no live browser right now".
- *
- * == 文件内部结构（维护前先看 docs/ARCH.md）==
- *   顶部常量   : 状态路径 / 哨兵 / HUMAN_PROBE_JS(人机探针) / probeCache
- *   Cdp 类     : CDP 连接封装（call/on）
- *   createCastPool : screencast 池 + viewport + 实时帧广播
- *   sseBroadcast   : SSE 客户端扇出（frame / spaces 事件）
- *   probeHuman     : 每页 humanCheck 检测（节流5s, fire-and-forget）
- *   runConnectLoop : 浏览器连接/重连
- *   keepCastsAlive : 兜底截图 + humanCheck 刷新
- *   main           : loopback HTTP 路由（/api/spaces /api/stream /api/input /api/flush /api/close）
- * 注意：humanCheck 探针与 lib/index.js 各有一份，改特征要两处同步。
- */
 import { createServer } from "node:http";
 import { mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
+import { CdpClient } from "./cdp-client.mjs";
+import { TargetSessions, CdpCaptureBackend } from "./capture-cdp.mjs";
+import { CaptureManager } from "./capture-manager.mjs";
+import { FfmpegCaptureBackend } from "./capture-ffmpeg.mjs";
 
 const SENTINEL = "@@DSH_RESULT@@";
-// Paths must mirror ego-linux/src/paths.mjs so we attach to the SAME browser.
-// Windows stores everything under %LOCALAPPDATA%\ego-lite-linux; POSIX uses
-// $XDG_STATE_HOME (default ~/.local/state)/ego-lite-linux.
 const HOME = homedir() || process.env.HOME || process.env.USERPROFILE || "/root";
 const IS_WIN = platform() === "win32";
-const STATE_HOME = IS_WIN
-  ? process.env.LOCALAPPDATA || join(HOME, "AppData", "Local")
-  : process.env.XDG_STATE_HOME || join(HOME, ".local", "state");
-const EGO_LITE_STATE_DIR = process.env.EGO_LINUX_STATE_DIR || join(STATE_HOME, "ego-lite-linux");
-const BROWSER_STATE_FILE = join(EGO_LITE_STATE_DIR, "browser.json");
-const CAST_STATE_FILE = join(EGO_LITE_STATE_DIR, "ego-cast.json");
+const STATE_HOME = IS_WIN ? process.env.LOCALAPPDATA || join(HOME, "AppData", "Local") : process.env.XDG_STATE_HOME || join(HOME, ".local", "state");
+const STATE_DIR = process.env.EGO_LINUX_STATE_DIR || join(STATE_HOME, "ego-lite-linux");
+const BROWSER_STATE_FILE = join(STATE_DIR, "browser.json");
+const CAST_STATE_FILE = join(STATE_DIR, "ego-cast.json");
+const DEFAULT_CONFIG = {
+  captureBackend: "auto", streamProfile: "balanced",
+  cdpFps: 20, cdpQuality: 55, cdpMaxWidth: 960, cdpBackstopIntervalMs: 3000,
+  ffmpegFps: 20, ffmpegMaxWidth: 1280, ffmpegEncoder: "auto", ffmpegPath: "",
+};
+let castConfig = { ...DEFAULT_CONFIG };
+try { castConfig = { ...castConfig, ...JSON.parse(process.argv[2] || "{}") }; } catch {}
 
-/** Poll a DevTools port for its browser-level WS URL (mirrors chrome.mjs probe). */
-async function probe(port, ms = 1500) {
-  try {
-    const res = await fetch(`http://127.0.0.1:${port}/json/version`, { signal: AbortSignal.timeout(ms) });
-    if (!res.ok) return null;
-    return (await res.json()).webSocketDebuggerUrl || null;
-  } catch {
-    return null;
-  }
-}
-
-/** Read the chromium browser state file the ego runtime wrote. */
-async function readBrowserState() {
-  try {
-    const { readFile } = await import("node:fs/promises");
-    return JSON.parse(await readFile(BROWSER_STATE_FILE, "utf8"));
-  } catch {
-    return null;
-  }
-}
-
-/** Resolve the live browser ws, honoring an explicit CDP override first. */
-async function resolveBrowserWs() {
-  const over = process.env.EGO_LINUX_CDP_URL;
-  if (over) return { wsUrl: over, port: null };
-  const state = await readBrowserState();
-  if (!state?.port) return null;
-  const wsUrl = await probe(state.port);
-  return wsUrl ? { wsUrl, port: state.port } : null;
-}
-
-// ---------------------------------------------------------------------------
-// CDP plumbing (Node >= 22 ships a global WebSocket)
-// ---------------------------------------------------------------------------
-class Cdp {
-  constructor(ws) {
-    this.ws = ws;
-    this.id = 0;
-    this.pending = new Map();
-    this.events = new Map();
-    ws.addEventListener("message", (ev) => {
-      let m;
-      try {
-        m = JSON.parse(ev.data);
-      } catch {
-        return;
-      }
-      if (m.id && this.pending.has(m.id)) {
-        const [resolve] = this.pending.get(m.id);
-        this.pending.delete(m.id);
-        resolve(m);
-        return;
-      }
-      if (m.method) {
-        for (const h of this.events.get(m.method) || []) h(m.params, m.sessionId);
-      }
-    });
-  }
-  call(method, params = {}, sessionId, timeoutMs = 6000) {
-    const id = ++this.id;
-    const payload = { id, method, params };
-    if (sessionId) payload.sessionId = sessionId;
-    return new Promise((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.pending.delete(id);
-        reject(new Error(`CDP ${method} timed out after ${timeoutMs}ms`));
-      }, timeoutMs);
-      this.pending.set(id, [
-        (m) => {
-          clearTimeout(timer);
-          resolve(m);
-        },
-      ]);
-      try {
-        this.ws.send(JSON.stringify(payload));
-      } catch (err) {
-        clearTimeout(timer);
-        this.pending.delete(id);
-        reject(err);
-      }
-    });
-  }
-  on(method, handler) {
-    if (!this.events.has(method)) this.events.set(method, []);
-    this.events.get(method).push(handler);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Real-time SSE fan-out. The watch panel runs on an EventSource; every new
-// screencast frame is pushed immediately (browser repaint cadence), so the UI
-// stops waiting on a per-request captureScreenshot (which measured ~700ms).
-// ---------------------------------------------------------------------------
-const sseClients = new Set();
-
-// Lightweight DOM probe for human-verification (CAPTCHA) challenges. Runs via
-// Runtime.evaluate on a page session during snapshotting, so the watch panel can
-// flash a reminder when the agent is being asked to verify.
 const HUMAN_PROBE_JS = `(() => {
-  const sel = [
-    'iframe[src*="recaptcha"]', '.g-recaptcha',
-    '.h-captcha', 'iframe[src*="hcaptcha"]',
-    '.cf-turnstile', 'iframe[src*="turnstile"]',
-    'iframe[src*="cloudflare"]', '#challenge-form', '.challenge-form',
-    '#captcha', '.captcha'
-  ].join(',');
-  const el = document.querySelector(sel);
-  if (el) {
-    const s = el.outerHTML || '';
-    if (/recaptcha|g-recaptcha/i.test(s)) return { detected: true, kind: 'recaptcha' };
-    if (/hcaptcha|h-captcha/i.test(s)) return { detected: true, kind: 'hcaptcha' };
-    if (/turnstile/i.test(s)) return { detected: true, kind: 'turnstile' };
-    if (/cloudflare/i.test(s)) return { detected: true, kind: 'cloudflare' };
-    return { detected: true, kind: 'captcha' };
-  }
-  const t = ((document.body && document.body.innerText) || '').slice(0, 120000).toLowerCase();
-  if (/verify you are human|your activity looks unusual|captcha|i.?m not a robot|人机验证|安全验证|我是人类|验证码|滑块验证/.test(t)) return { detected: true, kind: 'captcha' };
-  return { detected: false, kind: null };
+  const el=document.querySelector('iframe[src*="recaptcha"],.g-recaptcha,.h-captcha,iframe[src*="hcaptcha"],.cf-turnstile,iframe[src*="turnstile"],iframe[src*="cloudflare"],#challenge-form,.challenge-form,#captcha,.captcha');
+  if(el)return{detected:true,kind:/recaptcha/i.test(el.outerHTML)?'recaptcha':/hcaptcha/i.test(el.outerHTML)?'hcaptcha':/turnstile/i.test(el.outerHTML)?'turnstile':'captcha'};
+  const t=((document.body&&document.body.innerText)||'').slice(0,120000).toLowerCase();
+  return /verify you are human|your activity looks unusual|captcha|i.?m not a robot|人机验证|安全验证|我是人类|验证码|滑块验证/.test(t)?{detected:true,kind:'captcha'}:{detected:false,kind:null};
 })()`;
 
-/** Best-effort runtime of the human-check probe on a page session. */
-async function probeHuman(cdp, sessionId) {
-  if (!sessionId) return null;
-  try {
-    const r = await cdp.call(
-      "Runtime.evaluate",
-      { expression: HUMAN_PROBE_JS, returnByValue: true, awaitPromise: false },
-      sessionId,
-      3000
-    );
-    const v = r?.result?.result?.value;
-    return v && typeof v === "object" ? v : null;
-  } catch {
-    return null;
-  }
+const sseClients = new Set();
+const videoClients = new Set();
+const probeCache = new Map();
+const frameCache = new Map();
+let active = null;
+let currentStatus = { backend: "cdp", state: "idle", targetId: null, generation: 0, watchers: 0 };
+let videoInit = null;
+
+function normalizeConfig(input) {
+  const next = { ...castConfig };
+  const enumValue = (key, values) => { if (values.includes(input[key])) next[key] = input[key]; };
+  const numberValue = (key, min, max) => { if (Number.isFinite(input[key]) && input[key] >= min && input[key] <= max) next[key] = input[key]; };
+  enumValue("captureBackend", ["auto", "cdp", "ffmpeg"]);
+  enumValue("streamProfile", ["low", "balanced", "high"]);
+  enumValue("ffmpegEncoder", ["auto", "software", "h264_nvenc", "h264_qsv", "h264_amf", "h264_videotoolbox", "h264_vaapi"]);
+  numberValue("cdpFps", 5, 30); numberValue("cdpQuality", 1, 100); numberValue("cdpMaxWidth", 320, 1920); numberValue("cdpBackstopIntervalMs", 1000, 10000);
+  numberValue("ffmpegFps", 5, 30); numberValue("ffmpegMaxWidth", 320, 1920);
+  if (typeof input.ffmpegPath === "string") next.ffmpegPath = input.ffmpegPath;
+  return next;
 }
-
-function sseBracket(res, status = 200) {
-  res.writeHead(status, {
-    "content-type": "text/event-stream",
-    "cache-control": "no-cache",
-    connection: "keep-alive",
-    "x-accel-buffering": "no",
-  });
-  res.flushHeaders?.();
-  res.write(":ok\n\n");
-}
-/** Write one SSE event to every connected client. `payload` must be JSON-safe. */
-function sseBroadcast(event, payload) {
-  const data = typeof payload === "string" ? payload : JSON.stringify(payload);
-  const frame = `event: ${event}\ndata: ${data}\n\n`;
-  for (const res of sseClients) {
-    try {
-      res.write(frame);
-    } catch {
-      sseClients.delete(res);
-    }
-  }
-}
-/** Rebuild the current snapshot ({targetId,url,title,lastActive}) for a client. */
-const probeCache = new Map(); // targetId -> { at, human }
-const PROBE_INTERVAL_MS = 5000;
-// ── Cast config (live-hot-swappable) ────────────────────────────────────────
-// The host spawns this worker with the current cast settings as a JSON argv
-// arg (process.argv[2]); subsequent settings edits are hot-pushed via
-// POST /api/config. All three values are mutable so the watch panel's
-// screencast parameters can be tuned at runtime without restarting the
-// worker or the browser attachment.
-//
-//   castFpsCap        : 0 = uncapped (full repaint cadence); >0 = at most N
-//                       frames/sec pushed to clients. The watched (active)
-//                       tab is never throttled; only background repainting
-//                       tabs are rate-limited.
-//   screencastQuality : JPEG quality (1-100) for startScreencast + backstop
-//                       captureScreenshot.
-//   screencastMaxWidth: max CSS px width of each pushed frame.
-let castConfig = { castFpsCap: 0, screencastQuality: 55, screencastMaxWidth: 960, backstopIntervalMs: 5000 };
-try {
-  const arg = process.argv[2];
-  if (arg) {
-    const parsed = JSON.parse(arg);
-    if (parsed && typeof parsed === "object") {
-      if (typeof parsed.castFpsCap === "number") castConfig.castFpsCap = parsed.castFpsCap;
-      if (typeof parsed.screencastQuality === "number") castConfig.screencastQuality = parsed.screencastQuality;
-      if (typeof parsed.screencastMaxWidth === "number") castConfig.screencastMaxWidth = parsed.screencastMaxWidth;
-      if (typeof parsed.backstopIntervalMs === "number") castConfig.backstopIntervalMs = parsed.backstopIntervalMs;
-    }
-  }
-} catch { /* malformed argv — keep defaults */ }
-
-// ── active-tab tracking ─────────────────────────────────────────────────────
-// Which page the agent is CURRENTLY on is the single most important fact for the
-// watch panel's auto-follow. It is NOT "the page that last repainted" — Chrome
-// runs each page's screencast stream independently, so an animated/video tab in
-// the background repaints (and bumps lastActive) as fast as the operated one and
-// can steal the view. The authoritative signal is the DevTools HTTP endpoint
-// `/json/list`, which returns targets in most-recently-used order — it reflects
-// both the user's manual tab switches and the runtime's programmatic
-// `Target.activateTarget` (switchTab / openOrReuseTab). The first page entry is
-// the one the agent is looking at right now. (tabs.mjs in the runtime trusts the
-// same source for exactly this reason.)
-let activeTabCache = null; // { at, id } — id of the MRU-active page target
-const ACTIVE_TAB_TTL_MS = 1500;
-/** The id of the browser's most-recently-used (currently-active) page, or null. */
-async function activeTabId() {
-  const port = active?.port;
-  if (!port) return null;
-  if (activeTabCache && Date.now() - activeTabCache.at < ACTIVE_TAB_TTL_MS) {
-    return activeTabCache.id;
-  }
-  let id = null;
-  try {
-    const res = await fetch(`http://127.0.0.1:${port}/json/list`, { signal: AbortSignal.timeout(2000) });
-    if (res.ok) {
-      const list = await res.json();
-      const first = (Array.isArray(list) ? list : []).find((e) => e.type === "page");
-      id = first?.id ?? null;
-    }
-  } catch {
-    id = null;
-  }
-  activeTabCache = { at: Date.now(), id };
-  return id;
-}
-
-/** Synchronous peek of the most-recently-known active tab (may be a moment stale).
- *  Used on the hot screencast path so a frame is never gated behind an await. */
-function peekActiveTabId() {
-  return (activeTabCache && Date.now() - activeTabCache.at < ACTIVE_TAB_TTL_MS)
-    ? activeTabCache.id
-    : null;
-}
-
-/** Clear the MRU cache when the browser (re)connects so we never follow a stale tab. */
-function resetActiveTabCache() {
-  activeTabCache = null;
-}
-async function snapshotSpaces() {
-  if (!active) return [];
-  try {
-    const targets = await listPageTargets(active.cdp);
-    // Authoritative active page: the browser's MRU-active tab. Never fall back
-    // to "highest lastActive" here — background repaints must not win.
-    const activeId = await activeTabId();
-    // Read only already-cached frames — never call startScreencast here. That
-    // keeps the initial "spaces" push instant and, crucially, does not steal
-    // the one screencast stream Chrome allows per target away from the live
-    // fan-out below. We also do NOT include the frame bytes in the snapshot
-    // anymore — the live JPEGs stream over SSE `frame` events; the snapshot
-    // is pure metadata so the panel can render its tab list without waiting
-    // on a captureScreenshot per target.
-    const frames = active.pool.cachedFrames ? active.pool.cachedFrames() : new Map();
-    const spaces = [];
-    for (const t of targets.slice(0, 30)) {
-      const meta = frames.get(t.targetId);
-      const isActive = activeId !== null && t.targetId === activeId;
-      // Human-check probe: cached, throttled (5s), fire-and-forget so it never
-      // blocks the snapshot. Each page's value is refreshed lazily; the panel
-      // reads the last known one.
-      const cached = probeCache.get(t.targetId);
-      if (!cached || Date.now() - cached.at > PROBE_INTERVAL_MS) {
-        const sess = active.pool.sessionFor ? active.pool.sessionFor(t.targetId) : null;
-        probeHuman(active.cdp, sess).then((human) => {
-          probeCache.set(t.targetId, { at: Date.now(), human });
-        }).catch(() => {});
-      }
-      spaces.push({
-        targetId: t.targetId,
-        url: t.url,
-        title: t.title,
-        active: isActive,
-        lastActive: meta?.lastActive ?? 0,
-        viewportW: meta?.viewportW ?? undefined,
-        viewportH: meta?.viewportH ?? undefined,
-        humanCheck: (cached && cached.human) ?? null,
-      });
-    }
-    // Active page always first; the rest by recency of activity.
-    spaces.sort((a, b) => {
-      const ad = a.active ? 1 : 0, bd = b.active ? 1 : 0;
-      if (ad !== bd) return bd - ad;
-      return (b.lastActive ?? 0) - (a.lastActive ?? 0);
-    });
-    return spaces;
-  } catch {
-    return [];
-  }
-}
-
-/**
- * Script injected into every page target to force the compositor to keep
- * producing frames. Without this, pages that don't visibly repaint — video
- * players with hardware-accelerated <video>, canvas animations rendered in
- * a separate compositor layer, or simply static pages — never trigger
- * Page.screencastFrame events, so the watch panel freezes until the 5-second
- * captureScreenshot backstop fires.
- *
- * The element is a 1px fully-transparent div with an infinite opacity
- * animation. The animation forces the compositor to recomposite every frame
- * (opacity is a compositor-layer property), which in turn causes Chrome to
- * emit Page.screencastFrame events at the browser's native cadence. The
- * element is invisible (opacity:0 + pointer-events:none + z-index:-1) and
- * costs negligible CPU/GPU on modern hardware.
- *
- * Idempotent: the guard variable prevents double-injection on
- * addScriptToEvaluateOnNewDocument + Runtime.evaluate overlap.
- */
-const FORCE_REPAINT_SCRIPT = `(function(){
-  if(window.__egoForceRepaint__)return;
-  window.__egoForceRepaint__=true;
-  var s=document.createElement('style');
-  s.textContent='@keyframes __ego_fr__{0%,100%{opacity:0}50%{opacity:0.001}}';
-  (document.head||document.documentElement).appendChild(s);
-  function add(){
-    var el=document.createElement('div');
-    el.setAttribute('data-ego-fr','');
-    el.style.cssText='position:fixed;top:0;left:0;width:1px;height:1px;pointer-events:none;z-index:-1;opacity:0;animation:__ego_fr__ 0.5s infinite';
-    (document.body||document.documentElement).appendChild(el);
-  }
-  if(document.body)add();
-  else document.addEventListener('DOMContentLoaded',add);
-})();`;
-
-/** Screencast pool: one live stream per page target, newest JPEG cached. */
-function createCastPool(cdp) {
-  const casts = new Map();
-  cdp.on("Page.screencastFrame", (params, sessionId) => {
-    cdp.call("Page.screencastFrameAck", { sessionId }, sessionId).catch(() => {});
-    for (const cast of casts.values()) {
-      if (cast.sessionId !== sessionId) continue;
-      cast.frame = params.data || null;
-      cast.seq += 1;
-      cast.lastActive = Date.now();
-      // Capture the page's CSS viewport + page scale so the panel can map its
-      // pointer coordinates back to real browser pixels. screencastFrame carries
-      // these in metadata; frameFor's snapshot has no repaint event, so we only
-      // learn them here (and refresh them from /api/input-able targets lazily).
-      const md = params.metadata || {};
-      if (Number.isFinite(md.visibleViewportWidth)) cast.viewportW = md.visibleViewportWidth;
-      if (Number.isFinite(md.visibleViewportHeight)) cast.viewportH = md.visibleViewportHeight;
-      // Real-time push: forward every fresh frame to the watch panel as soon as
-      // it arrives, instead of waiting for the next /api/spaces poll. The panel
-      // dataURL-caches per target so reconnecting clients catch up cheaply.
-      if (cast.frame && sseClients.size > 0) {
-        // Optional fan-out cap. Uncapped (0) → always send. Capped → the
-        // watched (active) tab always passes; only background repainting tabs
-        // are rate-limited to free bandwidth/CPU on dynamic pages.
-        let pass = castConfig.castFpsCap <= 0;
-        if (!pass) {
-          // Sync path: use the cached active id so a frame is never gated
-          // behind an await. The cap is opt-in; the default (0) short-circuits
-          // above and stays fully synchronous.
-          const activeId = peekActiveTabId();
-          const isWatched = !activeId || cast.targetId === activeId;
-          if (isWatched) {
-            pass = true;
-          } else {
-            const minGapMs = 1000 / castConfig.castFpsCap;
-            const now = Date.now();
-            if (!cast.lastCastAt || now - cast.lastCastAt >= minGapMs) {
-              cast.lastCastAt = now;
-              pass = true;
-            }
-          }
-        }
-        if (pass) {
-          sseBroadcast("frame", {
-            targetId: cast.targetId,
-            data: cast.frame,
-            ts: Date.now(),
-            vw: cast.viewportW || null,
-            vh: cast.viewportH || null,
-          });
-        }
-      }
-      break;
-    }
-  });
-  /** Drop a target's cast and stop its screencast stream (best-effort). */
-  async function drop(targetId) {
-    const cast = casts.get(targetId);
-    if (!cast) return;
-    casts.delete(targetId);
-    cdp.call("Page.stopScreencast", {}, cast.sessionId).catch(() => {});
-  }
-  // Keep the pool bounded: a target that goes away must not linger forever
-  // (it would keep acked screencast frames and leak memory over a long run).
-  cdp.on("Target.targetDestroyed", (params) => {
-    for (const [tid, cast] of casts) {
-      if (cast.targetId === params.targetId) drop(tid);
-    }
-  });
-  async function frameFor(targetId) {
-    if (casts.has(targetId)) return casts.get(targetId);
-    let sessionId;
-    try {
-      const { result } = await cdp.call("Target.attachToTarget", { targetId, flatten: true });
-      sessionId = result.sessionId;
-      // Enable Page domain explicitly so screencastFrame events are delivered.
-      // startScreencast implicitly enables it in most Chrome builds, but being
-      // explicit avoids relying on undocumented behavior.
-      await cdp.call("Page.enable", {}, sessionId).catch(() => {});
-      await cdp.call("Page.startScreencast", { format: "jpeg", quality: castConfig.screencastQuality, maxWidth: castConfig.screencastMaxWidth, everyNthFrame: 1 }, sessionId);
-      // Inject a force-repaint animation so the compositor keeps producing
-      // frames even on pages that don't repaint on their own — video players,
-      // canvas animations, and static pages with hardware-accelerated content
-      // all freeze the screencast stream because Chrome's compositor only
-      // emits a new frame when something visible changes. The injected element
-      // is a 1px transparent div with an infinite opacity animation; this
-      // forces the compositor to recomposite every frame, which triggers
-      // Page.screencastFrame events at the browser's native cadence.
-      // addScriptToEvaluateOnNewDocument survives navigation; Runtime.evaluate
-      // covers the current page immediately.
-      try {
-        await cdp.call("Page.addScriptToEvaluateOnNewDocument", { source: FORCE_REPAINT_SCRIPT }, sessionId);
-        await cdp.call("Runtime.evaluate", { expression: FORCE_REPAINT_SCRIPT, silent: true }, sessionId);
-      } catch { /* best-effort — screencast still works, just may be slow on static pages */ }
-    } catch (err) {
-      return null; // attach/screencast failed — caller reports no thumbnail
-    }
-    const cast = { targetId, sessionId, frame: null, seq: 0, lastActive: Date.now(), viewportW: null, viewportH: null };
-    casts.set(targetId, cast);
-    // Pull the CSS viewport once so the panel can map coordinates even before
-    // the first repaint (screencast metadata only arrives on a pushed frame).
-    updateViewport(cast).catch(() => {});
-    await refreshFrame(targetId);
-    return cast;
-  }
-  /** Best-effort: fill cast.viewportW/H from the page's layout metrics. */
-  async function updateViewport(cast) {
-    try {
-      if (!cast.sessionId) return;
-      const shot = await cdp.call("Page.getLayoutMetrics", {}, cast.sessionId);
-      const r = shot?.result || shot || {};
-      const css = r.cssLayoutViewport || r.cssViewport || {};
-      const w = css.clientWidth ?? css.width;
-      const h = css.clientHeight ?? css.height;
-      if (Number.isFinite(w) && w > 0) cast.viewportW = w;
-      if (Number.isFinite(h) && h > 0) cast.viewportH = h;
-    } catch {
-      /* leave existing values */
-    }
-  }
-  /**
-   * Force a fresh screenshot for a target, updating its cached frame.
-   *
-   * Screencast only emits frames when the PAGE repaints; pages that change
-   * without repainting — a <video> element playing inside a static layout, a
-   * canvas that animates off-throttle — may never push a new screencast frame,
-   * so the cached frame freezes. `/api/spaces` calls this so the watch panel
-   * shows the CURRENT picture, not a stale one. Rate-limited per target
-   * (min 500ms) to avoid hammering every poll, and parallel-safe via a
-   * per-target in-flight promise.
-   */
-  const pending = new Map();
-  const lastShot = new Map();
-  function refreshFrame(targetId) {
-    const cast = casts.get(targetId);
-    if (!cast) return frameFor(targetId);
-    // The minimum interval between forced captures for the same target is
-    // derived from castConfig.backstopIntervalMs so lowering the backstop
-    // setting actually increases the forced-capture rate (the previous
-    // hardcoded 500ms floor could silently cap a user-set 200ms backstop).
-    const floorMs = Math.max(100, Math.min(castConfig.backstopIntervalMs, 2000));
-    const since = Date.now() - (lastShot.get(targetId) || 0);
-    if (since < floorMs) return cast;
-    if (pending.has(targetId)) return pending.get(targetId);
-    const p = (async () => {
-      try {
-        const shot = await cdp.call("Page.captureScreenshot", { format: "jpeg", quality: castConfig.screencastQuality }, cast.sessionId);
-        const data = shot?.result?.data || shot?.data || null;
-        if (data && data.length > 0) {
-          cast.frame = data;
-          cast.lastActive = Date.now();
-        }
-        // The screenshot itself implies the page is rendered — line up the viewport
-        // there too (cheap; only when we still don't know it).
-        if (!cast.viewportW || !cast.viewportH) await updateViewport(cast);
-      } catch {
-        /* transient — keep last frame */
-      } finally {
-        lastShot.set(targetId, Date.now());
-        pending.delete(targetId);
-      }
-      return cast;
-    })();
-    pending.set(targetId, p);
-    return p;
-  }
-  async function removeCast(targetId) {
-    await drop(targetId);
-  }
-  /** Map of targetId -> { frame } for targets that already have a cast. */
-  function cachedFrames() {
-    const out = new Map();
-    for (const [targetId, cast] of casts) {
-      if (cast.frame) out.set(targetId, { frame: cast.frame, lastActive: cast.lastActive, viewportW: cast.viewportW, viewportH: cast.viewportH });
-    }
-    return out;
-  }
-  /**
-   * Dispatch a raw browser-input event to a live page via its screencast session.
-   *
-   * The watch panel sends pointer/wheel intentions with coordinates already
-   * mapped to browser CSS pixels (it knows the page viewport from the frame
-   * metadata we attach). Here we turn them into CDP `Input.dispatchMouseEvent`
-   * calls on the same session that drives the screencast for that target, so a
-   * click/drag/scroll lands on the real page the user is looking at.
-   *
-   * `payload.type` is one of:  mouseMoved | mousePressed | mouseReleased |
-   * mouseWheel. Fields mirror CDP's params where sensible.
-   */
-  async function sendInput(targetId, payload) {
-    const cast = casts.get(targetId);
-    if (!cast || !cast.sessionId) return { ok: false, error: "no live session for target" };
-    const { type, x, y, button = "left", buttons = 0, deltaX = 0, deltaY = 0, clickCount = 0, modifiers = 0 } = payload || {};
-    const base = { button, buttons, clickCount, modifiers };
-    if (type === "mouseMoved") {
-      // during a drag Chrome expects buttons to stay held; aim for smoothness.
-      await cdp.call("Input.dispatchMouseEvent", { type: "mouseMoved", x, y, buttons }, cast.sessionId);
-    } else if (type === "mousePressed" || type === "mouseReleased") {
-      await cdp.call("Input.dispatchMouseEvent", { type, x, y, ...base }, cast.sessionId);
-    } else if (type === "mouseWheel") {
-      await cdp.call("Input.dispatchMouseEvent", { type: "mouseWheel", x, y, deltaX, deltaY }, cast.sessionId);
-    } else {
-      return { ok: false, error: `unsupported input type: ${type}` };
-    }
-    return { ok: true };
-  }
-
-  /** The screencast session id for a target (used to run in-page probes). */
-  function sessionFor(targetId) {
-    return casts.get(targetId)?.sessionId ?? null;
-  }
-
-  /**
-   * Restart every active screencast stream with the given parameters. Used
-   * when the user changes screencastQuality / screencastMaxWidth in the
-   * settings card — Chrome only honors new params on a fresh
-   * startScreencast call (the running stream keeps its original params).
-   * Best-effort: a target whose restart fails is left with its old stream.
-   */
-  async function restartScreencasts({ quality, maxWidth }) {
-    const tasks = [];
-    for (const [tid, cast] of casts) {
-      tasks.push((async () => {
-        try {
-          await cdp.call("Page.stopScreencast", {}, cast.sessionId);
-        } catch { /* may already be stopped */ }
-        try {
-          await cdp.call("Page.startScreencast", { format: "jpeg", quality, maxWidth, everyNthFrame: 1 }, cast.sessionId);
-        } catch { /* target may have died — drop will follow on targetDestroyed */ }
-      })());
-    }
-    await Promise.all(tasks);
-  }
-
-  return { frameFor, refreshFrame, removeCast, cachedFrames, sendInput, sessionFor, restartScreencasts };
-}
-
-async function listPageTargets(cdp) {
-  const { result } = await cdp.call("Target.getTargets");
-  return (result.targetInfos || []).filter((t) => t.type === "page");
-}
+castConfig = normalizeConfig(castConfig);
 
 function sendJson(res, status, body) {
   const payload = JSON.stringify(body);
-  res.writeHead(status, {
-    "content-type": "application/json",
-    "content-length": Buffer.byteLength(payload),
-    "cache-control": "no-store",
-  });
+  res.writeHead(status, { "content-type": "application/json", "content-length": Buffer.byteLength(payload), "cache-control": "no-store" });
   res.end(payload);
 }
 
-/** Collect a small JSON request body (bounded) and return it as a string. */
-function readBody(req, maxBytes = 8192) {
-  return new Promise((resolve, reject) => {
-    let data = "";
-    let tooBig = false;
-    req.on("data", (chunk) => {
-      data += chunk;
-      if (data.length > maxBytes) { tooBig = true; req.destroy(); }
-    });
-    req.on("end", () => (tooBig ? reject(new Error("body too large")) : resolve(data)));
-    req.on("error", reject);
-  }).catch(() => "");
+async function readJson(req, maxBytes = 8192) {
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of req) {
+    size += chunk.length;
+    if (size > maxBytes) throw new Error("body too large");
+    chunks.push(Buffer.from(chunk));
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
 }
 
-// ---------------------------------------------------------------------------
-// Single-instance guard: ensure only ONE ego-cast-worker is ever alive.
-//
-// Background: a worker can be launched both from the plugin install
-// (C:\Users\...\.external-plugins\ego-browser) and from a dev clone
-// (D:\AGENT LEARING\...), and `ensureWorker` respawns one whenever the last
-// known pid in ego-cast.json looks dead. That can leave a stale file pointing
-// at a dead pid while an older-but-alive worker keeps running on another port —
-// exactly the "watch panel lost the stream" state. Fix: on startup this worker
-// enumerates other node processes running the same ego-cast-worker.mjs and
-// stops them, then REMOVES any stale ego-cast.json so the fresh process's own
-// {port,pid} becomes authoritative.
-// ---------------------------------------------------------------------------
+function writeSse(res, event, payload) {
+  return res.write(`event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`);
+}
 
-// On Windows enumerate sibling node processes with a QUOTED commandline filter.
-// We avoid cmd.exe / nested-quote mess by shipping the PowerShell script to
-// powershell.exe -EncodedCommand as UTF-16LE base64 — immune to quote mangling.
-function listSiblingWorkerPids() {
-  const self = String(process.pid);
-  const pids = [];
-  if (IS_WIN) {
-    // The script outputs one integer PID per line for every node.exe whose
-    // command line contains our worker script, excluding our own pid.
-    const ps = [
-      "Get-CimInstance Win32_Process -Filter \"Name='node.exe'\"",
-      "| Where-Object { $_.CommandLine -like '*ego-cast-worker.mjs*' -and $_.ProcessId -ne $PID }",
-      "| Select-Object -ExpandProperty ProcessId",
-    ].join(" ");
+function broadcast(event, payload) {
+  for (const client of sseClients) {
+    if (event === "frame" && client.blocked) { client.pendingFrame = payload; continue; }
     try {
-      const enc = Buffer.from(ps, "utf16le").toString("base64");
-      const out = execFileSync("powershell.exe",
-        ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-EncodedCommand", enc],
-        { encoding: "utf8", timeout: 8000 });
-      for (const l of out.split(/\r?\n/)) {
-        const t = l.trim();
-        if (/^\d+$/.test(t) && t !== self) pids.push(Number(t));
+      const ok = writeSse(client.res, event, payload);
+      if (!ok) {
+        client.blocked = true;
+        client.res.once("drain", () => {
+          client.blocked = false;
+          if (client.pendingFrame) {
+            const pending = client.pendingFrame;
+            client.pendingFrame = null;
+            try { writeSse(client.res, "frame", pending); } catch { sseClients.delete(client); }
+          }
+        });
       }
-    } catch { /* enumeration failed → no-op */ }
-    return pids;
-  }
-  // POSIX: ps -eo pid=,args= and filter lines by our script name.
-  try {
-    const out = execFileSync("ps", ["-eo", "pid=,args="], { encoding: "utf8", timeout: 8000 });
-    for (const l of out.split(/\n/)) {
-      const m = l.match(/^\s*(\d+)\s+(.+)$/);
-      if (m && m[2].includes("ego-cast-worker.mjs") && m[1] !== self) pids.push(Number(m[1]));
-    }
-  } catch {}
-  return pids;
-}
-
-/** Stop (graceful SIGTERM, then force) node processes running ego-cast-worker.mjs other than ourselves. */
-function stopSiblingWorkers() {
-  const others = listSiblingWorkerPids();
-  for (const p of others) {
-    // Graceful first (lets the old worker flush its cast state and exit),
-    // then force if it lingers.
-    try { process.kill(p, "SIGTERM"); } catch {}
-    try { execFileSync("taskkill", ["/PID", String(p), "/T", "/F"], { timeout: 8000, stdio: "ignore" }); } catch {}
+    } catch { sseClients.delete(client); }
   }
 }
 
-/** Remove any stale ego-cast.json (dead pid, or a pid that will now be killed). */
-async function cleanStaleCastState() {
-  try {
-    const { readFile } = await import("node:fs/promises");
-    let pid = null;
-    try {
-      pid = JSON.parse(await readFile(CAST_STATE_FILE, "utf8"))?.pid ?? null;
-    } catch {
-      pid = null; // unparsable/absent → nothing to preserve
+function publishStatus(status) {
+  currentStatus = { ...currentStatus, ...status };
+  broadcast("capture-status", currentStatus);
+}
+
+function publishJpeg(frame) {
+  frameCache.delete(frame.targetId);
+  frameCache.set(frame.targetId, { frame: frame.data, lastActive: frame.ts, viewportW: frame.vw, viewportH: frame.vh });
+  while (frameCache.size > 30) frameCache.delete(frameCache.keys().next().value);
+  broadcast("frame", frame);
+}
+
+function publishVideoInit(event) {
+  videoInit = event;
+  for (const client of videoClients) {
+    if (client.generation === event.generation) writeVideo(client, event.buffer);
+  }
+}
+
+function publishVideoChunk(event) {
+  for (const client of videoClients) {
+    if (client.generation === event.generation) writeVideo(client, event.buffer);
+  }
+}
+
+function writeVideo(client, buffer) {
+  if (client.blocked) {
+    client.queue.push(buffer);
+    if (client.queue.length > 8) {
+      videoClients.delete(client);
+      try { client.res.destroy(new Error("video client is too slow")); } catch {}
     }
-    // If a live worker owns the file and it is NOT a stale duplicate we'd be
-    // killing, leaving it would confuse ensureWorker. We always own the file in
-    // the end, so just remove it; the fresh worker writes its own right after.
-    rmSync(CAST_STATE_FILE, { force: true });
-    console.error?.(`ego-cast-worker: stale cast state cleared (had pid=${pid ?? "-"})`);
-  } catch {}
+    return;
+  }
+  try {
+    if (!client.res.write(buffer)) {
+      client.blocked = true;
+      client.res.once("drain", () => {
+        client.blocked = false;
+        const pending = client.queue.shift();
+        if (pending) writeVideo(client, pending);
+      });
+    } else if (client.queue.length > 0) writeVideo(client, client.queue.shift());
+  } catch { videoClients.delete(client); }
 }
 
-// ---------------------------------------------------------------------------
-// main — resilient version: loopback HTTP stays up; the browser attachment is
-// re-established automatically whenever the agent browser appears, restarts,
-// or its CDP socket drops. This replaces the old "exit(2) if no browser" and
-// "one-shot WS" behavior so the panel never silently goes dead.
-// ---------------------------------------------------------------------------
-const RETRY_NO_BROWSER_MS = 3000;  // no browser.json / unreachable
-const RETRY_AFTER_DROP_MS = 2000;  // CDP socket closed or errored
-// Backstop stale threshold is now configurable via castConfig.backstopIntervalMs
-// (see castConfig above). The default (5000ms) is applied when no config is
-// provided. The value is read live from castConfig in keepCastsAlive so a
-// hot-update via POST /api/config takes effect on the next tick.
-let active = null; // { cdp, pool } for the live browser attachment
-
-async function openBrowserSession(wsUrl, browserPort = null) {
-  const ws = new WebSocket(wsUrl);
-  await new Promise((res, rej) => {
-    ws.addEventListener("open", res, { once: true });
-    ws.addEventListener("error", rej, { once: true });
-  });
-  const cdp = new Cdp(ws);
-  const pool = createCastPool(cdp);
-  const dropped = new Promise((resolve) => {
-    ws.addEventListener("close", () => resolve("close"), { once: true });
-    ws.addEventListener("error", () => resolve("error"), { once: true });
-  });
-  return { ws, cdp, pool, dropped, port: browserPort };
+function endVideo({ generation } = {}) {
+  for (const client of [...videoClients]) {
+    if (generation === undefined || client.generation === generation) {
+      videoClients.delete(client);
+      try { client.res.end(); } catch {}
+    }
+  }
 }
 
-async function runConnectLoop() {
+const manager = new CaptureManager({
+  getConfig: () => castConfig,
+  onStatus: publishStatus,
+  backendFactories: {
+    cdp: ({ onStatus }) => {
+      if (!active) throw new Error("no live browser");
+      return new CdpCaptureBackend({ cdp: active.cdp, sessions: active.sessions, getConfig: () => castConfig, onStatus, onJpegFrame: publishJpeg });
+    },
+    ffmpeg: ({ generation, onStatus }) => {
+      if (!active) throw new Error("no live browser");
+      return new FfmpegCaptureBackend({ sessions: active.sessions, getConfig: () => castConfig, generation, onStatus, onVideoInit: publishVideoInit, onVideoChunk: publishVideoChunk, onVideoEnd: endVideo });
+    },
+  },
+});
+
+async function readBrowserState() {
+  try { return JSON.parse(await import("node:fs/promises").then((fs) => fs.readFile(BROWSER_STATE_FILE, "utf8"))); }
+  catch { return null; }
+}
+
+async function resolveBrowser() {
+  if (process.env.EGO_LINUX_CDP_URL) return { wsUrl: process.env.EGO_LINUX_CDP_URL, port: null };
+  const state = await readBrowserState();
+  if (!state?.port) return null;
+  try {
+    const response = await fetch(`http://127.0.0.1:${state.port}/json/version`, { signal: AbortSignal.timeout(1500) });
+    const wsUrl = response.ok ? (await response.json()).webSocketDebuggerUrl : null;
+    return wsUrl ? { ...state, wsUrl } : null;
+  } catch { return null; }
+}
+
+async function listTargets() {
+  if (!active) return [];
+  const result = await active.cdp.call("Target.getTargets");
+  return (result.targetInfos || []).filter((target) => target.type === "page");
+}
+
+async function activeTargetId() {
+  if (!active?.port) return currentStatus.targetId || null;
+  try {
+    const response = await fetch(`http://127.0.0.1:${active.port}/json/list`, { signal: AbortSignal.timeout(1500) });
+    const list = response.ok ? await response.json() : [];
+    return list.find((entry) => entry.type === "page")?.id || currentStatus.targetId || null;
+  } catch { return currentStatus.targetId || null; }
+}
+
+async function snapshotSpaces() {
+  const targets = await listTargets();
+  const activeId = await activeTargetId();
+  const spaces = [];
+  for (const target of targets.slice(0, 30)) {
+    const frame = frameCache.get(target.targetId);
+    const session = active.sessions.get(target.targetId);
+    const cached = probeCache.get(target.targetId);
+    if (!cached || Date.now() - cached.at > 5000) {
+      active.sessions.call(target.targetId, "Runtime.evaluate", { expression: HUMAN_PROBE_JS, returnByValue: true, awaitPromise: false }, 3000)
+        .then((result) => probeCache.set(target.targetId, { at: Date.now(), human: result.result?.value || null })).catch(() => {});
+    }
+    spaces.push({ targetId: target.targetId, url: target.url, title: target.title, active: target.targetId === activeId, lastActive: frame?.lastActive || 0, viewportW: frame?.viewportW || session?.viewportW, viewportH: frame?.viewportH || session?.viewportH, humanCheck: cached?.human || null });
+  }
+  spaces.sort((a, b) => Number(b.active) - Number(a.active) || b.lastActive - a.lastActive);
+  return spaces;
+}
+
+async function connectLoop() {
   while (true) {
-    const browser = await resolveBrowserWs();
-    if (!browser) {
-      // Wait for the agent browser to appear; report empty in the meantime.
-      await sleep(RETRY_NO_BROWSER_MS);
-      continue;
-    }
+    const browser = await resolveBrowser();
+    if (!browser) { await sleep(3000); continue; }
     try {
-      const session = await openBrowserSession(browser.wsUrl, browser.port || null);
-      active = session;
-      resetActiveTabCache();
-      console.error(`ego-cast-worker: attached to browser (${browser.port ?? "override"})`);
-      keepCastsAlive(session);
-      await session.dropped;
-    } catch {
-      console.error("ego-cast-worker: browser connect failed, retrying");
+      const ws = new WebSocket(browser.wsUrl);
+      await new Promise((resolve, reject) => { ws.addEventListener("open", resolve, { once: true }); ws.addEventListener("error", reject, { once: true }); });
+      const cdp = new CdpClient(ws);
+      const sessions = new TargetSessions(cdp);
+      active = { ...browser, ws, cdp, sessions };
+      publishStatus({ browserConnected: true });
+      await manager.browserConnected();
+      await new Promise((resolve) => { ws.addEventListener("close", resolve, { once: true }); ws.addEventListener("error", resolve, { once: true }); });
+      await manager.browserDisconnected();
+      await sessions.dispose();
+    } catch (error) {
+      publishStatus({ state: "failed", code: "browser-disconnected", message: error.message, browserConnected: false });
     } finally {
       active = null;
-      await sleep(RETRY_AFTER_DROP_MS);
+      await sleep(2000);
     }
   }
 }
 
-/**
- * Keep a screencast stream on every live page target AND force a fresh frame
- * periodically as a backstop.
- *
- * Two complementary sources feed the watch panel:
- *   1. `Page.screencastFrame` — real time, but only fires while the page is
- *      actually repainting (a backgrounded or static page goes quiet), and only
- *      for targets with an open `Page.startScreencast` stream.
- *   2. a periodic `Page.captureScreenshot` — always renders, so a quiet page
- *      still gets a fresh frame. This is the backstop that keeps the panel from
- *      freezing on a page that stops repainting (e.g. a static layout while a
- *      <video> inside it keeps playing without a repaint would otherwise starve
- *      the screencast stream).
- *
- * Runs until `session` stops being current (its socket dropped). frameFor is
- * idempotent for existing casts, so calling it often is cheap; the screenshot
- * backstop is throttled per target by refreshFrame's own 500ms floor.
- *
- * This loop ALSO broadcasts a `spaces` event on every tick (URL/title/active
- * changes), so the watch panel no longer needs to poll /api/spaces. The tick
- * cadence is the panel's metadata freshness bound — every 500ms by default.
- */
+function sleep(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
 
-// Metadata broadcast throttle. `spaces` events are cheap (no JPEG bytes), but
-// we still don't want to flood the SSE pipe on a busy tab churn — coalesce
-// back-to-back triggers into a single push within this window.
-let spacesBroadcastPending = false;
-let spacesBroadcastTimer = null;
-const SPACES_BROADCAST_THROTTLE_MS = 250;
-/**
- * Schedule a `spaces` event broadcast on the next microtask, coalesced so a
- * flurry of target changes / url updates collapses into a single push.
- * Safe to call from any path (CDP event handler, keepalive tick, etc).
- */
-function scheduleSpacesBroadcast() {
-  if (spacesBroadcastPending) return;
-  spacesBroadcastPending = true;
-  spacesBroadcastTimer = setTimeout(() => {
-    spacesBroadcastPending = false;
-    spacesBroadcastTimer = null;
-    if (sseClients.size === 0) return;
-    snapshotSpaces().then((snap) => {
-      if (sseClients.size > 0) sseBroadcast("spaces", snap);
-    }).catch(() => {});
-  }, SPACES_BROADCAST_THROTTLE_MS);
-}
-
-async function keepCastsAlive(session, intervalMs = 500) {
-  while (active === session) {
+function stopSiblingWorkers() {
+  const self = String(process.pid);
+  if (IS_WIN) {
+    const ps = `Get-CimInstance Win32_Process -Filter "Name='node.exe'" | Where-Object { $_.CommandLine -like '*ego-cast-worker.mjs*' -and $_.ProcessId -ne ${self} } | Select-Object -ExpandProperty ProcessId`;
     try {
-      const targets = await listPageTargets(session.cdp);
-      const cached = session.pool.cachedFrames?.() ?? new Map();
-      const now = Date.now();
-      for (const t of targets.slice(0, 30)) {
-        if (!session.pool.frameFor) continue;
-        await session.pool.frameFor(t.targetId).catch(() => {});
-        const meta = cached.get(t.targetId);
-        const stale = !meta || (now - (meta.lastActive || 0)) > castConfig.backstopIntervalMs;
-        if (!stale) continue;
-        const cast = await session.pool.refreshFrame(t.targetId).catch(() => null);
-        if (cast?.frame && sseClients.size > 0) {
-          sseBroadcast("frame", { targetId: t.targetId, data: cast.frame, ts: Date.now() });
-        }
-      }
-      // Push the current tab list (url/title/active/viewport/humanCheck) so
-      // the panel can render its tab bar without polling /api/spaces.
-      scheduleSpacesBroadcast();
-    } catch {
-      // browser call failed; keep trying on the next tick
-    }
-    await sleep(intervalMs);
+      const output = execFileSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-EncodedCommand", Buffer.from(ps, "utf16le").toString("base64")], { encoding: "utf8", timeout: 8000 });
+      for (const line of output.split(/\r?\n/)) if (/^\d+$/.test(line.trim())) try { execFileSync("taskkill", ["/PID", line.trim(), "/T", "/F"], { stdio: "ignore" }); } catch {}
+    } catch {}
+    return;
   }
+  try {
+    const output = execFileSync("ps", ["-eo", "pid=,args="], { encoding: "utf8", timeout: 8000 });
+    for (const line of output.split("\n")) {
+      const match = line.match(/^\s*(\d+)\s+(.+)$/);
+      if (match && match[1] !== self && match[2].includes("ego-cast-worker.mjs")) try { process.kill(Number(match[1]), "SIGTERM"); } catch {}
+    }
+  } catch {}
 }
-
-function sleep(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-
 
 async function main() {
-  // Single-instance: kill duplicate workers first, then own the state file, so
-  // the port/pid we write below is the ONLY live worker's.
-  try { stopSiblingWorkers(); } catch {}
-  await cleanStaleCastState();
-
+  stopSiblingWorkers();
+  rmSync(CAST_STATE_FILE, { force: true });
   const server = createServer(async (req, res) => {
     const url = new URL(req.url, "http://127.0.0.1");
-    if (req.method === "GET" && url.pathname === "/api/health") return sendJson(res, 200, { ok: !!active });
-    if (req.method === "POST" && url.pathname === "/api/config") {
-      // Hot-update cast parameters. castFpsCap takes effect immediately (the
-      // screencastFrame handler reads castConfig on every frame);
-      // screencastQuality / screencastMaxWidth require restarting the running
-      // screencast streams (Chrome only honors new params on a fresh
-      // startScreencast call).
-      try {
-        const body = JSON.parse((await readBody(req)) || "{}");
-        const prev = { ...castConfig };
-        if (typeof body.castFpsCap === "number" && body.castFpsCap >= 0 && body.castFpsCap <= 60) {
-          castConfig.castFpsCap = body.castFpsCap;
-        }
-        if (typeof body.screencastQuality === "number" && body.screencastQuality >= 1 && body.screencastQuality <= 100) {
-          castConfig.screencastQuality = body.screencastQuality;
-        }
-        if (typeof body.screencastMaxWidth === "number" && body.screencastMaxWidth >= 320 && body.screencastMaxWidth <= 1920) {
-          castConfig.screencastMaxWidth = body.screencastMaxWidth;
-        }
-        if (typeof body.backstopIntervalMs === "number" && body.backstopIntervalMs >= 200 && body.backstopIntervalMs <= 10000) {
-          castConfig.backstopIntervalMs = body.backstopIntervalMs;
-        }
-        // If quality or width changed, restart the running screencast streams
-        // so the new params take effect immediately. fpsCap needs no restart.
-        const needsRestart = castConfig.screencastQuality !== prev.screencastQuality
-          || castConfig.screencastMaxWidth !== prev.screencastMaxWidth;
-        if (needsRestart && active?.pool?.restartScreencasts) {
-          active.pool.restartScreencasts({
-            quality: castConfig.screencastQuality,
-            maxWidth: castConfig.screencastMaxWidth,
-          }).catch(() => {});
-        }
-        return sendJson(res, 200, { ok: true, config: castConfig });
-      } catch (err) {
-        return sendJson(res, 500, { ok: false, error: String(err?.message || err) });
-      }
-    }
-    if (req.method === "POST" && url.pathname === "/api/close") {
-      const sess = active;
-      if (!sess) return sendJson(res, 400, { ok: false, error: "no live browser" });
-      try {
-        const body = JSON.parse((await readBody(req)) || "{}");
-        const targetId = body.targetId;
-        if (!targetId) return sendJson(res, 400, { ok: false, error: "targetId required" });
-        // closeTarget is a browser-level command; pass the target id as a param
-        // (no sessionId — it closes the whole page target).
-        await sess.cdp.call("Target.closeTarget", { targetId }, undefined, 6000);
-        // drop any cast stream for that page
-        try { await sess.pool.removeCast(targetId); } catch {}
-        return sendJson(res, 200, { ok: true });
-      } catch (err) {
-        return sendJson(res, 500, { ok: false, error: String(err?.message || err) });
-      }
-    }
-    if (req.method === "POST" && url.pathname === "/api/flush") {
-      const sess = active;
-      if (!sess) return sendJson(res, 400, { ok: false, error: "no live browser" });
-      try {
-        // Force all persistent cookies down to the on-disk profile store.
-        // Chrome buffers cookie writes in memory and only flushes lazily; a
-        // graceful Browser.close flushes them. To keep the login stable across a
-        // restart we re-write each non-session cookie via Network.setCookie on a
-        // page session, which nudges Chrome to persist it sooner.
-        const targets = await listPageTargets(sess.cdp);
-        let sessionId = null;
-        for (const t of targets.slice(0, 5)) {
-          try {
-            const { result } = await sess.cdp.call("Target.attachToTarget", { targetId: t.targetId, flatten: true });
-            if (result?.sessionId) { sessionId = result.sessionId; break; }
-          } catch { /* try next */ }
-        }
-        if (!sessionId) return sendJson(res, 200, { ok: true, flushed: 0, note: "no page session" });
-        await sess.cdp.call("Network.enable", {}, sessionId, 6000).catch(() => {});
-        const all = await sess.cdp.call("Network.getAllCookies", {}, sessionId, 6000);
-        const cookies = Array.isArray(all?.result?.cookies) ? all.result.cookies : [];
-        let rewrote = 0;
-        for (const c of cookies) {
-          if (c.session === true) continue; // session-only cookie can't persist
-          try {
-            await sess.cdp.call("Network.setCookie", {
-              name: c.name, value: c.value, domain: c.domain, path: c.path || "/",
-              secure: !!c.secure, httpOnly: !!c.httpOnly, sameSite: c.sameSite,
-              expires: c.expires ? c.expires : -1,
-              url: `https://${c.domain.replace(/^\./, "")}`,
-            }, sessionId, 6000);
-            rewrote++;
-          } catch { /* skip unpersistable */ }
-        }
-        return sendJson(res, 200, { ok: true, total: cookies.length, flushed: rewrote });
-      } catch (err) {
-        return sendJson(res, 500, { ok: false, error: String(err?.message || err) });
-      }
-    }
-    if (req.method === "POST" && url.pathname === "/api/input") {
-      // Forward a watch-panel pointer intention to the real agent page. Body:
-      //   { targetId, type, x, y, button, buttons, deltaX, deltaY, clickCount, modifiers }
-      // `x`/`y` are already in browser CSS pixels (the panel mapped them).
-      const sess = active;
-      if (!sess) return sendJson(res, 400, { ok: false, error: "no live browser" });
-      let body;
-      try { body = JSON.parse((await readBody(req)) || "{}"); }
-      catch { return sendJson(res, 400, { ok: false, error: "bad body" }); }
-      const { targetId, type, x, y } = body;
-      if (!targetId || typeof type !== "string" || !Number.isFinite(x) || !Number.isFinite(y)) {
-        return sendJson(res, 400, { ok: false, error: "targetId, type, x, y required" });
-      }
-      try {
-        const result = await sess.pool.sendInput(targetId, body);
-        return sendJson(res, 200, result);
-      } catch (err) {
-        return sendJson(res, 500, { ok: false, error: String(err?.message || err) });
-      }
-    }
-    if (req.method === "GET" && url.pathname === "/api/stream") {
-      // SSE: the live watch panel. On connect we send the current snapshot for
-      // every live page, then push each new screencast frame in real time. The
-      // browser-level 'spaces' event lets the panel keep its tab list in sync.
-      sseBracket(res);
-      sseClients.add(res);
-      const onClose = () => { sseClients.delete(res); };
-      req.on("close", onClose);
-      res.on("close", onClose);
-      // Non-blocking initial snapshot: never let the first event wait on a CDP
-      // call. Push the current pages in the background; live screencast frames
-      // follow on their own cadence in the screencastFrame handler.
-      snapshotSpaces().then((snap) => {
-        if (!sseClients.has(res)) return;
-        sseBroadcast("spaces", snap);
-      }).catch(() => {});
-      return;
-    }
-    if (req.method === "GET" && url.pathname === "/api/spaces") {
-      // Lightweight metadata endpoint. Used as the initial snapshot when a
-      // watch panel's SSE connection comes up, and as a reconnect fallback.
-      // Returns ONLY metadata (url/title/active/viewport/humanCheck) — no
-      // thumbnail bytes — because the live frames already stream over SSE.
-      // This drops a 30-tab response from ~30 × 700ms captureScreenshot calls
-      // down to a single Target.getTargets + cachedFrames() map lookup (<50ms).
-      const sess = active;
-      if (!sess) return sendJson(res, 200, { ok: true, spaces: [] });
-      try {
-        const snap = await snapshotSpaces();
-        return sendJson(res, 200, { ok: true, spaces: snap });
-      } catch {
-        return sendJson(res, 200, { ok: true, spaces: [] });
-      }
-    }
-    sendJson(res, 404, { ok: false, error: "not found" });
-  });
-
-  await new Promise((r) => server.listen(0, "127.0.0.1", r));
-  const { port } = server.address();
-  mkdirSync(EGO_LITE_STATE_DIR, { recursive: true });
-  writeFileSync(CAST_STATE_FILE, JSON.stringify({ port, pid: process.pid }, null, 2));
-
-  process.on("SIGTERM", shutdown);
-  process.on("SIGINT", shutdown);
-  async function shutdown() {
-    // Persist login state. Chrome flushes cookies to the on-disk profile on a
-    // graceful Browser.close; SIGTERM/kill leaves the journal unmerged and the
-    // newest logins are lost on restart. So before we detach, if we are attached
-    // to a live browser, ask it to close itself gracefully over the browser-level
-    // CDP channel — the exact graceful path the vendored runtime uses, matching
-    // upstream ego-lite's "the browser persists, not the driver".
-    if (active?.cdp) {
-      try {
-        await active.cdp.call("Browser.close", {}, undefined, 5000);
-      } catch { /* best-effort: browser may already be gone */ }
-    }
-    // Wait a beat for the close to settle so Chrome merges its cookie journal
-    // into the Cookies db before we tear down our own socket.
-    await new Promise((r) => setTimeout(r, 400));
-    // Only remove the state file if it still identifies THIS worker. During the
-    // single-instance guard a newer worker kills us right after writing its own
-    // ego-cast.json; blindly deleting here would erase the successor's truthful
-    // state and leave ensureWorker with a stale/missing file again.
     try {
-      const { readFile } = await import("node:fs/promises");
-      const rec = JSON.parse(await readFile(CAST_STATE_FILE, "utf8"));
-      if (rec.pid === process.pid) rmSync(CAST_STATE_FILE, { force: true });
-    } catch { /* absent/unparsable — nothing to clean */ }
-    server.close();
+      if (req.method === "GET" && url.pathname === "/api/health") return sendJson(res, 200, { workerOk: true, browserConnected: !!active, capture: manager.status() });
+      if (req.method === "GET" && url.pathname === "/api/spaces") return sendJson(res, 200, { ok: true, spaces: active ? await snapshotSpaces() : [], capture: manager.status() });
+      if (req.method === "GET" && url.pathname === "/api/watch/status") return sendJson(res, 200, { ok: true, ...manager.status() });
+      if (req.method === "GET" && url.pathname === "/api/video/status") return sendJson(res, 200, { ok: true, ...manager.status(), mime: videoInit?.mime || null });
+      if (req.method === "POST" && url.pathname === "/api/config") { castConfig = normalizeConfig(await readJson(req)); await manager.updateConfig(); return sendJson(res, 200, { ok: true, config: castConfig }); }
+      if (req.method === "POST" && url.pathname === "/api/watch/start") { if (!active) return sendJson(res, 409, { ok: false, error: "no live browser" }); return sendJson(res, 200, { ok: true, ...await manager.startWatch(await readJson(req)) }); }
+      if (req.method === "POST" && url.pathname === "/api/watch/switch") return sendJson(res, 200, { ok: true, ...await manager.switchWatch(await readJson(req)) });
+      if (req.method === "POST" && url.pathname === "/api/watch/stop") return sendJson(res, 200, { ok: true, ...await manager.stopWatch(await readJson(req)) });
+      if (req.method === "POST" && url.pathname === "/api/input") { const body = await readJson(req); if (!active) return sendJson(res, 409, { ok: false, error: "no live browser" }); return sendJson(res, 200, await active.sessions.sendInput(body.targetId, body)); }
+      if (req.method === "POST" && url.pathname === "/api/close") { const { targetId } = await readJson(req); if (!active || !targetId) return sendJson(res, 400, { ok: false, error: "targetId required" }); await active.cdp.call("Target.closeTarget", { targetId }); return sendJson(res, 200, { ok: true }); }
+      if (req.method === "POST" && url.pathname === "/api/flush") { if (!active) return sendJson(res, 409, { ok: false, error: "no live browser" }); await active.cdp.call("Storage.flushCookies").catch(() => {}); return sendJson(res, 200, { ok: true }); }
+      if (req.method === "GET" && url.pathname === "/api/stream") {
+        res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive", "x-accel-buffering": "no" });
+        res.write(":ok\n\n");
+        const client = { res, blocked: false, pendingFrame: null };
+        sseClients.add(client);
+        writeSse(res, "capture-status", manager.status());
+        snapshotSpaces().then((spaces) => { if (sseClients.has(client)) writeSse(res, "spaces", spaces); }).catch(() => {});
+        const close = () => sseClients.delete(client); req.on("close", close); res.on("close", close); return;
+      }
+      if (req.method === "GET" && url.pathname === "/api/video/stream") {
+        const generation = Number(url.searchParams.get("generation"));
+        if (!videoInit || generation !== currentStatus.generation || generation !== videoInit.generation) return sendJson(res, 409, { ok: false, error: "stale video generation", generation: currentStatus.generation });
+        res.writeHead(200, { "content-type": "video/mp4", "cache-control": "no-store", "x-ego-generation": String(generation), "x-ego-backend": "ffmpeg" });
+        const client = { res, generation, blocked: false, queue: [] };
+        videoClients.add(client); writeVideo(client, videoInit.buffer);
+        const close = () => videoClients.delete(client); req.on("close", close); res.on("close", close); return;
+      }
+      sendJson(res, 404, { ok: false, error: "not found" });
+    } catch (error) { sendJson(res, 500, { ok: false, error: error.message || String(error) }); }
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  mkdirSync(STATE_DIR, { recursive: true });
+  writeFileSync(CAST_STATE_FILE, JSON.stringify({ port, pid: process.pid }, null, 2));
+  const metadataTimer = setInterval(() => {
+    if (!active || sseClients.size === 0) return;
+    snapshotSpaces().then((spaces) => broadcast("spaces", spaces)).catch(() => {});
+  }, 1000);
+  const shutdown = async () => {
+    clearInterval(metadataTimer);
+    await manager.dispose().catch(() => {});
     try { active?.ws?.close(); } catch {}
+    try { const state = JSON.parse(await import("node:fs/promises").then((fs) => fs.readFile(CAST_STATE_FILE, "utf8"))); if (state.pid === process.pid) rmSync(CAST_STATE_FILE, { force: true }); } catch {}
+    server.close();
     process.exit(0);
-  }
-
+  };
+  process.on("SIGTERM", shutdown); process.on("SIGINT", shutdown);
   console.log(`${SENTINEL}${JSON.stringify({ ok: true, port, pid: process.pid })}`);
-  // Both the connect loop (forever) and the keepalive hold the loop open.
-  runConnectLoop().catch((e) => console.error("ego-cast-worker: connect loop died", e?.stack || e?.message));
-  setInterval(() => {}, 1 << 30);
+  connectLoop().catch((error) => console.error("ego-cast-worker: connect loop failed", error));
 }
 
-main().catch((e) => {
-  console.error("ego-cast-worker failed:", e.stack || e.message);
-  process.exit(1);
-});
+main().catch((error) => { console.error("ego-cast-worker failed:", error.stack || error.message); process.exit(1); });

--- a/bin/ego-cast-worker.mjs
+++ b/bin/ego-cast-worker.mjs
@@ -17,9 +17,9 @@ const STATE_DIR = process.env.EGO_LINUX_STATE_DIR || join(STATE_HOME, "ego-lite-
 const BROWSER_STATE_FILE = join(STATE_DIR, "browser.json");
 const CAST_STATE_FILE = join(STATE_DIR, "ego-cast.json");
 const DEFAULT_CONFIG = {
-  captureBackend: "auto", streamProfile: "balanced",
+  captureBackend: "auto", streamProfile: "balanced", ffmpegFallbackReason: "",
   cdpFps: 20, cdpQuality: 55, cdpMaxWidth: 960, cdpBackstopIntervalMs: 3000,
-  ffmpegFps: 20, ffmpegMaxWidth: 1280, ffmpegBitrateKbps: 4000, ffmpegEncoder: "auto", ffmpegPath: "",
+  ffmpegFps: 20, ffmpegMaxWidth: 1280, ffmpegBitrateKbps: 4000, ffmpegEncoder: "auto", ffmpegPath: "", ffmpegResolvedPath: "",
 };
 let castConfig = { ...DEFAULT_CONFIG };
 try { castConfig = { ...castConfig, ...JSON.parse(process.argv[2] || "{}") }; } catch {}
@@ -44,11 +44,13 @@ function normalizeConfig(input) {
   const enumValue = (key, values) => { if (values.includes(input[key])) next[key] = input[key]; };
   const numberValue = (key, min, max) => { if (Number.isFinite(input[key]) && input[key] >= min && input[key] <= max) next[key] = input[key]; };
   enumValue("captureBackend", ["auto", "cdp", "ffmpeg"]);
+  if (typeof input.ffmpegFallbackReason === "string") next.ffmpegFallbackReason = input.ffmpegFallbackReason;
   enumValue("streamProfile", ["low", "balanced", "high"]);
   enumValue("ffmpegEncoder", ["auto", "software", "h264_mf", "h264_nvenc", "h264_qsv", "h264_amf", "h264_videotoolbox", "h264_vaapi"]);
   numberValue("cdpFps", 5, 30); numberValue("cdpQuality", 1, 100); numberValue("cdpMaxWidth", 320, 1920); numberValue("cdpBackstopIntervalMs", 1000, 10000);
   numberValue("ffmpegFps", 5, 30); numberValue("ffmpegMaxWidth", 320, 1920); numberValue("ffmpegBitrateKbps", 500, 20000);
   if (typeof input.ffmpegPath === "string") next.ffmpegPath = input.ffmpegPath;
+  if (typeof input.ffmpegResolvedPath === "string") next.ffmpegResolvedPath = input.ffmpegResolvedPath;
   return next;
 }
 castConfig = normalizeConfig(castConfig);

--- a/bin/ffmpeg-probe.mjs
+++ b/bin/ffmpeg-probe.mjs
@@ -1,0 +1,42 @@
+import { spawn as nodeSpawn } from "node:child_process";
+
+export function runFfmpegProbe(path, argv, { spawn = nodeSpawn, timeoutMs = 3000 } = {}) {
+  return new Promise((resolve) => {
+    let child; let output = ""; let settled = false;
+    const finish = (ok) => { if (settled) return; settled = true; clearTimeout(timer); resolve({ ok, output }); };
+    try { child = spawn(path, argv, { shell: false, windowsHide: true, stdio: ["ignore", "pipe", "pipe"] }); }
+    catch { resolve({ ok: false, output }); return; }
+    child.stdout?.on("data", (chunk) => { output += chunk.toString(); });
+    child.stderr?.on("data", (chunk) => { output += chunk.toString(); });
+    child.once("error", () => finish(false));
+    child.once("exit", (code) => finish(code === 0));
+    const timer = setTimeout(() => { try { child.kill("SIGTERM"); } catch {}; finish(false); }, timeoutMs);
+  });
+}
+
+export async function probeFfmpeg(path, { platform = process.platform, env = process.env, spawn = nodeSpawn, requestedEncoder = "auto" } = {}) {
+  const versionResult = await runFfmpegProbe(path, ["-version"], { spawn });
+  if (!versionResult.ok) throw codedError("ffmpeg-not-executable", `FFmpeg is not executable: ${path}`);
+  const version = versionResult.output.split(/\r?\n/, 1)[0] || "FFmpeg";
+  if (platform === "win32") {
+    const support = await runFfmpegProbe(path, ["-hide_banner", "-h", "filter=gfxcapture"], { spawn });
+    if (!support.ok || !/Filter gfxcapture\b/.test(support.output)) throw codedError("ffmpeg-gfxcapture-unavailable", "FFmpeg does not support Windows gfxcapture");
+  } else if (platform === "darwin") {
+    const devices = await runFfmpegProbe(path, ["-hide_banner", "-devices"], { spawn });
+    if (!devices.ok || !/avfoundation/i.test(devices.output)) throw codedError("ffmpeg-capture-input-unavailable", "FFmpeg does not support avfoundation capture");
+  } else if (platform === "linux") {
+    if (env.XDG_SESSION_TYPE === "wayland" || env.WAYLAND_DISPLAY) throw codedError("ffmpeg-platform-unsupported", "Wayland capture is not supported");
+    const devices = await runFfmpegProbe(path, ["-hide_banner", "-devices"], { spawn });
+    if (!devices.ok || !/x11grab/i.test(devices.output)) throw codedError("ffmpeg-capture-input-unavailable", "FFmpeg does not support x11grab capture");
+  }
+  const automatic = platform === "win32" ? ["h264_mf", "h264_nvenc", "h264_qsv", "h264_amf", "libx264"]
+    : platform === "darwin" ? ["h264_videotoolbox", "libx264"] : ["h264_nvenc", "h264_vaapi", "h264_qsv", "libx264"];
+  const encoders = requestedEncoder === "auto" ? automatic : [requestedEncoder === "software" ? "libx264" : requestedEncoder];
+  for (const encoder of encoders) {
+    const args = ["-hide_banner", "-loglevel", "error", "-f", "lavfi", "-i", "color=size=64x64:rate=1", "-frames:v", "1", "-c:v", encoder, "-f", "null", "-"];
+    if ((await runFfmpegProbe(path, args, { spawn, timeoutMs: 5000 })).ok) return { version, encoder };
+  }
+  throw codedError("ffmpeg-encoder-unavailable", "FFmpeg has no usable H.264 encoder");
+}
+
+function codedError(code, message) { const error = new Error(message); error.code = code; return error; }

--- a/bin/mp4-fragments.mjs
+++ b/bin/mp4-fragments.mjs
@@ -1,0 +1,55 @@
+const MAX_BOX_BYTES = 64 * 1024 * 1024;
+
+export class Mp4FragmentParser {
+  constructor({ onInit, onFragment, maxBoxBytes = MAX_BOX_BYTES }) {
+    this.onInit = onInit;
+    this.onFragment = onFragment;
+    this.maxBoxBytes = maxBoxBytes;
+    this.buffer = Buffer.alloc(0);
+    this.initBoxes = [];
+    this.fragmentBoxes = [];
+    this.ready = false;
+  }
+
+  push(chunk) {
+    this.buffer = Buffer.concat([this.buffer, Buffer.from(chunk)]);
+    while (this.buffer.length >= 8) {
+      let size = this.buffer.readUInt32BE(0);
+      const type = this.buffer.toString("ascii", 4, 8);
+      if (size === 1) throw new Error("64-bit MP4 boxes are not supported");
+      if (size < 8 || size > this.maxBoxBytes) throw new Error(`invalid MP4 box size ${size}`);
+      if (this.buffer.length < size) return;
+      const box = this.buffer.subarray(0, size);
+      this.buffer = this.buffer.subarray(size);
+      this.#box(type, box);
+    }
+  }
+
+  end() {
+    if (this.buffer.length !== 0) throw new Error("truncated MP4 stream");
+  }
+
+  #box(type, box) {
+    if (!this.ready) {
+      if (type !== "ftyp" && type !== "moov") throw new Error(`unexpected MP4 init box ${type}`);
+      this.initBoxes.push(box);
+      if (type === "moov") {
+        this.ready = true;
+        this.onInit(Buffer.concat(this.initBoxes));
+        this.initBoxes = [];
+      }
+      return;
+    }
+    if (type === "moof") {
+      this.fragmentBoxes = [box];
+      return;
+    }
+    if (type === "mdat" && this.fragmentBoxes.length) {
+      this.fragmentBoxes.push(box);
+      this.onFragment(Buffer.concat(this.fragmentBoxes));
+      this.fragmentBoxes = [];
+      return;
+    }
+    if (type !== "free" && type !== "sidx") throw new Error(`unexpected MP4 media box ${type}`);
+  }
+}

--- a/docs/ARCH.md
+++ b/docs/ARCH.md
@@ -6,7 +6,7 @@
 ## 0. 一句话
 
 这是一个 DSH 插件：**自带 ego-lite 运行时**，把浏览器自动化能力封装成 `ego_*` 结构化工具，
-并提供**右下角实时观察窗 + 人机验证提醒 + 下载捕获**。三个运行时文件是唯一需要维护的核心。
+并提供**双后端实时观察窗 + 人机验证提醒 + 下载捕获**。
 
 ---
 
@@ -19,6 +19,12 @@ ego-browser/
   lib/cast-server.js    # [后端] host 路由：把前端 /api/ego/* 转发到观察窗 worker
   lib/client.js         # [前端] 右下角观察窗（通过 DSH 注入加载，单文件）
   bin/ego-cast-worker.mjs  # [后端] 观察窗 worker：attach 浏览器、SSE 实时画面、humanCheck
+  bin/cdp-client.mjs       # CDP 请求/错误/事件封装
+  bin/capture-manager.mjs  # watcher lease、单后端状态机、generation
+  bin/capture-cdp.mjs      # control session + 单 target JPEG capture
+  bin/capture-ffmpeg.mjs   # FFmpeg 进程与 fMP4 发布
+  bin/capture-platform.mjs # 平台来源/crop/argv
+  bin/mp4-fragments.mjs    # 有界 ISO BMFF box parser
   runtime/              # vendored ego-lite 运行时（只读参照，本地改动见 runtime/PATCHES.md）
   docs/ARCH.md          # 本文件
 ```
@@ -62,7 +68,9 @@ ego-browser/
 内部按 section 组织：CSS → icons → apply() → 各交互/渲染函数。
 
 维护时要同步注意：
-- 数据源：轮询 `/api/ego/spaces` + SSE `/api/ego/stream`（实时帧）
+- 数据源：`/api/ego/stream` 提供元数据、CDP JPEG 与 capture status；`/api/ego/video` 提供 FFmpeg 二进制 fMP4
+- 生命周期：浮窗/side Tab 通过 `/api/ego/watch/*` 获取租约；隐藏、页面后台或 dispose 时释放
+- renderer：CDP 用 `<img>` + rAF 最新帧；FFmpeg 用 generation-aware `MediaSource` + `<video>`
 - 坐标交互：`makeDraggable`（球/窗口各自拖动）、`browserXY`（坐标逆映射）
 - 状态：`pageMeta`（vw/vh）、`frameCache`、`lastList`
 - 提醒条：`maybeShowLoginGuide` / `maybeShowCaptchaGuide`（读 `space.humanCheck`）
@@ -71,11 +79,9 @@ ego-browser/
 
 ## 4. bin/ego-cast-worker.mjs — 观察窗 worker
 
-独立 Node 进程，attach 到 agent 浏览器，负责：
-- CDP 连接 / 重连（`runConnectLoop`）
-- screencast 池 + SSE 实时帧（`createCastPool` / `sseBroadcast`）
-- 每页 viewport（`updateViewport`）与 humanCheck 探针（`probeHuman`，节流 5s）
-- 输入回传（`/api/input` → `Input.dispatchMouseEvent`）
+独立 Node 进程，attach 到 agent 浏览器。控制面由 `TargetSessions` 持有，捕获停止时输入、viewport 与 humanCheck 不依赖 screencast session。`CaptureManager` 维护 lease、backend、target 与 generation；CDP/FFmpeg 后端只负责画面生产。JPEG 留在 SSE，fMP4 走独立二进制响应并处理背压。
+
+CDP 帧必须使用 `params.sessionId` 作为 `Page.screencastFrameAck` 参数，同时使用事件外层 session 作为命令路由 session。不要再次把二者合并。
 
 **改动需重启 worker**（DSH 的 cast-server 检测到 worker 死后会重启，或手动重启）。
 worker 与 lib/index.js 的探针逻辑（humanCheck）是两份相似实现——改动一处要同步另一处，

--- a/docs/ARCH.md
+++ b/docs/ARCH.md
@@ -17,12 +17,15 @@ ego-browser/
   package.json          # 版本号、build=语法校验、exports
   lib/index.js          # [后端] 插件入口 + 30+ ego_* 工具注册（权威）
   lib/cast-server.js    # [后端] host 路由：把前端 /api/ego/* 转发到观察窗 worker
+  lib/ffmpeg-installation.js # [后端] FFmpeg 检测、下载、校验与托管缓存
+  lib/ffmpeg-manifest.js # 固定平台资源、版本、SHA-256 与 GitHub 镜像改写
   lib/client.js         # [前端] 右下角观察窗（通过 DSH 注入加载，单文件）
   bin/ego-cast-worker.mjs  # [后端] 观察窗 worker：attach 浏览器、SSE 实时画面、humanCheck
   bin/cdp-client.mjs       # CDP 请求/错误/事件封装
   bin/capture-manager.mjs  # watcher lease、单后端状态机、generation
   bin/capture-cdp.mjs      # control session + 单 target JPEG capture
   bin/capture-ffmpeg.mjs   # FFmpeg 进程与 fMP4 发布
+  bin/ffmpeg-probe.mjs     # 可执行性、平台输入与 H.264 编码器探测
   bin/capture-platform.mjs # 平台来源/crop/argv
   bin/mp4-fragments.mjs    # 有界 ISO BMFF box parser
   runtime/              # vendored ego-lite 运行时（只读参照，本地改动见 runtime/PATCHES.md）
@@ -74,6 +77,7 @@ ego-browser/
 - 坐标交互：`makeDraggable`（球/窗口各自拖动）、`browserXY`（坐标逆映射）
 - 键盘交互：画面点击聚焦透明 textarea；beforeinput/composition 发送 `Input.insertText`，控制键/快捷键发送 keyDown/keyUp。禁止 document 全局键盘监听
 - 状态：`pageMeta`（vw/vh）、`frameCache`、`lastList`
+- FFmpeg 设置：`/ego/api/ffmpeg-*` 读取宿主安装状态；未通过检测时 `<option value="ffmpeg">` 必须禁用，不能只依赖后端启动失败兜底
 - 提醒条：`maybeShowLoginGuide` / `maybeShowCaptchaGuide`（读 `space.humanCheck`）
 
 ---
@@ -87,6 +91,8 @@ watch lease TTL 为 120 秒，抵抗浏览器后台定时器节流。host 对 st
 CDP 帧必须使用 `params.sessionId` 作为 `Page.screencastFrameAck` 参数，同时使用事件外层 session 作为命令路由 session。不要再次把二者合并。
 
 Windows FFmpeg 后端必须走 `Browser.getWindowForTarget` + Win32 顶层窗口枚举匹配 HWND，再使用 `gfxcapture`。禁止恢复 `gdigrab desktop` fallback：它会在 Chrome 被遮挡时串流用户前台应用。`h264_mf` 的能力探针必须使用真实 D3D11 窗口输入，不能用 `lavfi` 软件帧代替。
+
+FFmpeg 二进制不属于 worker 生命周期。宿主 `FfmpegInstallationManager` 按自定义路径、PATH、托管缓存的顺序检测，并把最终 `ffmpegResolvedPath` 作为运行态配置传给 worker。托管下载必须固定 manifest 和 SHA-256，临时目录完成校验/解压/探测后才能原子发布；CDP 路径不得触发下载。
 
 **改动需重启 worker**（DSH 的 cast-server 检测到 worker 死后会重启，或手动重启）。
 worker 与 lib/index.js 的探针逻辑（humanCheck）是两份相似实现——改动一处要同步另一处，

--- a/docs/ARCH.md
+++ b/docs/ARCH.md
@@ -69,9 +69,10 @@ ego-browser/
 
 维护时要同步注意：
 - 数据源：`/api/ego/stream` 提供元数据、CDP JPEG 与 capture status；`/api/ego/video` 提供 FFmpeg 二进制 fMP4
-- 生命周期：浮窗/side Tab 通过 `/api/ego/watch/*` 获取租约；隐藏、页面后台或 dispose 时释放
+- 生命周期：浮窗/side Tab 通过 `/api/ego/watch/*` 获取租约；组件逻辑隐藏或 dispose 时释放，`document.hidden` 不释放，以避免后台切换重建 WGC/FFmpeg
 - renderer：CDP 用 `<img>` + rAF 最新帧；FFmpeg 用 generation-aware `MediaSource` + `<video>`
 - 坐标交互：`makeDraggable`（球/窗口各自拖动）、`browserXY`（坐标逆映射）
+- 键盘交互：画面点击聚焦透明 textarea；beforeinput/composition 发送 `Input.insertText`，控制键/快捷键发送 keyDown/keyUp。禁止 document 全局键盘监听
 - 状态：`pageMeta`（vw/vh）、`frameCache`、`lastList`
 - 提醒条：`maybeShowLoginGuide` / `maybeShowCaptchaGuide`（读 `space.humanCheck`）
 
@@ -81,7 +82,11 @@ ego-browser/
 
 独立 Node 进程，attach 到 agent 浏览器。控制面由 `TargetSessions` 持有，捕获停止时输入、viewport 与 humanCheck 不依赖 screencast session。`CaptureManager` 维护 lease、backend、target 与 generation；CDP/FFmpeg 后端只负责画面生产。JPEG 留在 SSE，fMP4 走独立二进制响应并处理背压。
 
+watch lease TTL 为 120 秒，抵抗浏览器后台定时器节流。host 对 start/switch 使用 30 秒 POST 超时并透传 worker 状态；其他控制请求保持短超时。FFmpeg 能力探针不得使用 `spawnSync`，否则会阻塞 health 并触发 sibling worker 误替换。
+
 CDP 帧必须使用 `params.sessionId` 作为 `Page.screencastFrameAck` 参数，同时使用事件外层 session 作为命令路由 session。不要再次把二者合并。
+
+Windows FFmpeg 后端必须走 `Browser.getWindowForTarget` + Win32 顶层窗口枚举匹配 HWND，再使用 `gfxcapture`。禁止恢复 `gdigrab desktop` fallback：它会在 Chrome 被遮挡时串流用户前台应用。`h264_mf` 的能力探针必须使用真实 D3D11 窗口输入，不能用 `lavfi` 软件帧代替。
 
 **改动需重启 worker**（DSH 的 cast-server 检测到 worker 死后会重启，或手动重启）。
 worker 与 lib/index.js 的探针逻辑（humanCheck）是两份相似实现——改动一处要同步另一处，

--- a/docs/plans/2026-08-17-dual-capture-pipeline-design.md
+++ b/docs/plans/2026-08-17-dual-capture-pipeline-design.md
@@ -1,0 +1,945 @@
+# ego-browser 双画面管线设计与实施计划
+
+日期：2026-08-17
+
+状态：设计已确认，待实施
+
+## 1. 目标
+
+为观察窗提供两套可由用户选择的画面后端：
+
+1. `cdp`：修复并优化现有 `Page.startScreencast` JPEG 管线。
+2. `ffmpeg`：捕获真实浏览器窗口或显示输出，编码为低延迟 H.264 视频流。
+
+两套后端共用现有 CDP 控制面，包括标签发现、当前页面识别、viewport、鼠标输入、标签关闭、登录落盘和验证码检测。后端切换只替换画面生产和前端播放方式，不重写浏览器控制逻辑。
+
+主要验收目标：
+
+- 滚动时画面连续，不再依赖 5 秒 `captureScreenshot` 兜底刷新。
+- 默认配置下观察窗达到稳定 15-20 FPS。
+- CDP 后端修复后不通过高频强制截图换取流畅度。
+- FFmpeg 后端在支持的平台使用视频编码降低传输和前端解码压力。
+- 面板关闭或不可见时停止昂贵的画面生产。
+- 任一后端失败时给出可诊断状态，不静默伪装成功。
+- 不启动或修改 `dsh web`；实际 UI 验收由人类完成。
+
+## 2. 已确认决策
+
+### 2.1 后端选择
+
+新增配置：
+
+```text
+captureBackend: auto | cdp | ffmpeg
+```
+
+- `auto` 默认选择 `cdp`。CDP 无系统屏幕权限、支持后台窗口和 headless，仍是最稳妥的默认值。
+- `cdp` 强制使用 CDP JPEG 管线。
+- `ffmpeg` 强制使用 FFmpeg 视频管线。启动失败时前端展示失败原因和“切回 CDP”操作，不静默降级。
+
+### 2.2 FFmpeg 分发
+
+- 通过 npm 包提供 FFmpeg，不要求用户手工安装。
+- 首选依赖 `ffmpeg-static`，覆盖 Windows、Linux、macOS 及常见 x64/ARM 架构。
+- 必须在 `THIRD_PARTY_NOTICES.md` 和 README 中记录 npm 包及其实际分发二进制的许可证。`ffmpeg-static` 包当前为 GPL-3.0-or-later，不能按纯 MIT 依赖处理。
+- 安装阶段下载失败、平台无对应二进制或二进制不可执行时，FFmpeg 后端应明确标记为 unavailable，CDP 后端仍可工作。
+
+### 2.3 FFmpeg 播放协议
+
+首版采用：
+
+```text
+FFmpeg H.264 -> fragmented MP4 -> HTTP chunked binary stream -> MediaSource -> <video>
+```
+
+不在首版引入 WebRTC，原因如下：
+
+- 当前主要是本机 worker 到本机 DSH Web，不需要 NAT 穿透。
+- WebRTC 需要额外的原生 WebRTC 栈、RTP 打包和信令。
+- HTTP chunked + MSE 可以复用现有 host 代理模式，复杂度显著更低。
+- MSE 不依赖 WebCodecs 的 secure-context 条件，兼容性更稳。
+
+若后续需要跨公网观看、拥塞控制或音视频同步，再将 WebRTC 作为第三后端评估，不污染本次双后端设计。
+
+### 2.4 Wayland
+
+Wayland 首次启用允许弹出 XDG Desktop Portal 选择窗口并由用户授权。
+
+必须明确：标准 `ffmpeg-static` 当前提供的 FFmpeg 6.1.1 不能保证包含尚未稳定进入主线的 PipeWire portal 抓屏输入。因此实施分两级：
+
+1. 优先探测 FFmpeg 是否具备可用的 `pipewiregrab` 或等价输入；具备则走 Portal/PipeWire。
+2. 不具备时，FFmpeg 后端在 Wayland 显示“当前随包 FFmpeg 不支持 Portal 捕获”，允许切回 CDP。
+
+不使用需要 root 或 `CAP_SYS_ADMIN` 的 `kmsgrab` 作为默认方案。若项目要求 Wayland FFmpeg 后端必须无条件可用，则需要另行维护一个启用 PipeWire portal 的自定义 FFmpeg npm 二进制包；该工作作为独立发布项，不在普通 `ffmpeg-static` 接入中假装已经解决。
+
+## 3. 当前根因
+
+现有 worker 的帧 ACK 使用了错误的 session ID：
+
+```js
+cdp.call("Page.screencastFrameAck", { sessionId }, sessionId)
+```
+
+这里两个值含义不同：
+
+- 第三个参数应是 flattened CDP target session ID，用于把命令发给正确页面。
+- ACK 参数中的 `sessionId` 必须是 `Page.screencastFrame` 事件 `params.sessionId` 提供的帧会话编号。
+
+正确形式：
+
+```js
+cdp.call(
+  "Page.screencastFrameAck",
+  { sessionId: params.sessionId },
+  targetSessionId,
+)
+```
+
+错误 ACK 会导致 Chrome 认为帧未被消费并停止持续发送，现象与“滚动后预览停住，直到截图兜底触发”一致。
+
+当前还有以下资源放大因素：
+
+- 为所有页面注入无限透明动画，持续强制 compositor 重绘。
+- 最多为 30 个页面保持 screencast，而不是只为实际观看页面工作。
+- 活动标签默认不限帧。
+- JPEG Base64 经 worker SSE、host SSE 和 EventSource/JSON 多次复制。
+- rAF 只减少 `<img>` 解码次数，不能阻止上游编码、Base64 解析和字符串分配。
+- 浮动观察窗即使收起，也可能继续保持画面订阅。
+
+因此 CDP 后端必须先修复协议和生命周期，不能继续依赖把 backstop 调到 200ms。
+
+## 4. 总体架构
+
+```text
+                         CDP browser connection
+                                  |
+                 +----------------+----------------+
+                 |                                 |
+           control plane                      capture manager
+    targets / active / viewport / input       backend lifecycle
+                 |                                 |
+                 |                  +--------------+--------------+
+                 |                  |                             |
+                 |             CDP backend                  FFmpeg backend
+                 |        JPEG screencast frames      OS capture -> H.264/fMP4
+                 |                  |                             |
+                 +------------------+--------------+--------------+
+                                                    |
+                                              worker HTTP API
+                                      metadata SSE + selected media stream
+                                                    |
+                                               host proxy
+                                                    |
+                                    +---------------+---------------+
+                                    |                               |
+                              <img> renderer                  <video> renderer
+                                  CDP                              FFmpeg
+```
+
+核心原则：
+
+- 一个 worker 中同时只能有一个活动画面后端。
+- 一个 FFmpeg worker 同时只编码一个当前观看 target。
+- CDP 后端也只实时推送当前观看 target；其他标签只保留元数据和可选低频缩略图。
+- 标签切换不改变输入 API，前端始终用目标页面 CSS viewport 坐标发送 CDP 输入。
+- 视频流和元数据流分离。JPEG 可继续走 SSE；H.264/fMP4 必须走二进制 HTTP。
+
+## 5. 统一后端契约
+
+在 worker 内建立 `CaptureManager`，避免 HTTP 路由直接操作具体后端。
+
+建议契约：
+
+```js
+backend.start({ targetId, sessionId, viewport, clientId })
+backend.switchTarget({ targetId, sessionId, viewport })
+backend.updateConfig(config)
+backend.stop(reason)
+backend.status()
+```
+
+后端事件：
+
+```js
+onStatus({ backend, state, targetId, message, metrics })
+onJpegFrame({ targetId, data, vw, vh, ts })
+onVideoInit({ targetId, mime, width, height, generation })
+onVideoChunk(buffer)
+```
+
+状态机：
+
+```text
+idle
+  -> starting
+  -> streaming
+  -> switching
+  -> streaming
+  -> stopping
+  -> idle
+
+starting/switching/streaming
+  -> failed
+  -> idle after explicit retry or backend change
+```
+
+每次启动或切换视频流生成递增 `generation`。前端只接受当前 generation，防止旧 FFmpeg 进程退出时残留 chunk 污染新流。
+
+## 6. 订阅与生命周期
+
+### 6.1 客户端订阅
+
+画面后端不应由“浏览器进程存在”触发，而应由“至少一个可见观察窗正在观看”触发。
+
+新增 worker API：
+
+```text
+POST /api/watch/start
+  { clientId, backend, targetId }
+
+POST /api/watch/switch
+  { clientId, targetId }
+
+POST /api/watch/stop
+  { clientId }
+
+GET /api/watch/status
+```
+
+规则：
+
+- sidebar Tab 可见或浮动面板展开时 `start`。
+- Tab 隐藏、浮动面板收起、页面进入 `visibilitychange=hidden` 一段时间后 `stop`。
+- 使用 1-2 秒 idle grace，避免快速开关导致进程抖动。
+- worker 维护 client lease；客户端异常断开后租约超时自动释放。
+- 多个前端客户端同时观看时，首版采用单节目源：最后一次明确选择的 target 成为当前流，所有客户端观看同一 target。
+- 若未来需要每客户端独立 target，再扩展多路编码；首版避免多 FFmpeg 进程。
+
+### 6.2 worker 生命周期
+
+- 没有观看者时停止 `Page.startScreencast` 或 FFmpeg 子进程。
+- 元数据 SSE 可以保留低频 keepalive，但不携带画面。
+- 浏览器 CDP 断线时停止后端，状态变为 `failed/browser-disconnected`。
+- 浏览器恢复连接后不自动开始昂贵捕获，只有仍存在有效 lease 才恢复。
+- 配置切换后端时，严格执行 stop old -> drain -> start new。
+
+## 7. CDP 后端详细设计
+
+### 7.1 ACK 修复
+
+事件处理器必须同时保留：
+
+- `params.sessionId`：帧 ACK ID。
+- 外层 `targetSessionId`：flattened CDP session。
+
+ACK 应尽快发出，不等待前端消费。CDP screencast 自身不适合作为跨层背压机制；应用层通过丢中间帧控制资源。
+
+`Cdp.call()` 还应识别 CDP 返回中的 `error` 并 reject。当前只按 `id` resolve，会吞掉错误 ACK、错误 start/stop 等协议问题，导致故障不可见。
+
+### 7.2 移除强制重绘
+
+删除或默认禁用 `FORCE_REPAINT_SCRIPT`：
+
+- 不再给每个页面注入无限 CSS 动画。
+- 不再依赖 compositor 空转制造帧。
+- 静态页没有新帧是正常状态。
+- 视频或 canvas 若 Chromium screencast 本身仍无法产生帧，交由 FFmpeg 后端解决，而不是让所有页面持续重绘。
+
+若保留诊断开关，只允许显式 debug 配置启用，不进入普通设置 UI。
+
+### 7.3 帧率与背压
+
+新增配置：
+
+```text
+cdpFps: 5-30，默认 20
+cdpQuality: 1-100，默认 55
+cdpMaxWidth: 320-1920，默认 960
+cdpBackstopIntervalMs: 1000-10000，默认 3000
+```
+
+处理策略：
+
+1. 每个源帧立即正确 ACK。
+2. 如果距上次发送不足 `1000 / cdpFps`，只覆盖 `pendingLatestFrame`。
+3. 到发送时间只广播最新帧一次。
+4. 若下游响应 `write()` 返回 `false`，标记客户端 congested，在 `drain` 前不继续写 JPEG，只保留最新帧。
+5. SSE 客户端持续阻塞或断开时清理。
+
+这里的目标不是“保证每一帧送达”，而是“保证最新画面尽快送达”。远控预览中旧帧没有价值。
+
+### 7.4 target 范围
+
+- 仅对当前观看 target 调用 `Page.startScreencast`。
+- 切换 target 时先 stop 旧 target，再 attach/start 新 target。
+- 元数据列表仍可展示最多 30 个页面，但不为每页持续编码。
+- 历史抽屉缩略图使用最后缓存帧，不要求后台实时更新。
+
+### 7.5 backstop
+
+- backstop 只用于静态页首次画面、导航后丢首帧和异常恢复。
+- 滚动流畅度不得依赖 backstop。
+- backstop 只针对当前观看 target。
+- `captureScreenshot` 必须带与 screencast 相同的质量和最大尺寸约束；必要时使用 `clip`/缩放，而不是原始全分辨率截图。
+
+## 8. FFmpeg 后端详细设计
+
+### 8.1 进程模型
+
+每个 worker 最多一个 FFmpeg 子进程：
+
+```text
+resolve capture source
+  -> probe encoder
+  -> spawn ffmpeg
+  -> parse stdout fMP4 boxes
+  -> publish init segment
+  -> publish media fragments
+```
+
+进程要求：
+
+- `stdin` 用于发送 `q` 做优雅停止。
+- `stdout` 只承载 fMP4 二进制。
+- `stderr` 使用有界环形缓冲，保留最后 32-64 KB 供诊断。
+- 启动超时默认 8 秒；超时或在首个 init segment 前退出视为失败。
+- stop 时先写 `q`，等待 1.5 秒，再 SIGTERM，最后才强制终止。
+- 进程退出必须关闭对应视频 HTTP 响应，促使前端重新建流。
+
+### 8.2 编码参数
+
+默认平衡档：
+
+```text
+fps=20
+maxWidth=1280
+codec=h264
+pixelFormat=yuv420p
+gop=20
+bFrames=0
+softwarePreset=ultrafast
+tune=zerolatency
+```
+
+软件编码基线：
+
+```text
+-c:v libx264
+-preset ultrafast
+-tune zerolatency
+-profile:v baseline
+-pix_fmt yuv420p
+-g 20
+-keyint_min 20
+-sc_threshold 0
+-bf 0
+-an
+-movflags empty_moov+default_base_moof+frag_keyframe
+-frag_duration 500000
+-f mp4 pipe:1
+```
+
+为了降低首帧等待，关键帧间隔不超过 1 秒，fragment 建议 250-500ms。实际参数需以 MSE 是否能及时 append 和播放为准，不能只看 FFmpeg 是否成功启动。
+
+### 8.3 硬件编码
+
+新增配置：
+
+```text
+ffmpegEncoder: auto | software | h264_nvenc | h264_qsv | h264_amf |
+                h264_videotoolbox | h264_vaapi
+```
+
+`auto` 不是只检查 `ffmpeg -encoders` 列表，而要做一次短的真实编码 probe；编码器被编译进去不代表本机驱动可用。
+
+优先级：
+
+- Windows：NVENC -> QSV -> AMF -> libx264。
+- macOS：VideoToolbox -> libx264。
+- Linux：NVENC -> VAAPI/QSV -> libx264。
+
+硬件输入/像素格式转换失败时，可以回退软件编码，但必须在状态中报告实际使用的编码器。
+
+### 8.4 画质档位
+
+```text
+low:
+  15 FPS, 960px, 较高压缩
+
+balanced:
+  20 FPS, 1280px, 默认
+
+high:
+  30 FPS, 1600px, 更高码率
+```
+
+底层仍保留高级字段，UI 首版优先展示档位，避免普通用户面对大量 FFmpeg 参数。
+
+码率策略优先使用 CRF/CQ，不以固定超高码率浪费静态页面带宽。低延迟优先于完美压缩率。
+
+## 9. 平台捕获适配
+
+### 9.1 通用窗口与内容区域定位
+
+FFmpeg 应尽量只编码网页 viewport，不包含 Chrome 标签栏和系统标题栏，否则前端坐标无法直接映射到 CDP CSS viewport。
+
+通过目标页面 `Runtime.evaluate` 获取：
+
+```js
+({
+  screenX,
+  screenY,
+  outerWidth,
+  outerHeight,
+  innerWidth,
+  innerHeight,
+  devicePixelRatio,
+})
+```
+
+结合 `Browser.getWindowForTarget` / `Browser.getWindowBounds` 计算窗口和内容区域。平台适配层返回统一结构：
+
+```js
+{
+  sourceType,
+  sourceId,
+  captureX,
+  captureY,
+  captureWidth,
+  captureHeight,
+  contentWidthCss,
+  contentHeightCss,
+  scaleFactor,
+}
+```
+
+坐标映射验收必须覆盖：
+
+- Windows 显示缩放 100%、125%、150%。
+- macOS Retina DPR。
+- Linux X11 fractional scaling。
+- 窗口移动和 resize 后重新计算 capture rect。
+
+### 9.2 Windows
+
+首版输入：
+
+- 兼容路径：`gdigrab`。
+- 优化路径：探测可用时使用 `ddagrab`。
+
+窗口识别优先使用 HWND，而不是标题字符串：网页标题会变化且可能重复。可用小型 PowerShell 探针根据 browser PID 枚举可见顶层窗口并返回 HWND/bounds；探针只做发现，不持续轮询。
+
+若具体 FFmpeg build 支持 `hwnd=` 输入，直接按 HWND 捕获；否则捕获桌面后按 bounds crop。
+
+限制：
+
+- 桌面 crop 路径会受到遮挡、最小化和虚拟桌面影响。
+- `ddagrab` 捕获显示输出，仍不是 Chrome 内部 surface。
+- 检测到最小化或连续黑帧时报告 `capture-source-not-visible`。
+
+### 9.3 Linux X11
+
+使用 `x11grab`：
+
+```text
+-f x11grab -framerate N -video_size WxH -i DISPLAY+X,Y
+```
+
+窗口 XID 和几何信息可以通过现有系统工具或轻量 X11 helper 探测。不能假设 `xdotool`/`xwininfo` 一定安装；若不增加原生模块，优先使用浏览器 JS + CDP bounds 计算 display crop。
+
+在 Xvfb/headless 环境中，只要 Chromium 和 FFmpeg 共享同一 `DISPLAY`，该后端可工作。
+
+### 9.4 macOS
+
+`ffmpeg-static` 的 avfoundation 路径以显示捕获为主：
+
+- 首次使用触发系统“屏幕录制”权限。
+- 捕获对应显示后按窗口内容 bounds crop。
+- 使用 `h264_videotoolbox` 作为首选编码器。
+
+前端必须区分：
+
+- 尚未授权。
+- 用户拒绝授权。
+- 授权后需要重启宿主进程。
+- 没找到目标窗口或窗口不在可捕获显示上。
+
+macOS 单窗口无侵入捕获若要求遮挡时仍正确，后续应改用 ScreenCaptureKit 原生 helper；avfoundation display crop 不能提供同等保证。
+
+### 9.5 Wayland
+
+检测：
+
+```text
+XDG_SESSION_TYPE=wayland 或 WAYLAND_DISPLAY 存在
+```
+
+流程：
+
+1. 请求 XDG Desktop Portal ScreenCast session。
+2. 用户在系统窗口中选择 ego Chrome 窗口。
+3. 获得 PipeWire node/FD。
+4. 若随包 FFmpeg 支持 PipeWire portal 输入，将 node 交给 FFmpeg。
+5. 否则状态置为 `unsupported-ffmpeg-pipewire`，提示切回 CDP。
+
+禁止默认使用：
+
+- root 权限 `kmsgrab`。
+- 自动切换整个桌面捕获而不告知用户。
+- 假装 portal 授权成功但实际继续展示 CDP JPEG。
+
+若后续发布自定义 FFmpeg npm 包，应按 OS/arch 拆分 optionalDependencies，避免所有用户下载所有平台二进制。
+
+## 10. 二进制流协议
+
+### 10.1 worker 路由
+
+```text
+GET /api/video/status
+GET /api/video/stream?generation=N
+POST /api/watch/start
+POST /api/watch/switch
+POST /api/watch/stop
+```
+
+`/api/video/stream` 响应：
+
+```text
+Content-Type: video/mp4
+Cache-Control: no-store
+Transfer-Encoding: chunked
+X-Ego-Generation: N
+X-Ego-Backend: ffmpeg
+```
+
+只允许当前 generation 建立流。旧 generation 返回 409，前端重新读取 status。
+
+### 10.2 host 代理
+
+新增 `/api/ego/video` 精确路由，使用 `node:http.request` 原样转发二进制 chunk，禁止：
+
+- 使用 `fetch().arrayBuffer()` 缓冲整段。
+- 转为 Base64。
+- 经 SSE 或 JSON 包装。
+- 在 host 内重封装 MP4。
+
+代理必须处理 `backpressure`：下游 `res.write()` 返回 `false` 时暂停上游 `upRes.pause()`，`drain` 后 `resume()`。
+
+### 10.3 MP4 分片
+
+worker 需要一个小型 ISO BMFF box splitter，至少识别 32 位 box length 和以下 box：
+
+```text
+ftyp, moov, moof, mdat
+```
+
+- `ftyp+moov` 作为 init segment 缓存。
+- `moof+mdat` 作为媒体 fragment。
+- 新客户端先收到 init segment，再收到后续 fragment。
+- box 长度异常或超过合理上限时终止流并报告协议错误。
+
+不要假设 Node stdout 的 `data` chunk 正好对齐 MP4 box。
+
+## 11. 前端播放器
+
+### 11.1 统一控制器状态
+
+`LivePreviewController` 增加：
+
+```js
+backend
+streamState
+streamMessage
+streamGeneration
+actualEncoder
+videoElement
+mediaSource
+sourceBuffer
+appendQueue
+```
+
+React sidebar 和浮动面板继续共用控制器逻辑，避免实现两套不同的数据面。
+
+### 11.2 CDP renderer
+
+- 保留 `<img>`。
+- 继续使用 rAF 合帧。
+- 修正缓存为最新帧覆盖，不因为 Map 重复 set 误判 LRU。
+- 仅面板可见时建立帧订阅。
+
+### 11.3 FFmpeg renderer
+
+- 使用 `<video muted autoplay playsInline>`。
+- 建立 `MediaSource`，创建 `video/mp4; codecs="avc1.42E01E"` 或由 worker status 返回的实际 codec string。
+- 通过 `fetch('/api/ego/video')` 读取 `ReadableStream`。
+- append queue 串行调用 `SourceBuffer.appendBuffer()`。
+- 始终保持低延迟：当 `video.buffered` 落后 live edge 超过 500-800ms，跳到接近最新时间。
+- 缓冲超过 2-3 秒时删除旧 range，防止长时间观看内存增长。
+- generation 变化、SourceBuffer error、视频停滞或 fetch 断开时完整销毁 MediaSource 后重建，不能复用污染状态。
+
+### 11.4 UI 状态
+
+观察窗显示简洁状态：
+
+```text
+CDP · 20 FPS
+FFmpeg · H.264 · VideoToolbox
+正在请求屏幕权限
+窗口被最小化或遮挡
+Wayland FFmpeg 不支持，请切回 CDP
+```
+
+设置卡提供：
+
+- 捕获后端。
+- 画质档位。
+- 高级区域中的 FPS、最大宽度、编码器。
+- “检测 FFmpeg 能力”按钮及检测结果。
+
+## 12. 配置模型
+
+建议最终配置：
+
+```js
+{
+  chromePath: "",
+
+  captureBackend: "auto",
+  streamProfile: "balanced",
+
+  cdpFps: 20,
+  cdpQuality: 55,
+  cdpMaxWidth: 960,
+  cdpBackstopIntervalMs: 3000,
+
+  ffmpegFps: 20,
+  ffmpegMaxWidth: 1280,
+  ffmpegEncoder: "auto",
+  ffmpegPath: "",
+}
+```
+
+兼容策略：
+
+- 现有 `castFpsCap` 映射到 `cdpFps`。
+- 现有 `screencastQuality` 映射到 `cdpQuality`。
+- 现有 `screencastMaxWidth` 映射到 `cdpMaxWidth`。
+- 现有 `backstopIntervalMs` 映射到 `cdpBackstopIntervalMs`。
+
+由于这些值已可能持久化，允许一个版本周期读取旧字段，但保存时只写新字段。迁移逻辑应集中在 `resolveConfig()`，不要散落在 worker 和前端。
+
+## 13. 指标与诊断
+
+worker 每 2 秒计算滑动指标，但只在 status 请求或低频 `metrics` SSE 事件中发送：
+
+```js
+{
+  backend,
+  sourceFps,
+  sentFps,
+  droppedFrames,
+  bytesPerSecond,
+  ackErrors,
+  downstreamBlockedMs,
+  captureLatencyMs,
+  encoder,
+  targetId,
+}
+```
+
+CDP 重点关注：
+
+- screencastFrame 到达频率。
+- ACK 错误。
+- 限帧丢弃数。
+- SSE 背压时间。
+
+FFmpeg 重点关注：
+
+- 首个 init segment 时间。
+- 编码进程 CPU 和退出码。
+- fMP4 parser 错误。
+- MSE 缓冲延迟。
+- 黑帧/停滞检测。
+
+日志不得逐帧输出，只记录状态切换和聚合指标，避免日志本身造成卡顿。
+
+## 14. 错误处理与降级
+
+错误码建议：
+
+```text
+cdp-ack-failed
+cdp-start-failed
+browser-disconnected
+ffmpeg-not-installed
+ffmpeg-not-executable
+ffmpeg-encoder-unavailable
+ffmpeg-capture-source-missing
+capture-permission-required
+capture-permission-denied
+capture-source-not-visible
+unsupported-ffmpeg-pipewire
+video-stream-corrupt
+video-player-unsupported
+```
+
+行为：
+
+- `captureBackend=auto`：仅启动前能力检测失败时可选 CDP；运行中故障不反复自动切换，避免画面闪烁和难诊断。
+- `captureBackend=ffmpeg`：失败后保持明确错误，提供用户操作切换。
+- `captureBackend=cdp`：FFmpeg 不参与探测或启动。
+- 任何错误都不得影响 `ego_*` 浏览器工具本身；观察窗失败必须是旁路故障。
+
+## 15. 安全与隐私
+
+- FFmpeg 后端捕获操作系统窗口/显示，范围可能超出网页内容，必须在启用时明确提示。
+- 默认只捕获 ego 浏览器窗口或其内容区域，不默认捕获整个桌面。
+- Wayland/macOS 系统授权必须由用户明确完成。
+- 视频接口继续绑定 loopback worker，并经 DSH host 路由访问，不暴露独立公网端口。
+- `/api/watch/*` 和 `/api/video/*` 复用 DSH 现有会话边界；若 host 路由未来可被跨站调用，需要增加 origin/CSRF 检查。
+- FFmpeg 命令参数必须使用 argv 数组，不拼接 shell 字符串；窗口标题、DISPLAY 和路径不得进入 shell。
+
+## 16. 文件改动规划
+
+计划修改：
+
+```text
+package.json
+  添加 ffmpeg-static 依赖，更新 scripts/tests
+
+lib/config.js
+  新配置 schema、旧字段迁移、默认值
+
+lib/index.d.ts
+  配置类型同步
+
+lib/settings.js
+  新配置桥接
+
+lib/cast-server.js
+  watch API 代理、视频二进制代理、背压
+
+lib/client.js
+  双 renderer、MSE 播放器、可见性订阅、设置 UI、状态提示
+
+bin/ego-cast-worker.mjs
+  CaptureManager、统一状态、路由接线、CDP 控制面保留
+
+bin/capture-cdp.mjs
+  正确 ACK、单 target、限帧、latest-frame 背压
+
+bin/capture-ffmpeg.mjs
+  FFmpeg 生命周期、编码 probe、fMP4 输出
+
+bin/capture-platform.mjs
+  Windows/X11/macOS/Wayland 来源发现和参数生成
+
+bin/mp4-fragments.mjs
+  有界 ISO BMFF box parser
+
+tests/*.test.mjs
+  配置、ACK、背压、MP4 parser、命令生成、生命周期测试
+
+README.md
+CHANGELOG.md
+THIRD_PARTY_NOTICES.md
+docs/ARCH.md
+```
+
+是否拆 `bin/*.mjs` 的判断：worker 已超过 1000 行，双后端继续内联会显著增加维护风险，因此这里允许按职责拆模块；不拆前端 `lib/client.js`，因为 DSH 客户端注入仍要求单文件 bundle。
+
+## 17. 测试计划
+
+### 17.1 单元测试
+
+CDP：
+
+- `screencastFrameAck` 使用 `params.sessionId` 作为 ACK 参数。
+- flattened target session ID 仍作为命令 session 参数。
+- `Cdp.call()` 对 CDP `error` reject。
+- 20 FPS 限制下 60 FPS 输入只发送约 20 FPS，并始终发送最新帧。
+- 下游阻塞时不堆积所有 JPEG。
+- 无 watcher 时不启动 screencast。
+- target 切换会 stop 旧 stream。
+
+FFmpeg：
+
+- 各平台 argv 生成不经过 shell。
+- encoder probe 成功、失败和软件回退。
+- 启动超时、异常退出和优雅 stop。
+- stdout 任意切块情况下正确重组 `ftyp/moov/moof/mdat`。
+- 非法 box length、超大 box 和截断流安全失败。
+- 新订阅者先收到 init segment。
+- generation 切换隔离旧进程 chunk。
+
+配置：
+
+- 默认值。
+- 数值边界。
+- 旧字段迁移。
+- `captureBackend` 非法值回落。
+
+### 17.2 集成测试
+
+使用 fake FFmpeg Node fixture：
+
+- 周期输出预生成 fMP4 fragments。
+- 验证 worker 二进制路由不 Base64 化。
+- 验证 host 代理保持 chunk 顺序。
+- 模拟下游 `drain`，验证 pause/resume。
+- 模拟进程崩溃，验证前端 generation 重建。
+
+使用 mock CDP WebSocket：
+
+- 发送滚动期间连续 `Page.screencastFrame`。
+- 断言每帧 ACK 正确。
+- 模拟导航、target 销毁和浏览器重连。
+
+### 17.3 性能测试
+
+固定场景：
+
+1. 960x720 页面连续滚动 30 秒。
+2. 动画/canvas 页面 30 秒。
+3. 1080p 视频页面 30 秒。
+4. 静态页面空闲 60 秒。
+5. 面板关闭 60 秒。
+
+记录：
+
+- worker CPU/内存。
+- Chrome CPU/GPU。
+- DSH 前端 CPU/内存。
+- 平均 FPS、P95 帧间隔。
+- 端到端视觉延迟。
+- 每秒传输字节。
+
+目标基线：
+
+```text
+CDP 滚动：>= 15 FPS，P95 帧间隔 < 120ms
+FFmpeg 滚动：>= 18 FPS，P95 帧间隔 < 90ms
+面板关闭：不运行 FFmpeg，不保持 Page.startScreencast
+静态页：不因透明动画持续满帧合成
+前端缓冲：通常 < 800ms，不持续增长
+```
+
+绝对 CPU 数字与硬件相关，不设不现实的统一百分比；以同机现有版本为基线，要求明显下降并记录测试机器配置。
+
+### 17.4 人工跨平台验收
+
+Windows：
+
+- Chrome 窗口移动、缩放、125% DPI。
+- GDI 与可用硬件编码器。
+- 窗口遮挡和最小化提示。
+
+Linux X11/Xvfb：
+
+- `DISPLAY` 来源正确。
+- 浏览器和 FFmpeg 同显示。
+- 软件编码与 VAAPI/NVENC 可用性。
+
+Wayland：
+
+- Portal 授权流程。
+- 随包 FFmpeg 不支持 PipeWire 时错误信息准确。
+- 切回 CDP 后功能正常。
+
+macOS：
+
+- 首次屏幕录制权限。
+- Retina 坐标映射。
+- VideoToolbox。
+- 拒绝权限后的恢复指引。
+
+## 18. 实施阶段
+
+### 阶段 A：修复和量化 CDP
+
+1. 为 `Cdp.call()` 增加协议 error reject。
+2. 修复 screencast ACK。
+3. 删除默认强制重绘。
+4. 实现单 target 订阅。
+5. 实现 FPS 限制和 latest-frame 背压。
+6. 增加聚合指标。
+7. 补单元和 mock CDP 测试。
+8. 跑 `pnpm test`、`pnpm run build`。
+
+阶段验收：连续滚动不再落到 backstop；关闭面板后 screencast 停止。
+
+### 阶段 B：统一 CaptureManager 与路由
+
+1. 引入统一后端状态机。
+2. 增加 watch lease API。
+3. 改造 sidebar 和浮动面板可见性生命周期。
+4. 保持 CDP 后端功能完整。
+5. 增加 host/worker 状态代理测试。
+
+阶段验收：在尚未加入 FFmpeg 时，CDP 已完全经统一接口运行。
+
+### 阶段 C：FFmpeg 核心视频流
+
+1. 添加 `ffmpeg-static`。
+2. 实现二进制路径解析和能力检测。
+3. 实现 FFmpeg 进程生命周期。
+4. 实现 fMP4 parser 和 init/media fragment 广播。
+5. 实现 worker/host 二进制 HTTP 流及背压。
+6. 使用 fake FFmpeg 完成自动测试。
+
+阶段验收：测试视频源可在前端 `<video>` 连续播放，流不经过 Base64。
+
+### 阶段 D：前端双 renderer
+
+1. 增加 MSE player。
+2. 增加 backend 和 profile 设置。
+3. 实现切换清理和 generation 重连。
+4. 增加低延迟追帧和旧 buffer 清理。
+5. 同步 sidebar 与浮动面板。
+
+阶段验收：运行中可在 CDP/FFmpeg 间切换，无双重捕获、无旧流串入。
+
+### 阶段 E：平台适配
+
+1. Windows gdigrab/硬件编码。
+2. Linux X11/Xvfb。
+3. macOS avfoundation/权限/VideoToolbox。
+4. Wayland Portal 能力探测和明确失败路径。
+5. 逐平台人工坐标和遮挡测试。
+
+阶段验收：每个平台要么成功使用 FFmpeg，要么给出准确、可操作的限制信息；CDP 始终可用。
+
+### 阶段 F：文档与发布准备
+
+1. 更新 README 使用说明、权限和限制。
+2. 更新 ARCH 双后端架构。
+3. 更新 CHANGELOG。
+4. 更新第三方许可证。
+5. 检查 npm/git 安装时 `ffmpeg-static` 二进制获取行为。
+6. 跑完整测试和 build。
+7. 由人类重启 `dsh web` 并完成浏览器硬刷新验收。
+
+## 19. 实施顺序中的停止条件
+
+以下情况应停止继续堆功能并先解决根因：
+
+- ACK 修复后 CDP 仍没有滚动帧：先用 CDP 协议日志确认 Chrome 是否发帧，不立即恢复 200ms 截图。
+- MSE 必须积累超过 1 秒才能播放：先调整 fragment/GOP，不接受以高延迟完成“能播”。
+- FFmpeg 捕获区域包含错误窗口或敏感桌面内容：停止发布该平台后端。
+- Wayland 随包 FFmpeg 无 PipeWire 支持：按设计报告不支持，不使用 root workaround。
+- 引入 `ffmpeg-static` 导致插件安装策略与 DSH bundle 规则冲突：先确定预构建/依赖分发方案，不把二进制手工提交进 `lib/`。
+
+## 20. 完成定义
+
+- CDP ACK 正确并有回归测试。
+- 滚动场景不依赖高频 screenshot backstop。
+- 用户可在设置中选择 `auto/cdp/ffmpeg`。
+- FFmpeg 视频为二进制 H.264/fMP4，不经过 SSE/Base64。
+- sidebar 和浮动面板均支持双 renderer。
+- 面板不可见时停止画面后端。
+- 所有后端和平台失败都有明确状态。
+- 单元、集成、build 全部通过。
+- Windows、Linux X11、Wayland、macOS 的支持范围和限制有文档。
+- 第三方许可证完整。
+- 人类完成 DSH Web 中的滚动、切换、输入坐标和资源占用验收。

--- a/docs/plans/2026-08-17-windows-gfxcapture-validation.md
+++ b/docs/plans/2026-08-17-windows-gfxcapture-validation.md
@@ -1,0 +1,146 @@
+# Windows gfxcapture 可行性验证
+
+日期：2026-08-17
+
+## 结论
+
+方案可行。Windows 上使用 FFmpeg `gfxcapture` 按 HWND 捕获 ego Chrome，能够直接取得目标窗口的 D3D11 surface，不再依赖桌面坐标。窗口被其他应用遮挡或移动后，采集仍保持目标 Chrome 内容。
+
+推荐的数据路径：
+
+```text
+Chrome HWND
+  -> Windows.Graphics.Capture / D3D11
+  -> fps=30 + 连续时间戳
+  -> h264_mf 硬件编码
+  -> 100ms fragmented MP4
+  -> 现有 Mp4FragmentParser / MediaSource
+```
+
+## 验证环境
+
+- ego Chrome PID：`2612`
+- ego Chrome HWND：`19797640`（`0x12E1688`）
+- 初始窗口 bounds：`395,99 1280x900`
+- 捕获内容尺寸：`1264x892`
+- 下载位置：`C:\Users\Administrator\AppData\Local\Temp\opencode\ffmpeg-master-latest-win64-gpl`
+- FFmpeg：`N-126188-g426841da9d-20260817`
+- 构建来源：`BtbN/FFmpeg-Builds` 的 `ffmpeg-master-latest-win64-gpl.zip`
+
+该构建确认包含：
+
+- `gfxcapture` source filter
+- `hwnd` 精确窗口选择
+- D3D11 硬件帧输出
+- `h264_mf`、`h264_nvenc`、`h264_qsv`、`h264_amf`
+
+## 功能验证
+
+### 精确窗口捕获
+
+使用 `gfxcapture=hwnd=19797640` 成功输出 ego Chrome 的 `1264x892` 页面内容。
+
+同一时刻分别截图：
+
+- `gfxcapture(hwnd)`：仍显示目标 ego Chrome 的猫视频页面。
+- 旧 `gdigrab desktop crop`：显示覆盖该屏幕区域的另一张 Bilibili 页面。
+
+这证明 `gfxcapture` 取得的是目标窗口 surface，而不是用户当前可见桌面像素。
+
+### 窗口移动
+
+将目标窗口从 `(395,99)` 临时移动到 `(40,40)` 后，原 HWND 继续输出正确页面。验证结束后窗口已恢复到 `(395,99)`。
+
+### H.264 和 fMP4
+
+`gfxcapture` 的 D3D11 帧可以直接交给 `h264_mf`：
+
+```text
+MFT name: NVIDIA H.264 Encoder MFT
+codec: H.264 Constrained Baseline
+resolution: 1264x892
+rate: 30 FPS
+```
+
+输出的 fragmented MP4 可由现有 `Mp4FragmentParser` 解析。2 秒、100ms 分片测试得到：
+
+```json
+{"init":809,"fragments":20,"mediaBytes":39156,"averageFragmentBytes":1958}
+```
+
+## 性能结果
+
+10 秒、30 FPS、D3D11 直通 `h264_mf`：
+
+```text
+wall time:          10.356s
+FFmpeg CPU time:     0.328s
+single-core usage:   3.2%
+whole-machine usage: 0.26% (12 logical processors)
+exit code:           0
+```
+
+100ms fMP4 分片时序：
+
+```text
+init segment:          487ms
+first media fragment:  545ms
+steady fragment gap:    94ms average
+```
+
+首次启动包含 FFmpeg、WGC 和编码器初始化；稳定串流分片间隔满足低于 300ms 的目标。
+
+## 验证中发现的必要修正
+
+### 不可只设置 max_framerate
+
+本机报告：
+
+```text
+Setting minimum update interval unavailable, framerate may be limited
+```
+
+仅设置 `max_framerate=30` 时，compositor 仍可能按更高更新率交付帧并产生重复时间戳。过滤链必须显式加入：
+
+```text
+fps=30,setpts=N/(30*TB)
+```
+
+### 必须跳过 MP4 trailer
+
+现有 parser 不接受 FFmpeg 正常结束时写出的 `mfra` box。流式输出应增加：
+
+```text
+movflags=empty_moov+default_base_moof+frag_keyframe+skip_trailer
+```
+
+否则优雅停止时会触发 `unexpected MP4 media box mfra`。
+
+### 分片时长应从 500ms 降到 100ms
+
+当前实现使用 `frag_duration=500000`，仅 muxer 分片就会引入约 500ms 延迟，不满足低于 300ms 的目标。验证表明 `frag_duration=100000` 可稳定产生约 100ms 的媒体分片。
+
+### NVENC 不应是唯一硬编路径
+
+master 构建要求 NVENC API 13.1，而本机驱动提供 13.0，直接 `h264_nvenc` 失败。`h264_mf -hw_encoding 1` 成功选择 NVIDIA H.264 Encoder MFT，并保持 D3D11 硬件帧路径。
+
+Windows 编码器优先级建议：
+
+```text
+h264_mf hardware -> h264_nvenc/qsv/amf probe -> libx264 fallback
+```
+
+## 实现边界
+
+本轮未启动 `dsh web`，未改动插件运行代码，仅验证底层捕获、编码、分片和 parser 兼容性。
+
+正式实现仍需完成：
+
+1. 从 `browser.json` 读取 browser PID。
+2. 枚举该进程的可见顶层窗口并取得 HWND。
+3. 多 Chrome 窗口时，结合 `Browser.getWindowForTarget` bounds 匹配 target 与 HWND。
+4. 探测 FFmpeg 是否包含 `gfxcapture` 和可用硬件编码器。
+5. 将 Windows `desktop crop` 替换为 `gfxcapture(hwnd)`，不可静默回退到桌面采集。
+6. 处理 resize、窗口关闭、最小化和 target 切换。
+7. 决定支持 `gfxcapture` 的 Windows FFmpeg 二进制分发方式；当前 `ffmpeg-static@5.2.0` 不满足要求。
+8. 完成 worker 到浏览器 MediaSource 的端到端延迟验证。

--- a/docs/plans/2026-08-18-ffmpeg-on-demand-install-design.md
+++ b/docs/plans/2026-08-18-ffmpeg-on-demand-install-design.md
@@ -1,0 +1,62 @@
+# FFmpeg On-Demand Installation Design
+
+## Goal
+
+Keep the CDP capture backend independent of FFmpeg. Detect compatible local
+FFmpeg installations first, and only download a pinned platform build after an
+explicit user action. The FFmpeg backend remains unavailable until a binary has
+passed platform capture and H.264 encoder probes.
+
+## Sources
+
+- Windows and Linux: pinned BtbN GitHub release tags and assets.
+- macOS Intel/Apple Silicon: pinned `ffmpeg-static` GitHub release assets whose
+  upstream binaries originate from Evermeet and OSXExperts respectively.
+
+Every asset is identified by an exact URL and SHA-256 digest. Floating `latest`
+or snapshot URLs are not allowed. GitHub URLs may be rewritten by replacing
+`https://github.com` with the configured HTTPS mirror base. Non-GitHub sources
+are not rewritten.
+
+## Resolution
+
+Candidates are checked in this order:
+
+1. User-configured `ffmpegPath`.
+2. `ffmpeg` from `PATH`.
+3. The plugin-managed cache.
+
+An invalid candidate does not block later candidates. Windows requires
+`gfxcapture`; macOS requires `avfoundation`; Linux requires X11 and `x11grab`.
+All platforms require a usable H.264 encoder. Wayland remains unsupported.
+
+## Installation
+
+The host owns a single installation manager. It downloads into a temporary
+directory under `~/.dsh/cache/ego-browser/ffmpeg`, verifies the archive hash,
+extracts only the declared FFmpeg executable, applies platform permissions,
+probes the installed binary, writes `install.json`, and atomically renames the
+temporary directory into place. Interrupted or failed installs never become
+selectable.
+
+The host exposes status, recheck, and install endpoints. Downloading continues
+if the settings page closes, and duplicate install requests share one task.
+
+## Settings UI
+
+The settings card shows source, version, path, progress, and failure details.
+It adds `githubMirror`, recheck, and download/reinstall controls. The FFmpeg
+backend option is disabled until host status reports `canSelectFfmpeg: true`.
+The settings gateway also rejects attempts to save FFmpeg while unavailable.
+
+If a previously valid binary disappears, capture falls back to CDP for that
+watch session and reports the reason without silently rewriting persisted
+settings.
+
+## Verification
+
+Tests cover manifest selection, mirror rewriting, checksums, safe extraction,
+candidate priority, platform probes, concurrent installs, gateway rejection,
+UI disabling, progress states, and CDP fallback. Manual validation covers
+Windows gfxcapture, macOS permissions and VideoToolbox, Linux X11, and explicit
+Wayland rejection.

--- a/docs/plans/2026-08-18-input-status-space-design.md
+++ b/docs/plans/2026-08-18-input-status-space-design.md
@@ -1,0 +1,63 @@
+# 输入、状态与活动空间设计
+
+日期：2026-08-18
+
+## 目标
+
+- 鼠标控制不受画面后端状态短暂滞后影响。
+- 支持英文、中文 IME、粘贴、控制键和快捷键。
+- FFmpeg/CDP 标签反映 worker 真实状态，不因 SSE 丢失回退 CDP。
+- `ego_space_open` 后省略 `space` 的工具继续使用同一空间，不留下 about:blank 窗口。
+
+## 鼠标控制
+
+控制面与画面后端解耦。发送鼠标事件只要求组件逻辑可见、存在当前画面 target，且事件 target 与当前画面 target 一致。不依赖 `streamState`，也不等待 spaces 列表包含 target。
+
+worker 负责最终 target 校验。target 已关闭时返回 409 `capture-target-stale`；其他 CDP dispatch 错误返回 503 `input-dispatch-failed`。
+
+## 键盘输入
+
+视频区域点击后聚焦一个透明 textarea 输入代理。焦点只存在于观察窗内部，不监听 document 全局键盘事件，避免抢占 DSH 输入框和快捷键。
+
+- 普通文字和粘贴：`Input.insertText`。
+- 中文 IME：忽略 composition 中间值，仅在 `compositionend` 发送最终文本。
+- Enter、Tab、Escape、方向键、退格、Delete、Home/End/Page、F 键：`Input.dispatchKeyEvent` keyDown/keyUp。
+- Ctrl/Cmd/Alt/Shift 快捷键：转发 key、code、repeat 和 modifier bitmask。
+- printable key 不通过 keyDown 重复插入，文字统一由 beforeinput/insertText 路径发送。
+
+worker 输入协议新增 `insertText`、`keyDown`、`keyUp`，并限制文本长度及允许字段。
+
+## Capture 状态收敛
+
+前端通过一个统一函数应用 capture 状态，来源包括：
+
+- SSE `capture-status`。
+- `watch/start`、`watch/switch` 和续租响应。
+- `/api/ego/spaces` 响应中的 `capture`。
+- 面板启动和重连时的 `/api/ego/watch/status`。
+
+状态没有 `backend` 时保留当前值，禁止缺省覆盖为 CDP。watch 响应为 failed 时不标记 started，下一次同步可以重试。
+
+FFmpeg 配置且无 watcher 时显示 `FFmpeg · idle`；只有 worker 明确报告 CDP 时才显示 CDP。
+
+## 活动空间
+
+插件进程维护 `activeSpace`，初始值为配置的 `defaultSpace`。
+
+- `ego_space_open(name)` 成功后将 `activeSpace` 更新为返回的 space id，缺少 id 时使用 name。
+- 所有带可选 `space` 的结构化工具：显式参数优先，否则使用 `activeSpace`。
+- 显式操作某个 space 成功后，将它设为 active，保持后续调用一致。
+- 关闭当前 active space 后回退到 `defaultSpace`。
+
+该状态由现有 ego tool 全局互斥锁保护。插件已明确不支持多个独立 Harness 会话同时共享同一浏览器，因此不新增跨会话空间路由层。
+
+## 测试
+
+- 鼠标发送不依赖 streamState/spaces 同步。
+- composition 中间值不发送，最终中文只发送一次。
+- printable、控制键、快捷键 modifier 映射。
+- worker 文本和键盘 CDP 参数。
+- watch/status、watch 响应和 spaces capture 都能更新 backend。
+- 缺少 backend 的状态不覆盖当前 FFmpeg。
+- `ego_space_open("task")` 后省略 space 的 navigate/click 使用同一个空间。
+- 关闭 active space 后恢复默认空间。

--- a/docs/plans/2026-08-18-stream-quality-lifecycle-design.md
+++ b/docs/plans/2026-08-18-stream-quality-lifecycle-design.md
@@ -44,7 +44,7 @@ Windows Media Foundation 和其他码率编码器使用：
 
 host 的 worker POST 代理返回 `{ status, body }`，不再把所有非 2xx 或网络错误折叠成 `null`。
 
-- `watch/start`、`watch/switch`：12 秒超时，覆盖 worker 的 8 秒 MP4 init 超时。
+- `watch/start`、`watch/switch`：30 秒超时，覆盖窗口探测、编码器探测和 8 秒 MP4 init 的完整上限；FFmpeg 探针必须异步执行，启动期间 health 仍可响应。
 - input、stop、close、flush、config：保持短超时。
 - worker 返回 4xx/5xx 时，host 原样转发状态与 JSON 错误。
 - worker 不可达时才返回 502。

--- a/docs/plans/2026-08-18-stream-quality-lifecycle-design.md
+++ b/docs/plans/2026-08-18-stream-quality-lifecycle-design.md
@@ -1,0 +1,78 @@
+# FFmpeg 画质与后台生命周期设计
+
+日期：2026-08-18
+
+## 目标
+
+- 平衡档在约 1280x805、30 FPS 下默认使用 4 Mbps。
+- DSH 窗口进入后台时保持观察流连续，不反复销毁和重建 WGC/FFmpeg。
+- `watch/start` 不因 host 的短超时错误返回 502。
+- 输入请求不再把 worker 的目标失效错误统一包装成 500。
+- FFmpeg 启动失败必须在有限时间内从 `starting` 转为 `failed`。
+
+## 配置
+
+新增 `ffmpegBitrateKbps`：
+
+```text
+range: 500-20000
+step: 250
+low: 2000
+balanced: 4000
+high: 8000
+```
+
+Windows Media Foundation 和其他码率编码器使用：
+
+```text
+-b:v <bitrate>k
+-maxrate <bitrate * 1.25>k
+-bufsize <bitrate * 2>k
+```
+
+`libx264` 改为相同的目标码率模式，不再固定使用 `crf=28`。
+
+## 后台生命周期
+
+`document.visibilityState` 不再决定 watcher 生命周期。只要 sidebar Tab 或浮窗仍处于逻辑可见状态，SSE、video 和 watch lease 就保持连接。真正隐藏组件、卸载组件或关闭面板时才停止。
+
+浏览器后台会节流 JavaScript 定时器，因此 worker lease TTL 从 15 秒提高到 120 秒。客户端仍每 5 秒续租；即使续租被节流到约一分钟，也不会误停 capture。
+
+客户端为 `watch/start` 和 `watch/switch` 增加单一 in-flight 请求。启动请求未结束时，续租定时器不能再发送并发 start。
+
+## 代理与错误
+
+host 的 worker POST 代理返回 `{ status, body }`，不再把所有非 2xx 或网络错误折叠成 `null`。
+
+- `watch/start`、`watch/switch`：12 秒超时，覆盖 worker 的 8 秒 MP4 init 超时。
+- input、stop、close、flush、config：保持短超时。
+- worker 返回 4xx/5xx 时，host 原样转发状态与 JSON 错误。
+- worker 不可达时才返回 502。
+
+## 输入
+
+客户端仅在以下条件同时成立时发送输入：
+
+- 当前组件仍可见且未 dispose。
+- `streamState === "streaming"`。
+- target 仍存在于最新 spaces 列表。
+- target 与当前视频 target 一致。
+
+worker 在 target 已关闭或无法 attach 时返回 409 `capture-target-stale`。客户端收到 409 后刷新 spaces、清除当前 pointer 状态，不继续向旧 target 发送 move/release。
+
+## 状态机
+
+FFmpeg 启动阶段继续发布具体阶段：解析二进制、解析窗口、探测编码器、启动 capture。8 秒内未收到 MP4 init segment 时停止子进程并进入 `failed`。
+
+配置更新、目标切换和 watcher 恢复均通过 CaptureManager 的串行 transition 执行。重复 start 只续租，不创建第二个 FFmpeg 进程。
+
+## 测试
+
+- 配置默认值、profile 码率和显式覆盖。
+- FFmpeg argv 的 `b:v/maxrate/bufsize`。
+- `document.hidden` 不停止 watch，逻辑隐藏仍停止。
+- start in-flight 去重。
+- 12 秒 watch 代理和上游状态透传。
+- stale target 输入返回 409。
+- CaptureManager lease 在后台节流窗口内不超时。
+- 完整单元测试、语法构建和真实 worker FFmpeg 状态验证。

--- a/lib/cast-server.js
+++ b/lib/cast-server.js
@@ -88,17 +88,16 @@ async function proxyFrom(port, path) {
   }
 }
 
-/** Proxy a POST with a JSON body to the worker. Returns null on failure. */
-async function proxyPost(port, path, body) {
+/** Proxy a POST with a JSON body to the worker. Returns status and body, or null when unreachable. */
+export async function proxyPost(port, path, body, timeoutMs = 4000) {
   try {
     const r = await fetch(`http://127.0.0.1:${port}${path}`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(4000),
+      signal: AbortSignal.timeout(timeoutMs),
     });
-    if (!r.ok) return null;
-    return await r.json();
+    return { status: r.status, body: await r.json().catch(() => ({ ok: false, error: `worker returned ${r.status}` })) };
   } catch {
     return null;
   }
@@ -151,6 +150,7 @@ function proxyWorkerStream(port, res, path) {
     }
   );
   up.on('error', endOnce);
+  up.setTimeout(5000, () => { try { up.destroy(); } catch {} endOnce(); });
   up.end();
   const onClose = () => { cancelled = true; sseClients.delete(res); try { up.destroy(); } catch {} }; // don't end res here; let worker stream close it
   res.on('close', onClose);
@@ -185,6 +185,11 @@ function proxyWorkerVideo(port, req, res) {
   });
   upstream.on('error', () => {
     if (!res.headersSent) sendJson(res, 502, { ok: false, error: 'video worker unavailable' });
+    else end();
+  });
+  upstream.setTimeout(5000, () => {
+    try { upstream.destroy(); } catch {}
+    if (!res.headersSent) sendJson(res, 504, { ok: false, error: 'video worker timeout' });
     else end();
   });
   upstream.end();
@@ -302,7 +307,8 @@ function makePushConfig(ensureWorker) {
     if (payload === lastPush) return;
     lastPush = payload;
     try {
-      await proxyPost(port, '/api/config', JSON.parse(payload));
+      const result = await proxyPost(port, '/api/config', JSON.parse(payload));
+      if (!result || result.status >= 400) throw new Error('worker config update failed');
     } catch {
       // worker may be mid-restart; the next ensureWorker will re-seed via argv
     }
@@ -319,6 +325,7 @@ function captureConfig(cfg) {
     cdpBackstopIntervalMs: cfg.cdpBackstopIntervalMs,
     ffmpegFps: cfg.ffmpegFps,
     ffmpegMaxWidth: cfg.ffmpegMaxWidth,
+    ffmpegBitrateKbps: cfg.ffmpegBitrateKbps,
     ffmpegEncoder: cfg.ffmpegEncoder,
     ffmpegPath: cfg.ffmpegPath,
   };
@@ -401,8 +408,8 @@ export function initCastServer(ctx, cfg, bridge) {
       if (port === null) return sendJson(res, 400, { ok: false, error: 'no live agent browser' });
       const body = await readJsonBody(req).catch(() => ({}));
       const result = await proxyPost(port, '/api/input', body);
-      if (!result) return sendJson(res, 500, { ok: false, error: 'worker input failed' });
-      return sendJson(res, 200, result);
+      if (!result) return sendJson(res, 502, { ok: false, error: 'input worker unavailable' });
+      return sendJson(res, result.status, result.body);
     },
   });
 
@@ -418,8 +425,8 @@ export function initCastServer(ctx, cfg, bridge) {
       const targetId = typeof body.targetId === 'string' ? body.targetId : '';
       if (!targetId) return sendJson(res, 400, { ok: false, error: 'targetId required' });
       const result = await proxyPost(port, '/api/close', { targetId });
-      if (!result) return sendJson(res, 500, { ok: false, error: 'worker close failed' });
-      return sendJson(res, 200, result);
+      if (!result) return sendJson(res, 502, { ok: false, error: 'close worker unavailable' });
+      return sendJson(res, result.status, result.body);
     },
   });
 
@@ -431,8 +438,8 @@ export function initCastServer(ctx, cfg, bridge) {
       const port = await ensureWorker();
       if (port === null) return sendJson(res, 400, { ok: false, error: 'no live agent browser' });
       const result = await proxyPost(port, '/api/flush', {});
-      if (!result) return sendJson(res, 500, { ok: false, error: 'worker flush failed' });
-      return sendJson(res, 200, result);
+      if (!result) return sendJson(res, 502, { ok: false, error: 'flush worker unavailable' });
+      return sendJson(res, result.status, result.body);
     },
   });
 
@@ -456,8 +463,11 @@ export function initCastServer(ctx, cfg, bridge) {
     handler: async (req, res) => {
       const port = await ensureWorker();
       if (port === null) return sendJson(res, 409, { ok: false, error: 'worker not ready' });
-      const result = await proxyPost(port, workerPath, await readJsonBody(req).catch(() => ({})));
-      return sendJson(res, result ? 200 : 502, result || { ok: false, error: 'worker request failed' });
+       const timeoutMs = workerPath === '/api/watch/start' || workerPath === '/api/watch/switch' ? 30000 : 4000;
+       const result = await proxyPost(port, workerPath, await readJsonBody(req).catch(() => ({})), timeoutMs);
+       return result
+         ? sendJson(res, result.status, result.body)
+         : sendJson(res, 502, { ok: false, error: 'worker request failed' });
     },
   }));
   const disposeWatchStatus = server.register({

--- a/lib/cast-server.js
+++ b/lib/cast-server.js
@@ -245,7 +245,7 @@ function isProcessAlive(pid) {
  * initial screencast parameters. Subsequent config edits are pushed to a
  * running worker via POST /api/config (see pushConfig below).
  */
-function makeEnsureWorker(ctx, cfg) {
+function makeEnsureWorker(ctx, cfg, ffmpegManager) {
   let lastAttempt = 0;
   async function launchedWorkerPort() {
     const state = await knownWorkerState();
@@ -264,7 +264,8 @@ function makeEnsureWorker(ctx, cfg) {
         // Pass the current cast config to the worker as a JSON argv arg so it
         // starts with the right screencast parameters without needing an
         // extra round-trip POST. The worker reads process.argv[2].
-        const initCfg = JSON.stringify(captureConfig(cfg));
+        await ffmpegManager?.check({ configuredPath: cfg.ffmpegPath, requestedEncoder: cfg.ffmpegEncoder }).catch(() => null);
+        const initCfg = JSON.stringify(captureConfig(cfg, ffmpegManager));
         const handle = ctx.subprocess.spawn({
           argv: [process.execPath, WORKER_BIN, initCfg],
           stdio: {
@@ -296,12 +297,13 @@ function makeEnsureWorker(ctx, cfg) {
  * will take effect on the next worker spawn (argv seed). Called whenever the
  * settings layer reports a change.
  */
-function makePushConfig(ensureWorker) {
+function makePushConfig(ensureWorker, ffmpegManager) {
   let lastPush = '';
   return async function pushConfig(cfg) {
+    await ffmpegManager?.check({ configuredPath: cfg.ffmpegPath, requestedEncoder: cfg.ffmpegEncoder }).catch(() => null);
     const port = await ensureWorker();
     if (port === null) return;
-    const payload = JSON.stringify(captureConfig(cfg));
+    const payload = JSON.stringify(captureConfig(cfg, ffmpegManager));
     // Dedupe: don't re-push identical config (settings onChange can fire
     // multiple times for a single logical edit).
     if (payload === lastPush) return;
@@ -315,9 +317,12 @@ function makePushConfig(ensureWorker) {
   };
 }
 
-function captureConfig(cfg) {
+function captureConfig(cfg, ffmpegManager) {
+  const ffmpegStatus = ffmpegManager?.status();
+  const unavailable = cfg.captureBackend === "ffmpeg" && !ffmpegStatus?.canSelectFfmpeg;
   return {
-    captureBackend: cfg.captureBackend,
+    captureBackend: unavailable ? "cdp" : cfg.captureBackend,
+    ffmpegFallbackReason: unavailable ? (ffmpegStatus?.reason || "FFmpeg is unavailable") : "",
     streamProfile: cfg.streamProfile,
     cdpFps: cfg.cdpFps,
     cdpQuality: cfg.cdpQuality,
@@ -328,6 +333,7 @@ function captureConfig(cfg) {
     ffmpegBitrateKbps: cfg.ffmpegBitrateKbps,
     ffmpegEncoder: cfg.ffmpegEncoder,
     ffmpegPath: cfg.ffmpegPath,
+    ffmpegResolvedPath: ffmpegStatus?.canSelectFfmpeg ? ffmpegStatus.path : "",
   };
 }
 
@@ -343,9 +349,9 @@ function captureConfig(cfg) {
  * `bridge` is the settings bridge — its `onChange` is used to react to
  * live settings saves and push the new config to a running worker.
  */
-export function initCastServer(ctx, cfg, bridge) {
-  const ensureWorker = makeEnsureWorker(ctx, cfg);
-  const pushConfig = makePushConfig(ensureWorker);
+export function initCastServer(ctx, cfg, bridge, ffmpegManager) {
+  const ensureWorker = makeEnsureWorker(ctx, cfg, ffmpegManager);
+  const pushConfig = makePushConfig(ensureWorker, ffmpegManager);
   // The web shell exposes `webServer` (the only HTTP host surface the plugin
   // declares in inject). We deliberately reach for `webServer` alone: touching
   // an undeclared `httpServer` on a strict-inject host would trip the

--- a/lib/cast-server.js
+++ b/lib/cast-server.js
@@ -23,6 +23,12 @@ export const EGO_HEALTH_ROUTE = '/api/ego/health';
 export const EGO_CLOSE_ROUTE = '/api/ego/close';
 export const EGO_FLUSH_ROUTE = '/api/ego/flush';
 export const EGO_INPUT_ROUTE = '/api/ego/input';
+export const EGO_WATCH_START_ROUTE = '/api/ego/watch/start';
+export const EGO_WATCH_SWITCH_ROUTE = '/api/ego/watch/switch';
+export const EGO_WATCH_STOP_ROUTE = '/api/ego/watch/stop';
+export const EGO_WATCH_STATUS_ROUTE = '/api/ego/watch/status';
+export const EGO_VIDEO_ROUTE = '/api/ego/video';
+export const EGO_VIDEO_STATUS_ROUTE = '/api/ego/video/status';
 
 // ── tool-call signal (auto-open sidebar Tab) ─────────────────────────────
 // Module-level counter bumped by markEgoToolCall() from the tool execute
@@ -133,7 +139,12 @@ function proxyWorkerStream(port, res, path) {
     (upRes) => {
       upRes.on('data', (chunk) => {
         if (cancelled || ended) return;
-        try { res.write(chunk); } catch { cancelled = true; endOnce(); }
+        try {
+          if (!res.write(chunk)) {
+            upRes.pause();
+            res.once('drain', () => { if (!cancelled && !ended) upRes.resume(); });
+          }
+        } catch { cancelled = true; endOnce(); }
       });
       upRes.on('end', endOnce);
       upRes.on('error', endOnce);
@@ -144,6 +155,51 @@ function proxyWorkerStream(port, res, path) {
   const onClose = () => { cancelled = true; sseClients.delete(res); try { up.destroy(); } catch {} }; // don't end res here; let worker stream close it
   res.on('close', onClose);
   return () => { cancelled = true; sseClients.delete(res); try { up.destroy(); } catch {} };
+}
+
+function proxyWorkerVideo(port, req, res) {
+  const sourceUrl = new URL(req.url || EGO_VIDEO_ROUTE, 'http://dsh.internal');
+  const generation = sourceUrl.searchParams.get('generation');
+  const path = `/api/video/stream${generation ? `?generation=${encodeURIComponent(generation)}` : ''}`;
+  let upstream;
+  let ended = false;
+  const end = () => { if (ended) return; ended = true; try { res.end(); } catch {} };
+  upstream = request({ host: '127.0.0.1', port, path, method: 'GET', headers: { accept: 'video/mp4' } }, (upRes) => {
+    res.writeHead(upRes.statusCode || 502, {
+      'content-type': upRes.headers['content-type'] || 'application/octet-stream',
+      'cache-control': 'no-store',
+      ...(upRes.headers['x-ego-generation'] ? { 'x-ego-generation': upRes.headers['x-ego-generation'] } : {}),
+      ...(upRes.headers['x-ego-backend'] ? { 'x-ego-backend': upRes.headers['x-ego-backend'] } : {}),
+    });
+    upRes.on('data', (chunk) => {
+      if (ended) return;
+      try {
+        if (!res.write(chunk)) {
+          upRes.pause();
+          res.once('drain', () => { if (!ended) upRes.resume(); });
+        }
+      } catch { upstream.destroy(); end(); }
+    });
+    upRes.on('end', end);
+    upRes.on('error', end);
+  });
+  upstream.on('error', () => {
+    if (!res.headersSent) sendJson(res, 502, { ok: false, error: 'video worker unavailable' });
+    else end();
+  });
+  upstream.end();
+  res.on('close', () => { ended = true; try { upstream.destroy(); } catch {} });
+}
+
+async function readJsonBody(req, maxBytes = 8192) {
+  const chunks = [];
+  let bytes = 0;
+  for await (const chunk of req) {
+    bytes += chunk.length;
+    if (bytes > maxBytes) throw new Error('body too large');
+    chunks.push(Buffer.from(chunk));
+  }
+  return JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}');
 }
 
 /** Read the worker's { port, pid } from ego-cast.json, if any. */
@@ -203,12 +259,7 @@ function makeEnsureWorker(ctx, cfg) {
         // Pass the current cast config to the worker as a JSON argv arg so it
         // starts with the right screencast parameters without needing an
         // extra round-trip POST. The worker reads process.argv[2].
-        const initCfg = JSON.stringify({
-          castFpsCap: cfg.castFpsCap,
-          screencastQuality: cfg.screencastQuality,
-          screencastMaxWidth: cfg.screencastMaxWidth,
-          backstopIntervalMs: cfg.backstopIntervalMs,
-        });
+        const initCfg = JSON.stringify(captureConfig(cfg));
         const handle = ctx.subprocess.spawn({
           argv: [process.execPath, WORKER_BIN, initCfg],
           stdio: {
@@ -218,8 +269,14 @@ function makeEnsureWorker(ctx, cfg) {
           },
           graceMs: 12_000,
         });
-        const done = handle.done.then(() => launchedWorkerPort()).catch(() => null);
-        return await Promise.race([done, new Promise((r) => setTimeout(() => r(null), 8000))]);
+        handle.done.catch(() => null);
+        const deadline = Date.now() + 8000;
+        while (Date.now() < deadline) {
+          const ready = await launchedWorkerPort();
+          if (ready !== null) return ready;
+          await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+        return null;
       } catch {
         return null;
       }
@@ -239,12 +296,7 @@ function makePushConfig(ensureWorker) {
   return async function pushConfig(cfg) {
     const port = await ensureWorker();
     if (port === null) return;
-    const payload = JSON.stringify({
-      castFpsCap: cfg.castFpsCap,
-      screencastQuality: cfg.screencastQuality,
-      screencastMaxWidth: cfg.screencastMaxWidth,
-      backstopIntervalMs: cfg.backstopIntervalMs,
-    });
+    const payload = JSON.stringify(captureConfig(cfg));
     // Dedupe: don't re-push identical config (settings onChange can fire
     // multiple times for a single logical edit).
     if (payload === lastPush) return;
@@ -254,6 +306,21 @@ function makePushConfig(ensureWorker) {
     } catch {
       // worker may be mid-restart; the next ensureWorker will re-seed via argv
     }
+  };
+}
+
+function captureConfig(cfg) {
+  return {
+    captureBackend: cfg.captureBackend,
+    streamProfile: cfg.streamProfile,
+    cdpFps: cfg.cdpFps,
+    cdpQuality: cfg.cdpQuality,
+    cdpMaxWidth: cfg.cdpMaxWidth,
+    cdpBackstopIntervalMs: cfg.cdpBackstopIntervalMs,
+    ffmpegFps: cfg.ffmpegFps,
+    ffmpegMaxWidth: cfg.ffmpegMaxWidth,
+    ffmpegEncoder: cfg.ffmpegEncoder,
+    ffmpegPath: cfg.ffmpegPath,
   };
 }
 
@@ -332,12 +399,7 @@ export function initCastServer(ctx, cfg, bridge) {
     handler: async (req, res) => {
       const port = await ensureWorker();
       if (port === null) return sendJson(res, 400, { ok: false, error: 'no live agent browser' });
-      const body = await new Promise((resolve) => {
-        let data = '';
-        req.on('data', (c) => { data += c; });
-        req.on('end', () => { try { resolve(JSON.parse(data || '{}')) } catch { resolve({}) } });
-        req.on('error', () => resolve({}));
-      });
+      const body = await readJsonBody(req).catch(() => ({}));
       const result = await proxyPost(port, '/api/input', body);
       if (!result) return sendJson(res, 500, { ok: false, error: 'worker input failed' });
       return sendJson(res, 200, result);
@@ -352,12 +414,7 @@ export function initCastServer(ctx, cfg, bridge) {
       const port = await ensureWorker();
       if (port === null) return sendJson(res, 400, { ok: false, error: 'no live agent browser' });
       // Collect the request body (small JSON: { targetId }).
-      const body = await new Promise((resolve) => {
-        let data = '';
-        req.on('data', (c) => { data += c; });
-        req.on('end', () => { try { resolve(JSON.parse(data || '{}')) } catch { resolve({}) } });
-        req.on('error', () => resolve({}));
-      });
+      const body = await readJsonBody(req).catch(() => ({}));
       const targetId = typeof body.targetId === 'string' ? body.targetId : '';
       if (!targetId) return sendJson(res, 400, { ok: false, error: 'targetId required' });
       const result = await proxyPost(port, '/api/close', { targetId });
@@ -390,6 +447,44 @@ export function initCastServer(ctx, cfg, bridge) {
     },
   });
 
+  const watchRoutes = [
+    [EGO_WATCH_START_ROUTE, '/api/watch/start'],
+    [EGO_WATCH_SWITCH_ROUTE, '/api/watch/switch'],
+    [EGO_WATCH_STOP_ROUTE, '/api/watch/stop'],
+  ].map(([path, workerPath]) => server.register({
+    kind: 'exact', path,
+    handler: async (req, res) => {
+      const port = await ensureWorker();
+      if (port === null) return sendJson(res, 409, { ok: false, error: 'worker not ready' });
+      const result = await proxyPost(port, workerPath, await readJsonBody(req).catch(() => ({})));
+      return sendJson(res, result ? 200 : 502, result || { ok: false, error: 'worker request failed' });
+    },
+  }));
+  const disposeWatchStatus = server.register({
+    kind: 'exact', path: EGO_WATCH_STATUS_ROUTE,
+    handler: async (_req, res) => {
+      const port = await ensureWorker();
+      const result = port === null ? null : await proxyFrom(port, '/api/watch/status');
+      return sendJson(res, 200, result || { ok: false, state: 'idle', reason: 'worker not ready' });
+    },
+  });
+  const disposeVideoStatus = server.register({
+    kind: 'exact', path: EGO_VIDEO_STATUS_ROUTE,
+    handler: async (_req, res) => {
+      const port = await ensureWorker();
+      const result = port === null ? null : await proxyFrom(port, '/api/video/status');
+      return sendJson(res, 200, result || { ok: false, state: 'idle', reason: 'worker not ready' });
+    },
+  });
+  const disposeVideo = server.register({
+    kind: 'exact', path: EGO_VIDEO_ROUTE,
+    handler: async (req, res) => {
+      const port = await ensureWorker();
+      if (port === null) return sendJson(res, 502, { ok: false, error: 'worker not ready' });
+      proxyWorkerVideo(port, req, res);
+    },
+  });
+
   ctx.effect(() => () => {
     try { disposeSpaces() } catch {}
     try { disposeStream() } catch {}
@@ -397,5 +492,9 @@ export function initCastServer(ctx, cfg, bridge) {
     try { disposeClose() } catch {}
     try { disposeFlush() } catch {}
     try { disposeHealth() } catch {}
+    for (const dispose of watchRoutes) try { dispose() } catch {}
+    try { disposeWatchStatus() } catch {}
+    try { disposeVideoStatus() } catch {}
+    try { disposeVideo() } catch {}
   });
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -51,7 +51,7 @@ window.__ModuleLoader__.load({
 			intro: 'Agent browser integration. Configure the Chrome/Chromium binary path and cast parameters below.',
 			chromePath: 'Browser binary path',
 			chromePathHint: 'Path to the Chrome/Chromium/Edge binary. Empty = auto-detect.',
-			captureBackend: 'Capture backend', streamProfile: 'Quality profile', cdpFps: 'CDP FPS', cdpQuality: 'CDP JPEG quality', cdpMaxWidth: 'CDP max width', cdpBackstopIntervalMs: 'CDP recovery interval', ffmpegFps: 'FFmpeg FPS', ffmpegMaxWidth: 'FFmpeg max width', ffmpegEncoder: 'FFmpeg encoder', ffmpegPath: 'FFmpeg binary path', fpsUnit: 'fps', pxUnit: 'px', msUnit: 'ms',
+			captureBackend: 'Capture backend', streamProfile: 'Quality profile', cdpFps: 'CDP FPS', cdpQuality: 'CDP JPEG quality', cdpMaxWidth: 'CDP max width', cdpBackstopIntervalMs: 'CDP recovery interval', ffmpegFps: 'FFmpeg FPS', ffmpegMaxWidth: 'FFmpeg max width', ffmpegBitrateKbps: 'FFmpeg bitrate', ffmpegEncoder: 'FFmpeg encoder', ffmpegPath: 'FFmpeg binary path', fpsUnit: 'fps', pxUnit: 'px', kbpsUnit: 'kbps', msUnit: 'ms',
 			save: 'Save', saving: 'Saving…', discard: 'Discard',
 			unsaved: 'Unsaved', readOnly: 'Settings are read-only in this deployment.',
 			namespaceUnavailable: 'The ego-browser configuration channel is unavailable. Please retry later.',
@@ -63,7 +63,7 @@ window.__ModuleLoader__.load({
 			intro: 'Agent 浏览器集成。在下方配置 Chrome/Chromium 浏览器路径及推流参数。',
 			chromePath: '浏览器路径',
 			chromePathHint: 'Chrome/Chromium/Edge 可执行文件路径。留空 = 自动检测。',
-			captureBackend: '捕获后端', streamProfile: '画质档位', cdpFps: 'CDP 帧率', cdpQuality: 'CDP JPEG 质量', cdpMaxWidth: 'CDP 最大宽度', cdpBackstopIntervalMs: 'CDP 恢复截图间隔', ffmpegFps: 'FFmpeg 帧率', ffmpegMaxWidth: 'FFmpeg 最大宽度', ffmpegEncoder: 'FFmpeg 编码器', ffmpegPath: 'FFmpeg 路径', fpsUnit: 'fps', pxUnit: 'px', msUnit: 'ms',
+			captureBackend: '捕获后端', streamProfile: '画质档位', cdpFps: 'CDP 帧率', cdpQuality: 'CDP JPEG 质量', cdpMaxWidth: 'CDP 最大宽度', cdpBackstopIntervalMs: 'CDP 恢复截图间隔', ffmpegFps: 'FFmpeg 帧率', ffmpegMaxWidth: 'FFmpeg 最大宽度', ffmpegBitrateKbps: 'FFmpeg 码率', ffmpegEncoder: 'FFmpeg 编码器', ffmpegPath: 'FFmpeg 路径', fpsUnit: 'fps', pxUnit: 'px', kbpsUnit: 'kbps', msUnit: 'ms',
 			save: '保存', saving: '保存中…', discard: '放弃',
 			unsaved: '未保存', readOnly: '当前部署下设置只读。',
 			namespaceUnavailable: 'ego-browser 配置通道不可用，请稍后重试。',
@@ -77,7 +77,7 @@ window.__ModuleLoader__.load({
 				status: 'idle',        // 'idle' | 'loading' | 'ready'
 				available: false,      // true after a successful /ego/api/get
 				writable: false,       // false when settings service is absent
-				draft: { chromePath: '', captureBackend: 'auto', streamProfile: 'balanced', cdpFps: '20', cdpQuality: '55', cdpMaxWidth: '960', cdpBackstopIntervalMs: '3000', ffmpegFps: '20', ffmpegMaxWidth: '1280', ffmpegEncoder: 'auto', ffmpegPath: '' },
+				draft: { chromePath: '', captureBackend: 'auto', streamProfile: 'balanced', cdpFps: '20', cdpQuality: '55', cdpMaxWidth: '960', cdpBackstopIntervalMs: '3000', ffmpegFps: '20', ffmpegMaxWidth: '1280', ffmpegBitrateKbps: '4000', ffmpegEncoder: 'auto', ffmpegPath: '' },
 				dirty: false,
 				applyState: { kind: 'idle' }, // 'idle' | 'saving' | 'saved' | 'error'
 				errorMessage: undefined,
@@ -124,7 +124,7 @@ window.__ModuleLoader__.load({
 					chromePath: config.chromePath || '',
 					captureBackend: config.captureBackend || 'auto', streamProfile: config.streamProfile || 'balanced',
 					cdpFps: String(config.cdpFps ?? 20), cdpQuality: String(config.cdpQuality ?? 55), cdpMaxWidth: String(config.cdpMaxWidth ?? 960), cdpBackstopIntervalMs: String(config.cdpBackstopIntervalMs ?? 3000),
-					ffmpegFps: String(config.ffmpegFps ?? 20), ffmpegMaxWidth: String(config.ffmpegMaxWidth ?? 1280), ffmpegEncoder: config.ffmpegEncoder || 'auto', ffmpegPath: config.ffmpegPath || '',
+					ffmpegFps: String(config.ffmpegFps ?? 20), ffmpegMaxWidth: String(config.ffmpegMaxWidth ?? 1280), ffmpegBitrateKbps: String(config.ffmpegBitrateKbps ?? 4000), ffmpegEncoder: config.ffmpegEncoder || 'auto', ffmpegPath: config.ffmpegPath || '',
 				}
 				s.dirty = false
 				s.applyState = { kind: 'idle' }
@@ -164,7 +164,7 @@ window.__ModuleLoader__.load({
 			var gen = ++this.generation
 			var patch = {}
 			var NUMERIC_FIELDS = {
-				cdpFps: { min: 5, max: 30, def: 20 }, cdpQuality: { min: 1, max: 100, def: 55 }, cdpMaxWidth: { min: 320, max: 1920, def: 960 }, cdpBackstopIntervalMs: { min: 1000, max: 10000, def: 3000 }, ffmpegFps: { min: 5, max: 30, def: 20 }, ffmpegMaxWidth: { min: 320, max: 1920, def: 1280 },
+				cdpFps: { min: 5, max: 30, def: 20 }, cdpQuality: { min: 1, max: 100, def: 55 }, cdpMaxWidth: { min: 320, max: 1920, def: 960 }, cdpBackstopIntervalMs: { min: 1000, max: 10000, def: 3000 }, ffmpegFps: { min: 5, max: 30, def: 20 }, ffmpegMaxWidth: { min: 320, max: 1920, def: 1280 }, ffmpegBitrateKbps: { min: 500, max: 20000, def: 4000 },
 			}
 			this.staged.forEach(function (v, k) {
 				var spec = NUMERIC_FIELDS[k]
@@ -208,7 +208,7 @@ window.__ModuleLoader__.load({
 					chromePath: config.chromePath || '',
 					captureBackend: config.captureBackend || 'auto', streamProfile: config.streamProfile || 'balanced',
 					cdpFps: String(config.cdpFps ?? 20), cdpQuality: String(config.cdpQuality ?? 55), cdpMaxWidth: String(config.cdpMaxWidth ?? 960), cdpBackstopIntervalMs: String(config.cdpBackstopIntervalMs ?? 3000),
-					ffmpegFps: String(config.ffmpegFps ?? 20), ffmpegMaxWidth: String(config.ffmpegMaxWidth ?? 1280), ffmpegEncoder: config.ffmpegEncoder || 'auto', ffmpegPath: config.ffmpegPath || '',
+					ffmpegFps: String(config.ffmpegFps ?? 20), ffmpegMaxWidth: String(config.ffmpegMaxWidth ?? 1280), ffmpegBitrateKbps: String(config.ffmpegBitrateKbps ?? 4000), ffmpegEncoder: config.ffmpegEncoder || 'auto', ffmpegPath: config.ffmpegPath || '',
 				}
 				s.dirty = false
 				})
@@ -381,7 +381,8 @@ window.__ModuleLoader__.load({
 						h(SettingsField, { id: 'plugin-config-ego-browser-backstop', label: t('cdpBackstopIntervalMs'), value: state.draft.cdpBackstopIntervalMs, numeric: true, narrow: true, unit: t('msUnit'), min: 1000, max: 10000, step: 100, disabled: busy, onEdit: function (v) { controller.edit('cdpBackstopIntervalMs', v) } }),
 						h(SettingsField, { id: 'plugin-config-ego-browser-fffps', label: t('ffmpegFps'), value: state.draft.ffmpegFps, numeric: true, narrow: true, unit: t('fpsUnit'), min: 5, max: 30, step: 1, disabled: busy, onEdit: function (v) { controller.edit('ffmpegFps', v) } }),
 						h(SettingsField, { id: 'plugin-config-ego-browser-ffwidth', label: t('ffmpegMaxWidth'), value: state.draft.ffmpegMaxWidth, numeric: true, narrow: true, unit: t('pxUnit'), min: 320, max: 1920, step: 40, disabled: busy, onEdit: function (v) { controller.edit('ffmpegMaxWidth', v) } }),
-						h(SettingsField, { id: 'plugin-config-ego-browser-encoder', label: t('ffmpegEncoder'), value: state.draft.ffmpegEncoder, options: ['auto', 'software', 'h264_nvenc', 'h264_qsv', 'h264_amf', 'h264_videotoolbox', 'h264_vaapi'], disabled: busy, onEdit: function (v) { controller.edit('ffmpegEncoder', v) } }),
+						h(SettingsField, { id: 'plugin-config-ego-browser-ffbitrate', label: t('ffmpegBitrateKbps'), value: state.draft.ffmpegBitrateKbps, numeric: true, narrow: true, unit: t('kbpsUnit'), min: 500, max: 20000, step: 250, disabled: busy, onEdit: function (v) { controller.edit('ffmpegBitrateKbps', v) } }),
+						h(SettingsField, { id: 'plugin-config-ego-browser-encoder', label: t('ffmpegEncoder'), value: state.draft.ffmpegEncoder, options: ['auto', 'software', 'h264_mf', 'h264_nvenc', 'h264_qsv', 'h264_amf', 'h264_videotoolbox', 'h264_vaapi'], disabled: busy, onEdit: function (v) { controller.edit('ffmpegEncoder', v) } }),
 						h(SettingsField, { id: 'plugin-config-ego-browser-ffpath', label: t('ffmpegPath'), value: state.draft.ffmpegPath, placeholder: 'bundled ffmpeg-static', disabled: busy, onEdit: function (v) { controller.edit('ffmpegPath', v) },
 						}),
 					),
@@ -413,10 +414,77 @@ window.__ModuleLoader__.load({
 		const WATCH_START_ROUTE = '/api/ego/watch/start'
 		const WATCH_SWITCH_ROUTE = '/api/ego/watch/switch'
 		const WATCH_STOP_ROUTE = '/api/ego/watch/stop'
+		const WATCH_STATUS_ROUTE = '/api/ego/watch/status'
 		const VIDEO_ROUTE = '/api/ego/video'
 
 		function postJson(path, body) {
 			return fetch(path, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body || {}) }).then(function (res) { return res.json().catch(function () { return {} }) })
+		}
+
+		function createKeyboardProxy(send) {
+			var input = document.createElement('textarea')
+			input.className = 'dsh-ego-keyboard-proxy'
+			input.tabIndex = -1
+			input.setAttribute('autocomplete', 'off')
+			input.setAttribute('autocapitalize', 'off')
+			input.setAttribute('spellcheck', 'false')
+			input.style.cssText = 'position:fixed;z-index:-1;width:1px;height:1px;opacity:.01;pointer-events:none;resize:none;padding:0;border:0;'
+			document.body.appendChild(input)
+			var composing = false
+			var activeTargetId = null
+			var pressed = new Map()
+			var lastCompositionText = '', lastCompositionAt = 0, lastPasteText = '', lastPasteAt = 0
+			var modifiers = function (e) { return (e.altKey ? 1 : 0) | (e.ctrlKey ? 2 : 0) | (e.metaKey ? 4 : 0) | (e.shiftKey ? 8 : 0) }
+			var keyId = function (e) { return e.code || e.key }
+			var keyPayload = function (e) { return { key: e.key, code: e.code || '', modifiers: modifiers(e), autoRepeat: !!e.repeat, windowsVirtualKeyCode: Number(e.keyCode || e.which || 0) } }
+			input.addEventListener('compositionstart', function (e) { composing = true; e.stopPropagation() })
+			input.addEventListener('compositionend', function (e) {
+				composing = false; e.stopPropagation()
+				if (e.data && activeTargetId) { lastCompositionText = e.data; lastCompositionAt = Date.now(); send(activeTargetId, 'insertText', { text: e.data }) }
+				window.setTimeout(function () { input.value = '' }, 0)
+			})
+			input.addEventListener('beforeinput', function (e) {
+				e.stopPropagation()
+				if (composing || /Composition/i.test(e.inputType || '')) return
+				if (e.data && e.data === lastCompositionText && Date.now() - lastCompositionAt < 100) { e.preventDefault(); return }
+				if (e.data && e.data === lastPasteText && Date.now() - lastPasteAt < 100) { e.preventDefault(); return }
+				if (e.data && activeTargetId) { e.preventDefault(); send(activeTargetId, 'insertText', { text: e.data }); input.value = '' }
+			})
+			input.addEventListener('paste', function (e) {
+				var text = e.clipboardData && e.clipboardData.getData('text/plain')
+				if (!text) return
+				e.preventDefault(); e.stopPropagation(); lastPasteText = text; lastPasteAt = Date.now(); if (activeTargetId) send(activeTargetId, 'insertText', { text: text }); input.value = ''
+			})
+			input.addEventListener('keydown', function (e) {
+				e.stopPropagation()
+				if (composing || e.key === 'Process' || e.key === 'Dead') return
+				if (e.getModifierState && e.getModifierState('AltGraph') && e.key.length === 1) return
+				var isShortcut = e.ctrlKey || e.metaKey || e.altKey
+				var isControl = e.key.length > 1
+				if (!isShortcut && !isControl) return
+				if ((e.ctrlKey || e.metaKey) && String(e.key).toLowerCase() === 'v') return
+				if (!activeTargetId) return
+				e.preventDefault(); var payload = keyPayload(e); pressed.set(keyId(e), { targetId: activeTargetId, payload: payload }); send(activeTargetId, 'keyDown', payload)
+			})
+			input.addEventListener('keyup', function (e) {
+				e.stopPropagation()
+				var id = keyId(e)
+				var record = pressed.get(id)
+				if (!record) return
+				e.preventDefault(); pressed.delete(id); send(record.targetId, 'keyUp', keyPayload(e))
+			})
+			return {
+				focusAt: function (e, targetId) {
+					if (activeTargetId && targetId !== activeTargetId) {
+						for (const record of pressed.values()) send(record.targetId, 'keyUp', Object.assign({}, record.payload, { autoRepeat: false }))
+						pressed.clear()
+					}
+					activeTargetId = targetId
+					input.style.left = Math.max(0, e.clientX) + 'px'; input.style.top = Math.max(0, e.clientY) + 'px'
+					try { input.focus({ preventScroll: true }) } catch (err) { input.focus() }
+				},
+				dispose: function () { for (const record of pressed.values()) send(record.targetId, 'keyUp', Object.assign({}, record.payload, { autoRepeat: false })); pressed.clear(); input.remove() },
+			}
 		}
 
 		function createMsePlayer(video, generation, mime, onFailure) {
@@ -424,11 +492,23 @@ window.__ModuleLoader__.load({
 			var mediaSource = new MediaSource()
 			var objectUrl = URL.createObjectURL(mediaSource)
 			var abort = new AbortController()
-			var sourceBuffer = null, queue = [], disposed = false
+			var sourceBuffer = null, queue = [], queuedBytes = 0, disposed = false, reader = null, reading = false
+			var MAX_QUEUED_VIDEO_BYTES = 4 * 1024 * 1024
 			video.src = objectUrl; video.muted = true; video.autoplay = true; video.playsInline = true
 			function appendNext() {
 				if (disposed || !sourceBuffer || sourceBuffer.updating || queue.length === 0) return
-				try { sourceBuffer.appendBuffer(queue.shift()) } catch (error) { onFailure(error.message) }
+				var chunk = queue.shift(); queuedBytes -= chunk.byteLength
+				try { sourceBuffer.appendBuffer(chunk) } catch (error) { onFailure(error.message) }
+			}
+			function pump() {
+				if (disposed || reading || !reader || queuedBytes >= MAX_QUEUED_VIDEO_BYTES) return
+				reading = true
+				reader.read().then(function (part) {
+					reading = false
+					if (disposed) return
+					if (part.done) { onFailure('视频流已断开'); return }
+					queue.push(part.value); queuedBytes += part.value.byteLength; appendNext(); pump()
+				}).catch(function (error) { reading = false; if (!disposed && error.name !== 'AbortError') onFailure(error.message) })
 			}
 			mediaSource.addEventListener('sourceopen', function () {
 				if (disposed) return
@@ -440,17 +520,15 @@ window.__ModuleLoader__.load({
 						if (end - video.currentTime > .8) video.currentTime = Math.max(0, end - .15)
 						if (!sourceBuffer.updating && video.buffered.start(0) < end - 3) try { sourceBuffer.remove(video.buffered.start(0), end - 2) } catch (e) {}
 					}
-					appendNext()
+					appendNext(); pump()
 				})
 				fetch(VIDEO_ROUTE + '?generation=' + encodeURIComponent(generation), { signal: abort.signal }).then(function (res) {
 					if (!res.ok || !res.body) throw new Error('视频流连接失败 (' + res.status + ')')
-					var reader = res.body.getReader()
-					function pump() { return reader.read().then(function (part) { if (disposed || part.done) return; queue.push(part.value); appendNext(); return pump() }) }
-					return pump()
+					reader = res.body.getReader(); pump()
 				}).catch(function (error) { if (!disposed && error.name !== 'AbortError') onFailure(error.message) })
 			})
 			return function () {
-				disposed = true; abort.abort(); queue = []
+				disposed = true; abort.abort(); queue = []; queuedBytes = 0
 				try { video.pause(); video.removeAttribute('src'); video.load() } catch (e) {}
 				try { URL.revokeObjectURL(objectUrl) } catch (e) {}
 			}
@@ -913,16 +991,35 @@ window.__ModuleLoader__.load({
 				// from both sources here and follow from this map instead.
 				const pageMeta = new Map()
 				const watchClientId = 'floating-' + Math.random().toString(36).slice(2)
-				let watchStarted = false, watchTargetId = null, watchRenewTimer = null, watchStopTimer = null
+				let watchStarted = false, watchTargetId = null, watchRenewTimer = null, watchStopTimer = null, watchRequest = null
 				let captureBackend = 'cdp', streamGeneration = 0, streamState = 'idle', streamMessage = '', streamMime = 'video/mp4; codecs="avc1.42E01E"', videoCleanup = null
-				const effectiveVisible = () => !panel.hidden && document.visibilityState !== 'hidden'
+				const effectiveVisible = () => !panel.hidden
 				const stopVideo = () => { if (videoCleanup) try { videoCleanup() } catch {}; videoCleanup = null }
+				const applyCaptureStatus = (status) => {
+					if (!status || typeof status !== 'object') return
+					if (Number.isFinite(status.generation) && status.generation < streamGeneration) return
+					if (status.generation === streamGeneration && streamState === 'streaming' && status.state === 'starting') return
+					const nextBackend = status.backend || captureBackend
+					const nextGeneration = status.generation ?? streamGeneration
+					const nextState = status.state || streamState
+					const nextMime = status.mime || streamMime
+					const changed = captureBackend !== nextBackend || streamGeneration !== nextGeneration || streamState !== nextState || streamMime !== nextMime
+					captureBackend = nextBackend; streamGeneration = nextGeneration; streamState = nextState; streamMessage = status.message || status.code || ''; streamMime = nextMime
+					if (changed) { stopVideo(); const current = lastList.find((s) => s.targetId === (selectedTabId || currentActiveId)); if (current) renderLiveMain(current, selectedTabId !== null) }
+				}
+				const requestWatch = (route, body) => {
+					if (watchRequest) return null
+					watchRequest = postJson(route, body).finally(() => { watchRequest = null })
+					return watchRequest
+				}
 				const syncWatch = (targetId) => {
 					if (disposed || !effectiveVisible() || !targetId) return
 					if (watchStopTimer) { window.clearTimeout(watchStopTimer); watchStopTimer = null }
 					if (watchStarted && watchTargetId === targetId) return
-					postJson(watchStarted ? WATCH_SWITCH_ROUTE : WATCH_START_ROUTE, { clientId: watchClientId, targetId }).then((status) => { watchStarted = status && status.ok !== false; watchTargetId = targetId; if (!effectiveVisible()) stopWatch(true) }).catch(() => {})
-					if (!watchRenewTimer) watchRenewTimer = window.setInterval(() => { if (effectiveVisible() && watchTargetId) postJson(WATCH_START_ROUTE, { clientId: watchClientId, targetId: watchTargetId }).catch(() => {}) }, 5000)
+					const request = requestWatch(watchStarted ? WATCH_SWITCH_ROUTE : WATCH_START_ROUTE, { clientId: watchClientId, targetId })
+					if (!request) { watchRequest.finally(() => syncWatch(targetId)); return }
+					request.then((status) => { watchStarted = status && status.ok !== false; watchTargetId = status?.targetId || targetId; if (watchTargetId !== targetId) { selectedTabId = null; currentActiveId = watchTargetId }; applyCaptureStatus(status); if (!effectiveVisible()) stopWatch(true) }).catch(() => {})
+					if (!watchRenewTimer) watchRenewTimer = window.setInterval(() => { if (effectiveVisible() && watchTargetId) { const renewal = requestWatch(WATCH_START_ROUTE, { clientId: watchClientId, targetId: watchTargetId }); if (renewal) renewal.then(applyCaptureStatus).catch(() => {}) } }, 5000)
 				}
 				const stopWatch = (immediate) => {
 					if (watchRenewTimer) { window.clearInterval(watchRenewTimer); watchRenewTimer = null }
@@ -940,15 +1037,17 @@ window.__ModuleLoader__.load({
 				 * `type`: mouseMoved | mousePressed | mouseReleased | mouseWheel.
 				 */
 				const sendInput = (targetId, type, params) => {
-					if (inputBusy && type !== 'mouseReleased') return
-					inputBusy = true
-					window.setTimeout(() => { inputBusy = false }, type === 'mouseMoved' ? 24 : 8)
+					const targetValid = !!targetId
+					if (!targetValid || ((type !== 'mouseReleased' && type !== 'keyUp') && !effectiveVisible())) return
+					if (inputBusy && type === 'mouseMoved') return
+					if (type === 'mouseMoved') { inputBusy = true; window.setTimeout(() => { inputBusy = false }, 24) }
 					void fetch(INPUT_ROUTE, {
 						method: 'POST',
 						headers: { 'content-type': 'application/json' },
 						body: JSON.stringify({ targetId, type, ...params }),
-					}).catch(() => {})
+					}).then((res) => { if (res.status === 409) { liveImgTargetId = null; refresh() } }).catch(() => {})
 				}
+				const keyboardProxy = createKeyboardProxy((targetId, type, params) => sendInput(targetId, type, params))
 				/**
 				 * Map an event's client coords to the agent page's CSS pixels.
 				 *
@@ -1022,6 +1121,7 @@ window.__ModuleLoader__.load({
 					let browserDrag = false   // plain drag → send to agent
 					let sx = 0, sy = 0, stx = 0, sty = 0
 					let lastDragPos = null     // last browser coords sent during drag
+					let dragTargetId = null
 					let downButtons = 0
 
 					const resetView = () => {
@@ -1068,12 +1168,14 @@ window.__ModuleLoader__.load({
 						}
 						// Plain press → start a browser interaction (click or drag).
 						browserDrag = true
+						dragTargetId = liveImgTargetId
+						keyboardProxy.focusAt(e, dragTargetId)
 						lastDragPos = null
 						downButtons = 1
 						const p = browserXY(e)
 						if (p) {
 							lastDragPos = p
-							sendInput(liveImgTargetId, 'mousePressed', { x: p.x, y: p.y, button: 'left', buttons: 1, clickCount: 1 })
+							sendInput(dragTargetId, 'mousePressed', { x: p.x, y: p.y, button: 'left', buttons: 1, clickCount: 1 })
 						}
 					})
 					img.addEventListener('pointermove', (e) => {
@@ -1093,7 +1195,7 @@ window.__ModuleLoader__.load({
 						const p = browserXY(e)
 						if (p) {
 							// Skip a first tiny jitter if the press also set lastDragPos.
-							sendInput(liveImgTargetId, 'mouseMoved', { x: p.x, y: p.y, buttons: downButtons })
+							sendInput(dragTargetId, 'mouseMoved', { x: p.x, y: p.y, buttons: downButtons })
 							lastDragPos = p
 						}
 					})
@@ -1101,9 +1203,10 @@ window.__ModuleLoader__.load({
 						if (viewPanning) { viewPanning = false; img.style.cursor = e.ctrlKey ? 'grab' : 'grab' }
 						if (browserDrag) {
 							browserDrag = false
-							if (lastDragPos && liveImgTargetId) {
-								sendInput(liveImgTargetId, 'mouseReleased', { x: lastDragPos.x, y: lastDragPos.y, button: 'left', buttons: 0, clickCount: 1 })
+							if (lastDragPos && dragTargetId) {
+								sendInput(dragTargetId, 'mouseReleased', { x: lastDragPos.x, y: lastDragPos.y, button: 'left', buttons: 0, clickCount: 1 })
 							}
+							dragTargetId = null
 						}
 						img.style.cursor = 'grab'
 					}
@@ -1369,6 +1472,7 @@ window.__ModuleLoader__.load({
 							if (disposed || !res.ok) { renderEmpty(); return }
 							const data = await res.json()
 							if (!data || data.ok !== true) { renderEmpty(); return }
+							applyCaptureStatus(data.capture)
 							renderSpaces(data.spaces)
 						} catch {
 							renderEmpty()
@@ -1457,6 +1561,7 @@ window.__ModuleLoader__.load({
 
 				const openStream = () => {
 					if (disposed) return
+					fetch(WATCH_STATUS_ROUTE, { cache: 'no-store' }).then((res) => res.ok ? res.json() : null).then(applyCaptureStatus).catch(() => {})
 					try { if (sse) sse.close() } catch {}
 					doConnected = false
 					sse = new EventSource('/api/ego/stream')
@@ -1489,10 +1594,7 @@ window.__ModuleLoader__.load({
 				})
 				sse.addEventListener('capture-status', (ev) => {
 					try {
-						const status = JSON.parse(ev.data)
-						const changed = captureBackend !== (status.backend || 'cdp') || streamGeneration !== (status.generation || 0) || streamState !== (status.state || 'idle') || streamMime !== (status.mime || streamMime)
-						captureBackend = status.backend || 'cdp'; streamGeneration = status.generation || 0; streamState = status.state || 'idle'; streamMessage = status.message || status.code || ''; streamMime = status.mime || streamMime
-						if (changed) { stopVideo(); const current = lastList.find((s) => s.targetId === (selectedTabId || currentActiveId)); if (current) renderLiveMain(current, selectedTabId !== null) }
+						applyCaptureStatus(JSON.parse(ev.data))
 					} catch {}
 				})
 				// Debounced reconnect fallback: when the SSE stream drops,
@@ -1705,7 +1807,7 @@ window.__ModuleLoader__.load({
 				panel.hidden = true
 				fab.classList.remove('on')
 				refresh()
-				const onVisibility = () => { if (document.visibilityState === 'hidden') { try { if (sse) sse.close() } catch {}; sse = null; stopWatch(false); stopVideo() } else if (!panel.hidden) { openStream(); syncWatch(selectedTabId || currentActiveId) } }
+				const onVisibility = () => { if (document.visibilityState !== 'hidden' && !panel.hidden) { if (!sse) openStream(); syncWatch(selectedTabId || currentActiveId) } }
 				document.addEventListener('visibilitychange', onVisibility)
 
 				return () => {
@@ -1717,6 +1819,7 @@ window.__ModuleLoader__.load({
 					if (watchRenewTimer) window.clearInterval(watchRenewTimer)
 					if (watchStopTimer) window.clearTimeout(watchStopTimer)
 					stopWatch(true); stopVideo()
+					keyboardProxy.dispose()
 					try { if (sse) sse.close() } catch {}
 					fab.remove()
 					panel.remove()
@@ -1921,6 +2024,7 @@ window.__ModuleLoader__.load({
 			this.watchTargetId = null
 			this.watchRenewTimer = null
 			this.watchStopTimer = null
+			this.watchRequest = null
 			this.backend = 'cdp'
 			this.streamGeneration = 0
 			this.streamState = 'idle'
@@ -1943,6 +2047,8 @@ window.__ModuleLoader__.load({
 			this._zoomHint = null
 			this._zoomHintTimer = null
 			this._pointerState = null
+			var self = this
+			this.keyboardProxy = createKeyboardProxy(function (targetId, type, params) { self.sendInput(targetId, type, params) })
 			this.dismissedGuides = { login: false, captcha: false }
 		}
 		LivePreviewController.prototype._initialState = function () {
@@ -2026,9 +2132,10 @@ window.__ModuleLoader__.load({
 		LivePreviewController.prototype.start = function () {
 			document.addEventListener('visibilitychange', this.onDocumentVisibility)
 			this._recompute()
-			if (this.visible && this.documentVisible) { this.refresh(); this.openStream() }
+			if (this.visible) { this.refresh(); this.openStream() }
 		}
 		LivePreviewController.prototype.dispose = function () {
+			this.keyboardProxy.dispose()
 			this.disposed = true
 			if (this.liveFlushRaf != null) try { window.cancelAnimationFrame(this.liveFlushRaf) } catch (e) {}
 			if (this.followTimer) window.clearTimeout(this.followTimer)
@@ -2043,12 +2150,16 @@ window.__ModuleLoader__.load({
 		}
 		LivePreviewController.prototype._handleDocumentVisibility = function () {
 			this.documentVisible = document.visibilityState !== 'hidden'
-			this.setVisible(this.visible)
+			if (this.documentVisible && this.visible) {
+				this.refresh()
+				if (!this.sse) this.openStream()
+				this._syncWatch(this.currentActiveId)
+			}
 		}
 		LivePreviewController.prototype.setVisible = function (v) {
 			var changed = this.visible !== v
 			this.visible = v
-			var effective = v && this.documentVisible
+			var effective = v
 			if (effective) {
 				// On becoming visible again, do a one-shot fallback fetch to
 				// re-sync immediately (the SSE `spaces` event will also catch
@@ -2062,20 +2173,42 @@ window.__ModuleLoader__.load({
 				this._destroyVideo()
 			}
 		}
+		LivePreviewController.prototype._requestWatch = function (route, body) {
+			if (this.watchRequest) return null
+			var self = this
+			this.watchRequest = postJson(route, body).finally(function () { self.watchRequest = null })
+			return this.watchRequest
+		}
+		LivePreviewController.prototype._applyCaptureStatus = function (status) {
+			if (!status || typeof status !== 'object') return
+			if (Number.isFinite(status.generation) && status.generation < this.streamGeneration) return
+			if (status.generation === this.streamGeneration && this.streamState === 'streaming' && status.state === 'starting') return
+			var nextBackend = status.backend || this.backend
+			var nextGeneration = status.generation ?? this.streamGeneration
+			var nextState = status.state || this.streamState
+			var generationChanged = this.streamGeneration !== nextGeneration
+			this.backend = nextBackend; this.streamState = nextState; this.streamMessage = status.message || status.code || ''; this.streamGeneration = nextGeneration; this.streamMime = status.mime || this.streamMime
+			if (generationChanged || this.backend !== 'ffmpeg') this._destroyVideo()
+			this._recompute()
+		}
 		LivePreviewController.prototype._syncWatch = function (targetId) {
-			if (this.disposed || !this.visible || !this.documentVisible || !targetId) return
+			if (this.disposed || !this.visible || !targetId) return
 			var self = this
 			if (this.watchStopTimer) { window.clearTimeout(this.watchStopTimer); this.watchStopTimer = null }
 			var route = this.watchStarted ? WATCH_SWITCH_ROUTE : WATCH_START_ROUTE
 			if (this.watchStarted && this.watchTargetId === targetId) return
 			var body = { clientId: this.clientId, targetId: targetId }
-			postJson(route, body).then(function (status) {
+			var request = this._requestWatch(route, body)
+			if (!request) { this.watchRequest.finally(function () { self._syncWatch(targetId) }); return }
+			request.then(function (status) {
 				self.watchStarted = status && status.ok !== false
-				self.watchTargetId = targetId
-				if (!self.visible || !self.documentVisible) self._stopWatch(true)
+				self.watchTargetId = status && status.targetId || targetId
+				if (self.watchTargetId !== targetId) { self.selectedTabId = null; self.currentActiveId = self.watchTargetId }
+				self._applyCaptureStatus(status)
+				if (!self.visible) self._stopWatch(true)
 			}).catch(function () {})
 			if (!this.watchRenewTimer) this.watchRenewTimer = window.setInterval(function () {
-				if (self.visible && self.documentVisible && self.watchTargetId) postJson(WATCH_START_ROUTE, { clientId: self.clientId, targetId: self.watchTargetId }).catch(function () {})
+				if (self.visible && self.watchTargetId) { var renewal = self._requestWatch(WATCH_START_ROUTE, { clientId: self.clientId, targetId: self.watchTargetId }); if (renewal) renewal.then(function (status) { self._applyCaptureStatus(status) }).catch(function () {}) }
 			}, 5000)
 		}
 		LivePreviewController.prototype._stopWatch = function (immediate) {
@@ -2124,6 +2257,7 @@ window.__ModuleLoader__.load({
 					if (self.disposed || !res.ok) { self._renderEmpty(); return }
 					var data = await res.json()
 					if (!data || data.ok !== true) { self._renderEmpty(); return }
+					self._applyCaptureStatus(data.capture)
 					self._processSpaces(data.spaces)
 				} catch (e) {
 					self._renderEmpty()
@@ -2170,6 +2304,7 @@ window.__ModuleLoader__.load({
 			if (this.disposed || !this.visible) return
 			this.closeStream()
 			var self = this
+			fetch(WATCH_STATUS_ROUTE, { cache: 'no-store' }).then(function (res) { return res.ok ? res.json() : null }).then(function (status) { self._applyCaptureStatus(status) }).catch(function () {})
 			try {
 				this.sse = new EventSource('/api/ego/stream')
 			} catch (e) { return }
@@ -2200,11 +2335,7 @@ window.__ModuleLoader__.load({
 			})
 			this.sse.addEventListener('capture-status', function (ev) {
 				try {
-					var status = JSON.parse(ev.data)
-					var generationChanged = self.streamGeneration !== (status.generation || 0)
-					self.backend = status.backend || 'cdp'; self.streamState = status.state || 'idle'; self.streamMessage = status.message || status.code || ''; self.streamGeneration = status.generation || 0; self.streamMime = status.mime || self.streamMime
-					if (generationChanged || self.backend !== 'ffmpeg') self._destroyVideo()
-					self._recompute()
+					self._applyCaptureStatus(JSON.parse(ev.data))
 				} catch (e) {}
 			})
 			// Debounced reconnect fallback: EventSource auto-reconnects on
@@ -2274,11 +2405,19 @@ window.__ModuleLoader__.load({
 			}
 		}
 		LivePreviewController.prototype.sendInput = function (targetId, type, params) {
-			if (!targetId) return
+			var targetValid = !!targetId
+			if (!targetValid || this.disposed || ((type !== 'mouseReleased' && type !== 'keyUp') && !this.visible)) return
+			var self = this
 			void fetch(INPUT_ROUTE, {
 				method: 'POST',
 				headers: { 'content-type': 'application/json' },
 				body: JSON.stringify(Object.assign({ targetId: targetId, type: type }, params)),
+			}).then(function (res) {
+				if (res.status === 409) {
+					self.liveImgTargetId = null
+					self._pointerState = null
+					self.refresh()
+				}
 			}).catch(function () {})
 		}
 		LivePreviewController.prototype.browserXY = function (e) {
@@ -2397,7 +2536,7 @@ window.__ModuleLoader__.load({
 				viewPanning: false, browserDrag: false,
 				sx: e.clientX, sy: e.clientY,
 				stx: this.zoomState.tx, sty: this.zoomState.ty,
-				lastDragPos: null, downButtons: 0,
+				lastDragPos: null, downButtons: 0, targetId: this.liveImgTargetId,
 			}
 			try { e.currentTarget.setPointerCapture(e.pointerId) } catch (err) {}
 			if (e.ctrlKey || e.metaKey) {
@@ -2407,11 +2546,12 @@ window.__ModuleLoader__.load({
 				return
 			}
 			this._pointerState.browserDrag = true
+			this.keyboardProxy.focusAt(e, this._pointerState.targetId)
 			this._pointerState.downButtons = 1
 			var p = this.browserXY(e)
 			if (p) {
 				this._pointerState.lastDragPos = p
-				this.sendInput(this.liveImgTargetId, 'mousePressed', { x: p.x, y: p.y, button: 'left', buttons: 1, clickCount: 1 })
+				this.sendInput(this._pointerState.targetId, 'mousePressed', { x: p.x, y: p.y, button: 'left', buttons: 1, clickCount: 1 })
 			}
 		}
 		LivePreviewController.prototype.handlePointerMove = function (e) {
@@ -2429,7 +2569,7 @@ window.__ModuleLoader__.load({
 			if (this._pointerState.browserDrag) {
 				var p2 = this.browserXY(e)
 				if (p2) {
-					this.sendInput(this.liveImgTargetId, 'mouseMoved', { x: p2.x, y: p2.y, buttons: this._pointerState.downButtons })
+					this.sendInput(this._pointerState.targetId, 'mouseMoved', { x: p2.x, y: p2.y, buttons: this._pointerState.downButtons })
 					this._pointerState.lastDragPos = p2
 				}
 			}
@@ -2440,8 +2580,8 @@ window.__ModuleLoader__.load({
 				if (e.currentTarget) e.currentTarget.style.cursor = 'grab'
 			}
 			if (this._pointerState.browserDrag) {
-				if (this._pointerState.lastDragPos && this.liveImgTargetId) {
-					this.sendInput(this.liveImgTargetId, 'mouseReleased', {
+				if (this._pointerState.lastDragPos && this._pointerState.targetId) {
+					this.sendInput(this._pointerState.targetId, 'mouseReleased', {
 						x: this._pointerState.lastDragPos.x, y: this._pointerState.lastDragPos.y,
 						button: 'left', buttons: 0, clickCount: 1,
 					})

--- a/lib/client.js
+++ b/lib/client.js
@@ -504,15 +504,28 @@ window.__ModuleLoader__.load({
 			input.setAttribute('autocomplete', 'off')
 			input.setAttribute('autocapitalize', 'off')
 			input.setAttribute('spellcheck', 'false')
-			input.style.cssText = 'position:fixed;z-index:-1;width:1px;height:1px;opacity:.01;pointer-events:none;resize:none;padding:0;border:0;'
+			input.style.cssText = 'position:fixed;z-index:2147483647;width:1px;height:1px;opacity:.01;pointer-events:none;resize:none;padding:0;border:0;left:0;top:0;'
 			document.body.appendChild(input)
 			var composing = false
+			var armed = false
 			var activeTargetId = null
 			var pressed = new Map()
 			var lastCompositionText = '', lastCompositionAt = 0, lastPasteText = '', lastPasteAt = 0
+			var blurCount = 0, lastBlurAt = 0
 			var modifiers = function (e) { return (e.altKey ? 1 : 0) | (e.ctrlKey ? 2 : 0) | (e.metaKey ? 4 : 0) | (e.shiftKey ? 8 : 0) }
 			var keyId = function (e) { return e.code || e.key }
 			var keyPayload = function (e) { return { key: e.key, code: e.code || '', modifiers: modifiers(e), autoRepeat: !!e.repeat, windowsVirtualKeyCode: Number(e.keyCode || e.which || 0) } }
+			var isDshInput = function (target) {
+				if (!target || target === input) return false
+				var tag = target.tagName
+				if (tag === 'INPUT' || tag === 'TEXTAREA') return true
+				if (target.isContentEditable) return true
+				return false
+			}
+			var releaseAllKeys = function () {
+				for (const record of pressed.values()) send(record.targetId, 'keyUp', Object.assign({}, record.payload, { autoRepeat: false }))
+				pressed.clear()
+			}
 			input.addEventListener('compositionstart', function (e) { composing = true; e.stopPropagation() })
 			input.addEventListener('compositionend', function (e) {
 				composing = false; e.stopPropagation()
@@ -549,17 +562,63 @@ window.__ModuleLoader__.load({
 				if (!record) return
 				e.preventDefault(); pressed.delete(id); send(record.targetId, 'keyUp', keyPayload(e))
 			})
+			input.addEventListener('blur', function () {
+				if (!armed || !activeTargetId) return
+				var now = Date.now()
+				if (now - lastBlurAt < 1000) { blurCount++; if (blurCount > 3) return }
+				else blurCount = 0
+				lastBlurAt = now
+				window.setTimeout(function () { if (armed && activeTargetId) { try { input.focus({ preventScroll: true }) } catch (err) { input.focus() } } }, 0)
+			})
+			var onDocKeyDown = function (e) {
+				if (!armed || !activeTargetId) return
+				if (e.target === input) return
+				if (composing || e.key === 'Process' || e.key === 'Dead') return
+				if (e.getModifierState && e.getModifierState('AltGraph') && e.key.length === 1) return
+				if (isDshInput(e.target) && document.activeElement === e.target) return
+				var isShortcut = e.ctrlKey || e.metaKey || e.altKey
+				var isControl = e.key.length > 1
+				if (!isShortcut && !isControl) {
+					e.preventDefault(); e.stopPropagation()
+					send(activeTargetId, 'insertText', { text: e.key })
+					return
+				}
+				if ((e.ctrlKey || e.metaKey) && String(e.key).toLowerCase() === 'v') return
+				e.preventDefault(); e.stopPropagation()
+				var payload = keyPayload(e); pressed.set(keyId(e), { targetId: activeTargetId, payload: payload }); send(activeTargetId, 'keyDown', payload)
+			}
+			var onDocKeyUp = function (e) {
+				if (!armed || !activeTargetId) return
+				if (e.target === input) return
+				var id = keyId(e)
+				var record = pressed.get(id)
+				if (!record) return
+				e.preventDefault(); e.stopPropagation(); pressed.delete(id); send(record.targetId, 'keyUp', keyPayload(e))
+			}
+			var onDocPointerDown = function (e) {
+				if (armed && isDshInput(e.target) && e.target !== input) {
+					armed = false; releaseAllKeys()
+				}
+			}
+			document.addEventListener('keydown', onDocKeyDown, true)
+			document.addEventListener('keyup', onDocKeyUp, true)
+			document.addEventListener('pointerdown', onDocPointerDown, true)
 			return {
 				focusAt: function (e, targetId) {
-					if (activeTargetId && targetId !== activeTargetId) {
-						for (const record of pressed.values()) send(record.targetId, 'keyUp', Object.assign({}, record.payload, { autoRepeat: false }))
-						pressed.clear()
-					}
+					if (activeTargetId && targetId !== activeTargetId) releaseAllKeys()
 					activeTargetId = targetId
+					armed = true
+					blurCount = 0
 					input.style.left = Math.max(0, e.clientX) + 'px'; input.style.top = Math.max(0, e.clientY) + 'px'
 					try { input.focus({ preventScroll: true }) } catch (err) { input.focus() }
 				},
-				dispose: function () { for (const record of pressed.values()) send(record.targetId, 'keyUp', Object.assign({}, record.payload, { autoRepeat: false })); pressed.clear(); input.remove() },
+				dispose: function () {
+					armed = false
+					document.removeEventListener('keydown', onDocKeyDown, true)
+					document.removeEventListener('keyup', onDocKeyUp, true)
+					document.removeEventListener('pointerdown', onDocPointerDown, true)
+					releaseAllKeys(); input.remove()
+				},
 			}
 		}
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -51,7 +51,8 @@ window.__ModuleLoader__.load({
 			intro: 'Agent browser integration. Configure the Chrome/Chromium binary path and cast parameters below.',
 			chromePath: 'Browser binary path',
 			chromePathHint: 'Path to the Chrome/Chromium/Edge binary. Empty = auto-detect.',
-			captureBackend: 'Capture backend', streamProfile: 'Quality profile', cdpFps: 'CDP FPS', cdpQuality: 'CDP JPEG quality', cdpMaxWidth: 'CDP max width', cdpBackstopIntervalMs: 'CDP recovery interval', ffmpegFps: 'FFmpeg FPS', ffmpegMaxWidth: 'FFmpeg max width', ffmpegBitrateKbps: 'FFmpeg bitrate', ffmpegEncoder: 'FFmpeg encoder', ffmpegPath: 'FFmpeg binary path', fpsUnit: 'fps', pxUnit: 'px', kbpsUnit: 'kbps', msUnit: 'ms',
+			captureBackend: 'Capture backend', streamProfile: 'Quality profile', cdpFps: 'CDP FPS', cdpQuality: 'CDP JPEG quality', cdpMaxWidth: 'CDP max width', cdpBackstopIntervalMs: 'CDP recovery interval', ffmpegFps: 'FFmpeg FPS', ffmpegMaxWidth: 'FFmpeg max width', ffmpegBitrateKbps: 'FFmpeg bitrate', ffmpegEncoder: 'FFmpeg encoder', ffmpegPath: 'FFmpeg binary path', githubMirror: 'GitHub mirror', fpsUnit: 'fps', pxUnit: 'px', kbpsUnit: 'kbps', msUnit: 'ms',
+			ffmpegTitle: 'FFmpeg installation', ffmpegReady: 'Ready', ffmpegMissing: 'No compatible FFmpeg found', ffmpegChecking: 'Checking local FFmpeg…', ffmpegDownloading: 'Downloading FFmpeg…', ffmpegVerifying: 'Verifying download…', ffmpegExtracting: 'Extracting FFmpeg…', ffmpegProbing: 'Checking capture capabilities…', ffmpegUnsupported: 'FFmpeg capture is unsupported on this platform', ffmpegFailed: 'FFmpeg installation failed', ffmpegSource: 'Source', ffmpegVersion: 'Version', ffmpegInstall: 'Download FFmpeg', ffmpegReinstall: 'Reinstall', ffmpegRecheck: 'Recheck', ffmpegRequired: 'FFmpeg (install required)', githubMirrorHint: 'Replaces https://github.com for GitHub downloads, for example https://gh-proxy.com/github.com.',
 			save: 'Save', saving: 'Saving…', discard: 'Discard',
 			unsaved: 'Unsaved', readOnly: 'Settings are read-only in this deployment.',
 			namespaceUnavailable: 'The ego-browser configuration channel is unavailable. Please retry later.',
@@ -63,7 +64,8 @@ window.__ModuleLoader__.load({
 			intro: 'Agent 浏览器集成。在下方配置 Chrome/Chromium 浏览器路径及推流参数。',
 			chromePath: '浏览器路径',
 			chromePathHint: 'Chrome/Chromium/Edge 可执行文件路径。留空 = 自动检测。',
-			captureBackend: '捕获后端', streamProfile: '画质档位', cdpFps: 'CDP 帧率', cdpQuality: 'CDP JPEG 质量', cdpMaxWidth: 'CDP 最大宽度', cdpBackstopIntervalMs: 'CDP 恢复截图间隔', ffmpegFps: 'FFmpeg 帧率', ffmpegMaxWidth: 'FFmpeg 最大宽度', ffmpegBitrateKbps: 'FFmpeg 码率', ffmpegEncoder: 'FFmpeg 编码器', ffmpegPath: 'FFmpeg 路径', fpsUnit: 'fps', pxUnit: 'px', kbpsUnit: 'kbps', msUnit: 'ms',
+			captureBackend: '捕获后端', streamProfile: '画质档位', cdpFps: 'CDP 帧率', cdpQuality: 'CDP JPEG 质量', cdpMaxWidth: 'CDP 最大宽度', cdpBackstopIntervalMs: 'CDP 恢复截图间隔', ffmpegFps: 'FFmpeg 帧率', ffmpegMaxWidth: 'FFmpeg 最大宽度', ffmpegBitrateKbps: 'FFmpeg 码率', ffmpegEncoder: 'FFmpeg 编码器', ffmpegPath: 'FFmpeg 路径', githubMirror: 'GitHub 镜像源', fpsUnit: 'fps', pxUnit: 'px', kbpsUnit: 'kbps', msUnit: 'ms',
+			ffmpegTitle: 'FFmpeg 安装', ffmpegReady: '已就绪', ffmpegMissing: '未找到兼容的 FFmpeg', ffmpegChecking: '正在检测本机 FFmpeg…', ffmpegDownloading: '正在下载 FFmpeg…', ffmpegVerifying: '正在校验下载文件…', ffmpegExtracting: '正在解压 FFmpeg…', ffmpegProbing: '正在检查捕获能力…', ffmpegUnsupported: '当前平台不支持 FFmpeg 捕获', ffmpegFailed: 'FFmpeg 安装失败', ffmpegSource: '来源', ffmpegVersion: '版本', ffmpegInstall: '下载 FFmpeg', ffmpegReinstall: '重新下载', ffmpegRecheck: '重新检测', ffmpegRequired: 'FFmpeg（需要安装）', githubMirrorHint: '替换 https://github.com，例如 https://gh-proxy.com/github.com。',
 			save: '保存', saving: '保存中…', discard: '放弃',
 			unsaved: '未保存', readOnly: '当前部署下设置只读。',
 			namespaceUnavailable: 'ego-browser 配置通道不可用，请稍后重试。',
@@ -77,7 +79,8 @@ window.__ModuleLoader__.load({
 				status: 'idle',        // 'idle' | 'loading' | 'ready'
 				available: false,      // true after a successful /ego/api/get
 				writable: false,       // false when settings service is absent
-				draft: { chromePath: '', captureBackend: 'auto', streamProfile: 'balanced', cdpFps: '20', cdpQuality: '55', cdpMaxWidth: '960', cdpBackstopIntervalMs: '3000', ffmpegFps: '20', ffmpegMaxWidth: '1280', ffmpegBitrateKbps: '4000', ffmpegEncoder: 'auto', ffmpegPath: '' },
+				draft: { chromePath: '', captureBackend: 'auto', streamProfile: 'balanced', cdpFps: '20', cdpQuality: '55', cdpMaxWidth: '960', cdpBackstopIntervalMs: '3000', ffmpegFps: '20', ffmpegMaxWidth: '1280', ffmpegBitrateKbps: '4000', ffmpegEncoder: 'auto', ffmpegPath: '', githubMirror: '' },
+				ffmpegStatus: { state: 'checking', canDownload: false, canSelectFfmpeg: false },
 				dirty: false,
 				applyState: { kind: 'idle' }, // 'idle' | 'saving' | 'saved' | 'error'
 				errorMessage: undefined,
@@ -90,6 +93,7 @@ window.__ModuleLoader__.load({
 			this.loaded = false
 			this.generation = 0
 			this.staged = new Map()
+			this.ffmpegTimer = null
 			void this.load()
 		}
 		EgoBrowserSettingsController.prototype.load = function () {
@@ -114,6 +118,7 @@ window.__ModuleLoader__.load({
 					return
 				}
 				var config = parsed.value.config || {}
+				var ffmpegStatus = parsed.value.ffmpegStatus || { state: 'missing', canDownload: false, canSelectFfmpeg: false }
 				self.loaded = true
 				self.staged.clear()
 				self.store.update(function (s) {
@@ -122,13 +127,15 @@ window.__ModuleLoader__.load({
 					s.writable = true
 				s.draft = {
 					chromePath: config.chromePath || '',
-					captureBackend: config.captureBackend || 'auto', streamProfile: config.streamProfile || 'balanced',
+					captureBackend: config.captureBackend === 'ffmpeg' && !ffmpegStatus.canSelectFfmpeg ? 'cdp' : (config.captureBackend || 'auto'), streamProfile: config.streamProfile || 'balanced',
 					cdpFps: String(config.cdpFps ?? 20), cdpQuality: String(config.cdpQuality ?? 55), cdpMaxWidth: String(config.cdpMaxWidth ?? 960), cdpBackstopIntervalMs: String(config.cdpBackstopIntervalMs ?? 3000),
-					ffmpegFps: String(config.ffmpegFps ?? 20), ffmpegMaxWidth: String(config.ffmpegMaxWidth ?? 1280), ffmpegBitrateKbps: String(config.ffmpegBitrateKbps ?? 4000), ffmpegEncoder: config.ffmpegEncoder || 'auto', ffmpegPath: config.ffmpegPath || '',
+					ffmpegFps: String(config.ffmpegFps ?? 20), ffmpegMaxWidth: String(config.ffmpegMaxWidth ?? 1280), ffmpegBitrateKbps: String(config.ffmpegBitrateKbps ?? 4000), ffmpegEncoder: config.ffmpegEncoder || 'auto', ffmpegPath: config.ffmpegPath || '', githubMirror: config.githubMirror || '',
 				}
+				s.ffmpegStatus = ffmpegStatus
 				s.dirty = false
 				s.applyState = { kind: 'idle' }
 				})
+				if (isFfmpegBusy(ffmpegStatus.state)) self._scheduleFfmpegPoll()
 			}).catch(function () {
 				if (gen !== self.generation) return
 				self.store.update(function (s) {
@@ -147,6 +154,41 @@ window.__ModuleLoader__.load({
 				s.dirty = true
 				s.applyState = { kind: 'idle' }
 			})
+		}
+		EgoBrowserSettingsController.prototype._setFfmpegStatus = function (status) {
+			var self = this
+			if (!status) return
+			this.store.update(function (s) {
+				s.ffmpegStatus = status
+				if (!status.canSelectFfmpeg && s.draft.captureBackend === 'ffmpeg') s.draft = Object.assign({}, s.draft, { captureBackend: 'cdp' })
+			})
+			if (isFfmpegBusy(status.state)) self._scheduleFfmpegPoll()
+		}
+		EgoBrowserSettingsController.prototype._scheduleFfmpegPoll = function () {
+			var self = this
+			if (this.ffmpegTimer !== null) return
+			this.ffmpegTimer = setTimeout(function () {
+				self.ffmpegTimer = null
+				void self._ffmpegRequest('ffmpeg-status')
+			}, 700)
+		}
+		EgoBrowserSettingsController.prototype._ffmpegRequest = function (method, body) {
+			var self = this
+			return fetch('/ego/api/' + method, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body || {}) })
+				.then(function (res) { return res.json().catch(function () { return null }) })
+				.then(function (parsed) {
+					if (!parsed || parsed.ok !== true || !parsed.value) throw new Error(parsed && parsed.error ? parsed.error.message : 'FFmpeg request failed')
+					self._setFfmpegStatus(parsed.value.ffmpegStatus)
+					return parsed.value.ffmpegStatus
+				}).catch(function (error) {
+					self.store.update(function (s) { s.applyState = { kind: 'error', message: error instanceof Error ? error.message : String(error) } })
+				})
+		}
+		EgoBrowserSettingsController.prototype.checkFfmpeg = function () { void this._ffmpegRequest('ffmpeg-check') }
+		EgoBrowserSettingsController.prototype.installFfmpeg = function () {
+			var self = this
+			var snapshot = this.store.getSnapshot()
+			void this._ffmpegRequest('ffmpeg-install', { githubMirror: snapshot.draft.githubMirror || '' }).then(function () { self._scheduleFfmpegPoll() })
 		}
 		EgoBrowserSettingsController.prototype.discard = function () {
 			if (this.staged.size === 0) {
@@ -190,26 +232,27 @@ window.__ModuleLoader__.load({
 				headers: { 'content-type': 'application/json' },
 				body: JSON.stringify({ patch: patch }),
 			}).then(function (res) {
-				if (!res.ok) return null
 				return res.json().catch(function () { return null })
 			}).then(function (parsed) {
 				if (gen !== self.generation) return
 				if (!parsed || parsed.ok !== true || !parsed.value) {
 					self.store.update(function (s) {
-						s.applyState = { kind: 'error', message: 'Save failed' }
+						s.applyState = { kind: 'error', message: parsed && parsed.error ? parsed.error.message : 'Save failed' }
 					})
 					return
 				}
 				var config = parsed.value.config || {}
+				var ffmpegStatus = parsed.value.ffmpegStatus || self.store.getSnapshot().ffmpegStatus
 				self.staged.clear()
 				self.store.update(function (s) {
 				s.applyState = { kind: 'saved' }
 				s.draft = {
 					chromePath: config.chromePath || '',
-					captureBackend: config.captureBackend || 'auto', streamProfile: config.streamProfile || 'balanced',
+					captureBackend: config.captureBackend === 'ffmpeg' && ffmpegStatus && !ffmpegStatus.canSelectFfmpeg ? 'cdp' : (config.captureBackend || 'auto'), streamProfile: config.streamProfile || 'balanced',
 					cdpFps: String(config.cdpFps ?? 20), cdpQuality: String(config.cdpQuality ?? 55), cdpMaxWidth: String(config.cdpMaxWidth ?? 960), cdpBackstopIntervalMs: String(config.cdpBackstopIntervalMs ?? 3000),
-					ffmpegFps: String(config.ffmpegFps ?? 20), ffmpegMaxWidth: String(config.ffmpegMaxWidth ?? 1280), ffmpegBitrateKbps: String(config.ffmpegBitrateKbps ?? 4000), ffmpegEncoder: config.ffmpegEncoder || 'auto', ffmpegPath: config.ffmpegPath || '',
+					ffmpegFps: String(config.ffmpegFps ?? 20), ffmpegMaxWidth: String(config.ffmpegMaxWidth ?? 1280), ffmpegBitrateKbps: String(config.ffmpegBitrateKbps ?? 4000), ffmpegEncoder: config.ffmpegEncoder || 'auto', ffmpegPath: config.ffmpegPath || '', githubMirror: config.githubMirror || '',
 				}
+				if (ffmpegStatus) s.ffmpegStatus = ffmpegStatus
 				s.dirty = false
 				})
 			}).catch(function (err) {
@@ -261,6 +304,12 @@ window.__ModuleLoader__.load({
 .dsh-ego-card__input--narrow{width:120px;flex:none}
 .dsh-ego-card__unit{font-size:12px;color:var(--dsw-alias-label-tertiary);flex:none}
 .dsh-ego-card__hint{font-size:12px;color:var(--dsw-alias-label-tertiary);margin:0;line-height:1.5}
+.dsh-ego-card__ffmpeg{border:1px solid var(--dsw-alias-border-l2);border-radius:10px;padding:12px;display:flex;flex-direction:column;gap:8px}
+.dsh-ego-card__ffmpeg-title{font-size:13px;font-weight:600;color:var(--dsw-alias-label-primary)}
+.dsh-ego-card__ffmpeg-status{font-size:12px;line-height:1.5;color:var(--dsw-alias-label-secondary);overflow-wrap:anywhere}
+.dsh-ego-card__ffmpeg-actions{display:flex;gap:8px;flex-wrap:wrap}
+.dsh-ego-card__progress{height:6px;border-radius:999px;background:var(--dsw-alias-bg-module-platform);overflow:hidden}
+.dsh-ego-card__progress-bar{height:100%;background:var(--dsw-alias-brand-primary);transition:width .2s}
 .dsh-ego-card__footer{border-top:1px solid var(--dsw-alias-border-l2);justify-content:flex-end;align-items:center;gap:8px;padding:12px 0 4px;display:flex}
 .dsh-ego-card__btn{appearance:none;font:inherit;cursor:pointer;border:1px solid #0000;border-radius:8px;padding:5px 14px;font-size:13px;font-weight:500;line-height:20px;color:var(--dsw-alias-label-primary);background:var(--dsw-alias-bg-module-platform);transition:background .16s,opacity .16s}
 .dsh-ego-card__btn:disabled{cursor:not-allowed;opacity:.5}
@@ -290,7 +339,10 @@ window.__ModuleLoader__.load({
 			var inputEl = props.options ? h('select', {
 				id: id, className: 'dsh-ego-card__input', value: value, disabled: disabled,
 				onChange: function (e) { onEdit(e.target.value) },
-			}, props.options.map(function (option) { return h('option', { key: option, value: option }, option) })) : h('input', {
+			}, props.options.map(function (option) {
+				var spec = typeof option === 'string' ? { value: option, label: option } : option
+				return h('option', { key: spec.value, value: spec.value, disabled: !!spec.disabled }, spec.label)
+			})) : h('input', {
 				id: id,
 				className: 'dsh-ego-card__input' + (narrow ? ' dsh-ego-card__input--narrow' : ''),
 				type: numeric ? 'number' : 'text',
@@ -356,6 +408,11 @@ window.__ModuleLoader__.load({
 				)
 			} else {
 				var busy = !state.writable || saving
+				var ffmpegStatus = state.ffmpegStatus || { state: 'checking', canDownload: false, canSelectFfmpeg: false }
+				var ffmpegBusy = isFfmpegBusy(ffmpegStatus.state)
+				var ffmpegLabelKey = ffmpegStatus.state === 'ready' ? 'ffmpegReady' : ffmpegStatus.state === 'checking' ? 'ffmpegChecking' : ffmpegStatus.state === 'downloading' ? 'ffmpegDownloading' : ffmpegStatus.state === 'verifying' ? 'ffmpegVerifying' : ffmpegStatus.state === 'extracting' ? 'ffmpegExtracting' : ffmpegStatus.state === 'probing' ? 'ffmpegProbing' : ffmpegStatus.state === 'unsupported' ? 'ffmpegUnsupported' : ffmpegStatus.state === 'failed' ? 'ffmpegFailed' : 'ffmpegMissing'
+				var progress = ffmpegStatus.progress
+				var progressText = progress ? formatBytes(progress.receivedBytes || 0) + (progress.totalBytes ? ' / ' + formatBytes(progress.totalBytes) : '') + (progress.percent !== null && progress.percent !== undefined ? ' (' + progress.percent + '%)' : '') : ''
 				var saveDisabled = !state.dirty || saving || !state.writable
 				var discardDisabled = !state.dirty || saving
 				body = h('div', { className: 'dsh-ego-card__body' },
@@ -372,7 +429,7 @@ window.__ModuleLoader__.load({
 							onEdit: function (v) { controller.edit('chromePath', v) },
 						}),
 						h(SettingsField, {
-							id: 'plugin-config-ego-browser-backend', label: t('captureBackend'), value: state.draft.captureBackend, options: ['auto', 'cdp', 'ffmpeg'], disabled: busy, onEdit: function (v) { controller.edit('captureBackend', v) },
+							id: 'plugin-config-ego-browser-backend', label: t('captureBackend'), value: state.draft.captureBackend, options: ['auto', 'cdp', { value: 'ffmpeg', label: ffmpegStatus.canSelectFfmpeg ? 'ffmpeg' : t('ffmpegRequired'), disabled: !ffmpegStatus.canSelectFfmpeg }], disabled: busy, onEdit: function (v) { controller.edit('captureBackend', v) },
 						}),
 						h(SettingsField, { id: 'plugin-config-ego-browser-profile', label: t('streamProfile'), value: state.draft.streamProfile, options: ['low', 'balanced', 'high'], disabled: busy, onEdit: function (v) { controller.edit('streamProfile', v) } }),
 						h(SettingsField, { id: 'plugin-config-ego-browser-cdpfps', label: t('cdpFps'), value: state.draft.cdpFps, numeric: true, narrow: true, unit: t('fpsUnit'), min: 5, max: 30, step: 1, disabled: busy, onEdit: function (v) { controller.edit('cdpFps', v) } }),
@@ -383,8 +440,20 @@ window.__ModuleLoader__.load({
 						h(SettingsField, { id: 'plugin-config-ego-browser-ffwidth', label: t('ffmpegMaxWidth'), value: state.draft.ffmpegMaxWidth, numeric: true, narrow: true, unit: t('pxUnit'), min: 320, max: 1920, step: 40, disabled: busy, onEdit: function (v) { controller.edit('ffmpegMaxWidth', v) } }),
 						h(SettingsField, { id: 'plugin-config-ego-browser-ffbitrate', label: t('ffmpegBitrateKbps'), value: state.draft.ffmpegBitrateKbps, numeric: true, narrow: true, unit: t('kbpsUnit'), min: 500, max: 20000, step: 250, disabled: busy, onEdit: function (v) { controller.edit('ffmpegBitrateKbps', v) } }),
 						h(SettingsField, { id: 'plugin-config-ego-browser-encoder', label: t('ffmpegEncoder'), value: state.draft.ffmpegEncoder, options: ['auto', 'software', 'h264_mf', 'h264_nvenc', 'h264_qsv', 'h264_amf', 'h264_videotoolbox', 'h264_vaapi'], disabled: busy, onEdit: function (v) { controller.edit('ffmpegEncoder', v) } }),
-						h(SettingsField, { id: 'plugin-config-ego-browser-ffpath', label: t('ffmpegPath'), value: state.draft.ffmpegPath, placeholder: 'bundled ffmpeg-static', disabled: busy, onEdit: function (v) { controller.edit('ffmpegPath', v) },
+						h(SettingsField, { id: 'plugin-config-ego-browser-ffpath', label: t('ffmpegPath'), value: state.draft.ffmpegPath, placeholder: 'ffmpeg', disabled: busy, onEdit: function (v) { controller.edit('ffmpegPath', v) },
 						}),
+						h(SettingsField, { id: 'plugin-config-ego-browser-ghmirror', label: t('githubMirror'), value: state.draft.githubMirror, hint: t('githubMirrorHint'), placeholder: 'https://gh-proxy.com/github.com', disabled: busy, onEdit: function (v) { controller.edit('githubMirror', v) } }),
+						h('div', { className: 'dsh-ego-card__ffmpeg' },
+							h('div', { className: 'dsh-ego-card__ffmpeg-title' }, t('ffmpegTitle')),
+							h('div', { className: 'dsh-ego-card__ffmpeg-status', role: 'status' }, t(ffmpegLabelKey) + (ffmpegStatus.reason ? ': ' + ffmpegStatus.reason : '') + (progressText ? ' ' + progressText : '')),
+							progress && progress.percent !== null && progress.percent !== undefined ? h('div', { className: 'dsh-ego-card__progress' }, h('div', { className: 'dsh-ego-card__progress-bar', style: { width: progress.percent + '%' } })) : null,
+							ffmpegStatus.path ? h('div', { className: 'dsh-ego-card__ffmpeg-status' }, t('ffmpegSource') + ': ' + (ffmpegStatus.source || '-') + ' · ' + ffmpegStatus.path) : null,
+							ffmpegStatus.version ? h('div', { className: 'dsh-ego-card__ffmpeg-status' }, t('ffmpegVersion') + ': ' + ffmpegStatus.version) : null,
+							h('div', { className: 'dsh-ego-card__ffmpeg-actions' },
+								h('button', { type: 'button', className: 'dsh-ego-card__btn', disabled: ffmpegBusy, onClick: function () { controller.checkFfmpeg() } }, t('ffmpegRecheck')),
+								ffmpegStatus.canDownload ? h('button', { type: 'button', className: 'dsh-ego-card__btn dsh-ego-card__btn--primary', disabled: ffmpegBusy, onClick: function () { controller.installFfmpeg() } }, ffmpegStatus.source === 'managed' ? t('ffmpegReinstall') : t('ffmpegInstall')) : null,
+							),
+						),
 					),
 					h('div', { className: 'dsh-ego-card__footer' },
 						errorText !== undefined ? h('p', { className: 'dsh-ego-card__failed', role: 'status' }, errorText) : null,
@@ -407,6 +476,13 @@ window.__ModuleLoader__.load({
 			return h('li', {
 				className: 'dsh-ego-card' + (open ? ' dsh-ego-card--open' : ''),
 			}, header, open ? body : null)
+		}
+
+		function isFfmpegBusy(state) { return ['checking', 'downloading', 'verifying', 'extracting', 'probing'].includes(state) }
+		function formatBytes(value) {
+			if (!Number.isFinite(value) || value <= 0) return '0 B'
+			if (value < 1024 * 1024) return (value / 1024).toFixed(1) + ' KiB'
+			return (value / (1024 * 1024)).toFixed(1) + ' MiB'
 		}
 
 		const SPACES_ROUTE = '/api/ego/spaces'

--- a/lib/client.js
+++ b/lib/client.js
@@ -51,17 +51,7 @@ window.__ModuleLoader__.load({
 			intro: 'Agent browser integration. Configure the Chrome/Chromium binary path and cast parameters below.',
 			chromePath: 'Browser binary path',
 			chromePathHint: 'Path to the Chrome/Chromium/Edge binary. Empty = auto-detect.',
-			castFpsCap: 'Frame rate cap',
-			castFpsCapHint: 'Max frames/sec pushed to the panel (0 = uncapped, active tab never throttled). Lower to save bandwidth/CPU. Range 0–60.',
-			castFpsCapUnit: 'fps',
-			screencastQuality: 'JPEG quality',
-			screencastQualityHint: 'Quality of pushed screencast frames (1–100). Lower = smaller payload, more artifacts. Range 1–100.',
-			screencastMaxWidth: 'Frame max width',
-			screencastMaxWidthHint: 'Max width of screencast frames in CSS px (320–1920). Lower = smaller payload, less detail.',
-			screencastMaxWidthUnit: 'px',
-			backstopIntervalMs: 'Backstop interval',
-			backstopIntervalMsHint: 'How long (ms) a page may go without a screencast frame before a forced screenshot. Also the min interval between forced captures. Lower = more frequent backstop frames (higher CPU). Range 200–10000.',
-			backstopIntervalMsUnit: 'ms',
+			captureBackend: 'Capture backend', streamProfile: 'Quality profile', cdpFps: 'CDP FPS', cdpQuality: 'CDP JPEG quality', cdpMaxWidth: 'CDP max width', cdpBackstopIntervalMs: 'CDP recovery interval', ffmpegFps: 'FFmpeg FPS', ffmpegMaxWidth: 'FFmpeg max width', ffmpegEncoder: 'FFmpeg encoder', ffmpegPath: 'FFmpeg binary path', fpsUnit: 'fps', pxUnit: 'px', msUnit: 'ms',
 			save: 'Save', saving: 'Saving…', discard: 'Discard',
 			unsaved: 'Unsaved', readOnly: 'Settings are read-only in this deployment.',
 			namespaceUnavailable: 'The ego-browser configuration channel is unavailable. Please retry later.',
@@ -73,17 +63,7 @@ window.__ModuleLoader__.load({
 			intro: 'Agent 浏览器集成。在下方配置 Chrome/Chromium 浏览器路径及推流参数。',
 			chromePath: '浏览器路径',
 			chromePathHint: 'Chrome/Chromium/Edge 可执行文件路径。留空 = 自动检测。',
-			castFpsCap: '帧率上限',
-			castFpsCapHint: '推送到面板的最大帧率（0 = 不限，活跃标签永不降速）。调低可节省带宽/CPU。范围 0–60。',
-			castFpsCapUnit: 'fps',
-			screencastQuality: 'JPEG 质量',
-			screencastQualityHint: '推送帧的 JPEG 质量（1–100）。越低体积越小、伪影越多。范围 1–100。',
-			screencastMaxWidth: '帧最大宽度',
-			screencastMaxWidthHint: '推流帧的最大 CSS 像素宽度（320–1920）。越低体积越小、细节越少。',
-			screencastMaxWidthUnit: 'px',
-			backstopIntervalMs: '兜底间隔',
-			backstopIntervalMsHint: '页面多久没收到 screencast 帧就强制截图（毫秒）。也是两次强制截图的最小间隔。越低帧越频繁（CPU 越高）。范围 200–10000。',
-			backstopIntervalMsUnit: 'ms',
+			captureBackend: '捕获后端', streamProfile: '画质档位', cdpFps: 'CDP 帧率', cdpQuality: 'CDP JPEG 质量', cdpMaxWidth: 'CDP 最大宽度', cdpBackstopIntervalMs: 'CDP 恢复截图间隔', ffmpegFps: 'FFmpeg 帧率', ffmpegMaxWidth: 'FFmpeg 最大宽度', ffmpegEncoder: 'FFmpeg 编码器', ffmpegPath: 'FFmpeg 路径', fpsUnit: 'fps', pxUnit: 'px', msUnit: 'ms',
 			save: '保存', saving: '保存中…', discard: '放弃',
 			unsaved: '未保存', readOnly: '当前部署下设置只读。',
 			namespaceUnavailable: 'ego-browser 配置通道不可用，请稍后重试。',
@@ -97,7 +77,7 @@ window.__ModuleLoader__.load({
 				status: 'idle',        // 'idle' | 'loading' | 'ready'
 				available: false,      // true after a successful /ego/api/get
 				writable: false,       // false when settings service is absent
-				draft: { chromePath: '', castFpsCap: '0', screencastQuality: '55', screencastMaxWidth: '960', backstopIntervalMs: '5000' },
+				draft: { chromePath: '', captureBackend: 'auto', streamProfile: 'balanced', cdpFps: '20', cdpQuality: '55', cdpMaxWidth: '960', cdpBackstopIntervalMs: '3000', ffmpegFps: '20', ffmpegMaxWidth: '1280', ffmpegEncoder: 'auto', ffmpegPath: '' },
 				dirty: false,
 				applyState: { kind: 'idle' }, // 'idle' | 'saving' | 'saved' | 'error'
 				errorMessage: undefined,
@@ -142,10 +122,9 @@ window.__ModuleLoader__.load({
 					s.writable = true
 				s.draft = {
 					chromePath: config.chromePath || '',
-					castFpsCap: String(config.castFpsCap ?? 0),
-					screencastQuality: String(config.screencastQuality ?? 55),
-					screencastMaxWidth: String(config.screencastMaxWidth ?? 960),
-					backstopIntervalMs: String(config.backstopIntervalMs ?? 5000),
+					captureBackend: config.captureBackend || 'auto', streamProfile: config.streamProfile || 'balanced',
+					cdpFps: String(config.cdpFps ?? 20), cdpQuality: String(config.cdpQuality ?? 55), cdpMaxWidth: String(config.cdpMaxWidth ?? 960), cdpBackstopIntervalMs: String(config.cdpBackstopIntervalMs ?? 3000),
+					ffmpegFps: String(config.ffmpegFps ?? 20), ffmpegMaxWidth: String(config.ffmpegMaxWidth ?? 1280), ffmpegEncoder: config.ffmpegEncoder || 'auto', ffmpegPath: config.ffmpegPath || '',
 				}
 				s.dirty = false
 				s.applyState = { kind: 'idle' }
@@ -185,10 +164,7 @@ window.__ModuleLoader__.load({
 			var gen = ++this.generation
 			var patch = {}
 			var NUMERIC_FIELDS = {
-				castFpsCap: { min: 0, max: 60, def: 0 },
-				screencastQuality: { min: 1, max: 100, def: 55 },
-				screencastMaxWidth: { min: 320, max: 1920, def: 960 },
-				backstopIntervalMs: { min: 200, max: 10000, def: 5000 },
+				cdpFps: { min: 5, max: 30, def: 20 }, cdpQuality: { min: 1, max: 100, def: 55 }, cdpMaxWidth: { min: 320, max: 1920, def: 960 }, cdpBackstopIntervalMs: { min: 1000, max: 10000, def: 3000 }, ffmpegFps: { min: 5, max: 30, def: 20 }, ffmpegMaxWidth: { min: 320, max: 1920, def: 1280 },
 			}
 			this.staged.forEach(function (v, k) {
 				var spec = NUMERIC_FIELDS[k]
@@ -230,10 +206,9 @@ window.__ModuleLoader__.load({
 				s.applyState = { kind: 'saved' }
 				s.draft = {
 					chromePath: config.chromePath || '',
-					castFpsCap: String(config.castFpsCap ?? 0),
-					screencastQuality: String(config.screencastQuality ?? 55),
-					screencastMaxWidth: String(config.screencastMaxWidth ?? 960),
-					backstopIntervalMs: String(config.backstopIntervalMs ?? 5000),
+					captureBackend: config.captureBackend || 'auto', streamProfile: config.streamProfile || 'balanced',
+					cdpFps: String(config.cdpFps ?? 20), cdpQuality: String(config.cdpQuality ?? 55), cdpMaxWidth: String(config.cdpMaxWidth ?? 960), cdpBackstopIntervalMs: String(config.cdpBackstopIntervalMs ?? 3000),
+					ffmpegFps: String(config.ffmpegFps ?? 20), ffmpegMaxWidth: String(config.ffmpegMaxWidth ?? 1280), ffmpegEncoder: config.ffmpegEncoder || 'auto', ffmpegPath: config.ffmpegPath || '',
 				}
 				s.dirty = false
 				})
@@ -312,7 +287,10 @@ window.__ModuleLoader__.load({
 			var numeric = props.numeric
 			var narrow = props.narrow
 			var unit = props.unit
-			var inputEl = h('input', {
+			var inputEl = props.options ? h('select', {
+				id: id, className: 'dsh-ego-card__input', value: value, disabled: disabled,
+				onChange: function (e) { onEdit(e.target.value) },
+			}, props.options.map(function (option) { return h('option', { key: option, value: option }, option) })) : h('input', {
 				id: id,
 				className: 'dsh-ego-card__input' + (narrow ? ' dsh-ego-card__input--narrow' : ''),
 				type: numeric ? 'number' : 'text',
@@ -394,48 +372,17 @@ window.__ModuleLoader__.load({
 							onEdit: function (v) { controller.edit('chromePath', v) },
 						}),
 						h(SettingsField, {
-							id: 'plugin-config-ego-browser-castfps',
-							label: t('castFpsCap'),
-							hint: t('castFpsCapHint'),
-							value: state.draft.castFpsCap || '',
-							placeholder: '0',
-							numeric: true, narrow: true, unit: t('castFpsCapUnit'),
-							min: 0, max: 60, step: 1,
-							disabled: busy,
-							onEdit: function (v) { controller.edit('castFpsCap', v) },
+							id: 'plugin-config-ego-browser-backend', label: t('captureBackend'), value: state.draft.captureBackend, options: ['auto', 'cdp', 'ffmpeg'], disabled: busy, onEdit: function (v) { controller.edit('captureBackend', v) },
 						}),
-						h(SettingsField, {
-							id: 'plugin-config-ego-browser-quality',
-							label: t('screencastQuality'),
-							hint: t('screencastQualityHint'),
-							value: state.draft.screencastQuality || '',
-							placeholder: '55',
-							numeric: true, narrow: true,
-							min: 1, max: 100, step: 1,
-							disabled: busy,
-							onEdit: function (v) { controller.edit('screencastQuality', v) },
-						}),
-						h(SettingsField, {
-							id: 'plugin-config-ego-browser-maxwidth',
-							label: t('screencastMaxWidth'),
-							hint: t('screencastMaxWidthHint'),
-							value: state.draft.screencastMaxWidth || '',
-							placeholder: '960',
-							numeric: true, narrow: true, unit: t('screencastMaxWidthUnit'),
-							min: 320, max: 1920, step: 40,
-							disabled: busy,
-							onEdit: function (v) { controller.edit('screencastMaxWidth', v) },
-						}),
-						h(SettingsField, {
-							id: 'plugin-config-ego-browser-backstop',
-							label: t('backstopIntervalMs'),
-							hint: t('backstopIntervalMsHint'),
-							value: state.draft.backstopIntervalMs || '',
-							placeholder: '5000',
-							numeric: true, narrow: true, unit: t('backstopIntervalMsUnit'),
-							min: 200, max: 10000, step: 100,
-							disabled: busy,
-							onEdit: function (v) { controller.edit('backstopIntervalMs', v) },
+						h(SettingsField, { id: 'plugin-config-ego-browser-profile', label: t('streamProfile'), value: state.draft.streamProfile, options: ['low', 'balanced', 'high'], disabled: busy, onEdit: function (v) { controller.edit('streamProfile', v) } }),
+						h(SettingsField, { id: 'plugin-config-ego-browser-cdpfps', label: t('cdpFps'), value: state.draft.cdpFps, numeric: true, narrow: true, unit: t('fpsUnit'), min: 5, max: 30, step: 1, disabled: busy, onEdit: function (v) { controller.edit('cdpFps', v) } }),
+						h(SettingsField, { id: 'plugin-config-ego-browser-cdpquality', label: t('cdpQuality'), value: state.draft.cdpQuality, numeric: true, narrow: true, min: 1, max: 100, step: 1, disabled: busy, onEdit: function (v) { controller.edit('cdpQuality', v) } }),
+						h(SettingsField, { id: 'plugin-config-ego-browser-cdpwidth', label: t('cdpMaxWidth'), value: state.draft.cdpMaxWidth, numeric: true, narrow: true, unit: t('pxUnit'), min: 320, max: 1920, step: 40, disabled: busy, onEdit: function (v) { controller.edit('cdpMaxWidth', v) } }),
+						h(SettingsField, { id: 'plugin-config-ego-browser-backstop', label: t('cdpBackstopIntervalMs'), value: state.draft.cdpBackstopIntervalMs, numeric: true, narrow: true, unit: t('msUnit'), min: 1000, max: 10000, step: 100, disabled: busy, onEdit: function (v) { controller.edit('cdpBackstopIntervalMs', v) } }),
+						h(SettingsField, { id: 'plugin-config-ego-browser-fffps', label: t('ffmpegFps'), value: state.draft.ffmpegFps, numeric: true, narrow: true, unit: t('fpsUnit'), min: 5, max: 30, step: 1, disabled: busy, onEdit: function (v) { controller.edit('ffmpegFps', v) } }),
+						h(SettingsField, { id: 'plugin-config-ego-browser-ffwidth', label: t('ffmpegMaxWidth'), value: state.draft.ffmpegMaxWidth, numeric: true, narrow: true, unit: t('pxUnit'), min: 320, max: 1920, step: 40, disabled: busy, onEdit: function (v) { controller.edit('ffmpegMaxWidth', v) } }),
+						h(SettingsField, { id: 'plugin-config-ego-browser-encoder', label: t('ffmpegEncoder'), value: state.draft.ffmpegEncoder, options: ['auto', 'software', 'h264_nvenc', 'h264_qsv', 'h264_amf', 'h264_videotoolbox', 'h264_vaapi'], disabled: busy, onEdit: function (v) { controller.edit('ffmpegEncoder', v) } }),
+						h(SettingsField, { id: 'plugin-config-ego-browser-ffpath', label: t('ffmpegPath'), value: state.draft.ffmpegPath, placeholder: 'bundled ffmpeg-static', disabled: busy, onEdit: function (v) { controller.edit('ffmpegPath', v) },
 						}),
 					),
 					h('div', { className: 'dsh-ego-card__footer' },
@@ -463,6 +410,51 @@ window.__ModuleLoader__.load({
 
 		const SPACES_ROUTE = '/api/ego/spaces'
 		const EGO_CLOSE_ROUTE = '/api/ego/close'
+		const WATCH_START_ROUTE = '/api/ego/watch/start'
+		const WATCH_SWITCH_ROUTE = '/api/ego/watch/switch'
+		const WATCH_STOP_ROUTE = '/api/ego/watch/stop'
+		const VIDEO_ROUTE = '/api/ego/video'
+
+		function postJson(path, body) {
+			return fetch(path, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body || {}) }).then(function (res) { return res.json().catch(function () { return {} }) })
+		}
+
+		function createMsePlayer(video, generation, mime, onFailure) {
+			if (!window.MediaSource || !window.MediaSource.isTypeSupported(mime)) { onFailure('当前浏览器不支持此 H.264 流'); return function () {} }
+			var mediaSource = new MediaSource()
+			var objectUrl = URL.createObjectURL(mediaSource)
+			var abort = new AbortController()
+			var sourceBuffer = null, queue = [], disposed = false
+			video.src = objectUrl; video.muted = true; video.autoplay = true; video.playsInline = true
+			function appendNext() {
+				if (disposed || !sourceBuffer || sourceBuffer.updating || queue.length === 0) return
+				try { sourceBuffer.appendBuffer(queue.shift()) } catch (error) { onFailure(error.message) }
+			}
+			mediaSource.addEventListener('sourceopen', function () {
+				if (disposed) return
+				try { sourceBuffer = mediaSource.addSourceBuffer(mime) } catch (error) { onFailure(error.message); return }
+				sourceBuffer.mode = 'segments'
+				sourceBuffer.addEventListener('updateend', function () {
+					if (video.buffered.length) {
+						var end = video.buffered.end(video.buffered.length - 1)
+						if (end - video.currentTime > .8) video.currentTime = Math.max(0, end - .15)
+						if (!sourceBuffer.updating && video.buffered.start(0) < end - 3) try { sourceBuffer.remove(video.buffered.start(0), end - 2) } catch (e) {}
+					}
+					appendNext()
+				})
+				fetch(VIDEO_ROUTE + '?generation=' + encodeURIComponent(generation), { signal: abort.signal }).then(function (res) {
+					if (!res.ok || !res.body) throw new Error('视频流连接失败 (' + res.status + ')')
+					var reader = res.body.getReader()
+					function pump() { return reader.read().then(function (part) { if (disposed || part.done) return; queue.push(part.value); appendNext(); return pump() }) }
+					return pump()
+				}).catch(function (error) { if (!disposed && error.name !== 'AbortError') onFailure(error.message) })
+			})
+			return function () {
+				disposed = true; abort.abort(); queue = []
+				try { video.pause(); video.removeAttribute('src'); video.load() } catch (e) {}
+				try { URL.revokeObjectURL(objectUrl) } catch (e) {}
+			}
+		}
 		const OPEN_KEY = 'dsh.ego.watch.open'
 		// Treat the agent as "active" when any page was touched within this window.
 		const ACTIVE_WINDOW_MS = 3000
@@ -920,6 +912,23 @@ window.__ModuleLoader__.load({
 				// be findable in lastList in time to follow it. We merge updates
 				// from both sources here and follow from this map instead.
 				const pageMeta = new Map()
+				const watchClientId = 'floating-' + Math.random().toString(36).slice(2)
+				let watchStarted = false, watchTargetId = null, watchRenewTimer = null, watchStopTimer = null
+				let captureBackend = 'cdp', streamGeneration = 0, streamState = 'idle', streamMessage = '', streamMime = 'video/mp4; codecs="avc1.42E01E"', videoCleanup = null
+				const effectiveVisible = () => !panel.hidden && document.visibilityState !== 'hidden'
+				const stopVideo = () => { if (videoCleanup) try { videoCleanup() } catch {}; videoCleanup = null }
+				const syncWatch = (targetId) => {
+					if (disposed || !effectiveVisible() || !targetId) return
+					if (watchStopTimer) { window.clearTimeout(watchStopTimer); watchStopTimer = null }
+					if (watchStarted && watchTargetId === targetId) return
+					postJson(watchStarted ? WATCH_SWITCH_ROUTE : WATCH_START_ROUTE, { clientId: watchClientId, targetId }).then((status) => { watchStarted = status && status.ok !== false; watchTargetId = targetId; if (!effectiveVisible()) stopWatch(true) }).catch(() => {})
+					if (!watchRenewTimer) watchRenewTimer = window.setInterval(() => { if (effectiveVisible() && watchTargetId) postJson(WATCH_START_ROUTE, { clientId: watchClientId, targetId: watchTargetId }).catch(() => {}) }, 5000)
+				}
+				const stopWatch = (immediate) => {
+					if (watchRenewTimer) { window.clearInterval(watchRenewTimer); watchRenewTimer = null }
+					const stop = () => { watchStopTimer = null; watchStarted = false; watchTargetId = null; postJson(WATCH_STOP_ROUTE, { clientId: watchClientId }).catch(() => {}) }
+					if (immediate) stop(); else { if (watchStopTimer) window.clearTimeout(watchStopTimer); watchStopTimer = window.setTimeout(stop, 1500) }
+				}
 
 				// ── browser interaction: map panel pointer → real browser pixels ──
 				const INPUT_ROUTE = '/api/ego/input'
@@ -957,8 +966,8 @@ window.__ModuleLoader__.load({
 					const img = liveImg
 					if (!img) return null
 					const rect = img.getBoundingClientRect()
-					const natW = img.naturalWidth || rect.width
-					const natH = img.naturalHeight || rect.height
+					const natW = img.naturalWidth || img.videoWidth || rect.width
+					const natH = img.naturalHeight || img.videoHeight || rect.height
 					if (!natW || !natH) return null
 					const scale = Math.min(rect.width / natW, rect.height / natH)
 					const contentW = natW * scale
@@ -983,10 +992,11 @@ window.__ModuleLoader__.load({
 				//   Ctrl+drag    → pan the view (local only)
 				//   click        → click the agent page
 				//   dblclick     → reset the view zoom
-				const makeZoomImage = (urlEl) => {
-					const img = document.createElement('img')
+				const makeZoomImage = (urlEl, tagName = 'img') => {
+					const img = document.createElement(tagName)
 					img.className = 'dsh-ego-liveimg'
-					img.draggable = false
+					if (tagName === 'img') img.draggable = false
+					else { img.muted = true; img.autoplay = true; img.playsInline = true }
 					img.title = '滚轮缩放 · 按住拖动平移 · 缩小到最小或双击复位'
 					// Hint swap: remember the real URL, show a tip while operating,
 					// restore it after a short quiet period.
@@ -1146,6 +1156,7 @@ window.__ModuleLoader__.load({
 							selectedTabId = s.targetId
 							pinned = null
 							renderLiveMain(s, true)
+							syncWatch(s.targetId)
 							;[...tabsEl.querySelectorAll('.dsh-ego-tab')].forEach(t => t.classList.toggle('active', t.__tid === s.targetId))
 						})
 						tabsEl.appendChild(tab)
@@ -1186,9 +1197,10 @@ window.__ModuleLoader__.load({
 					// wires up the live <img> so future SSE frame events for this
 					// target swap its src in place.
 					const cached = frameCache.get(s.targetId)
-					if (cached) {
-						const img = makeZoomImage(u)
-						img.src = cached
+					if (captureBackend === 'ffmpeg' || cached) {
+						const img = makeZoomImage(u, captureBackend === 'ffmpeg' ? 'video' : 'img')
+						if (captureBackend === 'ffmpeg' && streamState === 'streaming') { stopVideo(); videoCleanup = createMsePlayer(img, streamGeneration, streamMime, (message) => { streamMessage = message }) }
+						else img.src = cached
 						img.alt = 'live'
 						attachLiveImg(s.targetId, img)
 						view.appendChild(img)
@@ -1277,6 +1289,7 @@ window.__ModuleLoader__.load({
 					const sel = selectedTabId !== null ? lastList.find(x => x.targetId === selectedTabId) : null
 					const current = sel || activeMarked
 					currentActiveId = current.targetId
+					syncWatch(current.targetId)
 					setTitle(sel ? 'Agent 浏览器' : 'Agent 浏览器 · 实时')
 					renderLiveMain(current, sel)
 				}
@@ -1319,9 +1332,10 @@ window.__ModuleLoader__.load({
 					})
 					badge.appendChild(openHere)
 					const cached = frameCache.get(current.targetId)
-					if (cached) {
-						const img = makeZoomImage(u)
-						img.src = cached
+					if (captureBackend === 'ffmpeg' || cached) {
+						const img = makeZoomImage(u, captureBackend === 'ffmpeg' ? 'video' : 'img')
+						if (captureBackend === 'ffmpeg' && streamState === 'streaming') { stopVideo(); videoCleanup = createMsePlayer(img, streamGeneration, streamMime, (message) => { streamMessage = message }) }
+						else img.src = cached
 						img.alt = 'live'
 						attachLiveImg(current.targetId, img)
 						view.appendChild(img)
@@ -1462,7 +1476,7 @@ window.__ModuleLoader__.load({
 				// The worker also sends the live list on open (and on tab
 				// churn); treat it as the authoritative tab-list + main-view
 				// update. This replaces the old /api/ego/spaces polling loop.
-				sse.addEventListener('spaces', (ev) => {
+					sse.addEventListener('spaces', (ev) => {
 					if (disposed) return
 					try {
 						const list = JSON.parse(ev.data)
@@ -1471,6 +1485,14 @@ window.__ModuleLoader__.load({
 							// so the "no live browser" placeholder shows up.
 							renderSpaces(list)
 						}
+					} catch {}
+				})
+				sse.addEventListener('capture-status', (ev) => {
+					try {
+						const status = JSON.parse(ev.data)
+						const changed = captureBackend !== (status.backend || 'cdp') || streamGeneration !== (status.generation || 0) || streamState !== (status.state || 'idle') || streamMime !== (status.mime || streamMime)
+						captureBackend = status.backend || 'cdp'; streamGeneration = status.generation || 0; streamState = status.state || 'idle'; streamMessage = status.message || status.code || ''; streamMime = status.mime || streamMime
+						if (changed) { stopVideo(); const current = lastList.find((s) => s.targetId === (selectedTabId || currentActiveId)); if (current) renderLiveMain(current, selectedTabId !== null) }
 					} catch {}
 				})
 				// Debounced reconnect fallback: when the SSE stream drops,
@@ -1597,6 +1619,8 @@ window.__ModuleLoader__.load({
 						panel.classList.add('dsh-ego-panel-open')
 						fab.classList.add('on')
 						refresh()
+						openStream()
+						if (currentActiveId) syncWatch(selectedTabId || currentActiveId)
 					} else {
 						panel.classList.remove('dsh-ego-panel-open')
 						// after the close transition ends, fully hide to free layout.
@@ -1606,6 +1630,10 @@ window.__ModuleLoader__.load({
 							panel.hidden = true
 							fab.classList.remove('on')
 						}, 280)
+						try { if (sse) sse.close() } catch {}
+						sse = null
+						stopWatch(false)
+						stopVideo()
 					}
 					try { localStorage.setItem(OPEN_KEY, open ? '1' : '0') } catch {}
 				}
@@ -1677,13 +1705,18 @@ window.__ModuleLoader__.load({
 				panel.hidden = true
 				fab.classList.remove('on')
 				refresh()
-				openStream()
+				const onVisibility = () => { if (document.visibilityState === 'hidden') { try { if (sse) sse.close() } catch {}; sse = null; stopWatch(false); stopVideo() } else if (!panel.hidden) { openStream(); syncWatch(selectedTabId || currentActiveId) } }
+				document.addEventListener('visibilitychange', onVisibility)
 
 				return () => {
 					disposed = true
 					if (liveFlushRaf != null) try { window.cancelAnimationFrame(liveFlushRaf) } catch {}
 					if (followTimer) window.clearTimeout(followTimer)
 					if (reconnectFallbackTimer) window.clearTimeout(reconnectFallbackTimer)
+					document.removeEventListener('visibilitychange', onVisibility)
+					if (watchRenewTimer) window.clearInterval(watchRenewTimer)
+					if (watchStopTimer) window.clearTimeout(watchStopTimer)
+					stopWatch(true); stopVideo()
 					try { if (sse) sse.close() } catch {}
 					fab.remove()
 					panel.remove()
@@ -1882,7 +1915,21 @@ window.__ModuleLoader__.load({
 			this.zoomState = { scale: 1, tx: 0, ty: 0 }
 			this.liveCount = 0
 			this.disposed = false
-			this.visible = true
+			this.visible = false
+			this.clientId = 'sidebar-' + Math.random().toString(36).slice(2)
+			this.watchStarted = false
+			this.watchTargetId = null
+			this.watchRenewTimer = null
+			this.watchStopTimer = null
+			this.backend = 'cdp'
+			this.streamGeneration = 0
+			this.streamState = 'idle'
+			this.streamMessage = ''
+			this.streamMime = 'video/mp4; codecs="avc1.42E01E"'
+			this.liveVideo = null
+			this.videoCleanup = null
+			this.documentVisible = document.visibilityState !== 'hidden'
+			this.onDocumentVisibility = this._handleDocumentVisibility.bind(this)
 			this.sse = null
 			this.reconnectFallbackTimer = null
 			this.lastSawActive = false
@@ -1911,6 +1958,7 @@ window.__ModuleLoader__.load({
 				captchaKind: null,
 				historyOpen: false,
 				zoomHint: null,
+				backend: 'cdp', streamState: 'idle', streamMessage: '', streamGeneration: 0, streamMime: 'video/mp4; codecs="avc1.42E01E"',
 			}
 		}
 		LivePreviewController.prototype.subscribe = function (cb) {
@@ -1967,12 +2015,18 @@ window.__ModuleLoader__.load({
 				s.captchaKind = captchaKind
 				s.historyOpen = self.historyOpen
 				s.zoomHint = self._zoomHint
+				s.backend = self.backend
+				s.streamState = self.streamState
+				s.streamMessage = self.streamMessage
+				s.streamGeneration = self.streamGeneration
+				s.streamMime = self.streamMime
 			})
+			this._syncWatch(currentTargetId)
 		}
 		LivePreviewController.prototype.start = function () {
+			document.addEventListener('visibilitychange', this.onDocumentVisibility)
 			this._recompute()
-			this.refresh()
-			this.openStream()
+			if (this.visible && this.documentVisible) { this.refresh(); this.openStream() }
 		}
 		LivePreviewController.prototype.dispose = function () {
 			this.disposed = true
@@ -1980,20 +2034,73 @@ window.__ModuleLoader__.load({
 			if (this.followTimer) window.clearTimeout(this.followTimer)
 			if (this.reconnectFallbackTimer) window.clearTimeout(this.reconnectFallbackTimer)
 			if (this._zoomHintTimer) window.clearTimeout(this._zoomHintTimer)
+			document.removeEventListener('visibilitychange', this.onDocumentVisibility)
+			if (this.watchRenewTimer) window.clearInterval(this.watchRenewTimer)
+			if (this.watchStopTimer) window.clearTimeout(this.watchStopTimer)
+			this._stopWatch(true)
+			this._destroyVideo()
 			this.closeStream()
 		}
+		LivePreviewController.prototype._handleDocumentVisibility = function () {
+			this.documentVisible = document.visibilityState !== 'hidden'
+			this.setVisible(this.visible)
+		}
 		LivePreviewController.prototype.setVisible = function (v) {
-			if (this.visible === v) return
+			var changed = this.visible !== v
 			this.visible = v
-			if (v) {
+			var effective = v && this.documentVisible
+			if (effective) {
 				// On becoming visible again, do a one-shot fallback fetch to
 				// re-sync immediately (the SSE `spaces` event will also catch
 				// up on the next keepalive tick, but this avoids a blank gap).
 				this.refresh()
 				this.openStream()
+				this._syncWatch(this.currentActiveId)
 			} else {
 				this.closeStream()
+				this._stopWatch(false)
+				this._destroyVideo()
 			}
+		}
+		LivePreviewController.prototype._syncWatch = function (targetId) {
+			if (this.disposed || !this.visible || !this.documentVisible || !targetId) return
+			var self = this
+			if (this.watchStopTimer) { window.clearTimeout(this.watchStopTimer); this.watchStopTimer = null }
+			var route = this.watchStarted ? WATCH_SWITCH_ROUTE : WATCH_START_ROUTE
+			if (this.watchStarted && this.watchTargetId === targetId) return
+			var body = { clientId: this.clientId, targetId: targetId }
+			postJson(route, body).then(function (status) {
+				self.watchStarted = status && status.ok !== false
+				self.watchTargetId = targetId
+				if (!self.visible || !self.documentVisible) self._stopWatch(true)
+			}).catch(function () {})
+			if (!this.watchRenewTimer) this.watchRenewTimer = window.setInterval(function () {
+				if (self.visible && self.documentVisible && self.watchTargetId) postJson(WATCH_START_ROUTE, { clientId: self.clientId, targetId: self.watchTargetId }).catch(function () {})
+			}, 5000)
+		}
+		LivePreviewController.prototype._stopWatch = function (immediate) {
+			var self = this
+			if (this.watchRenewTimer) { window.clearInterval(this.watchRenewTimer); this.watchRenewTimer = null }
+			var stop = function () {
+				self.watchStopTimer = null
+				self.watchStarted = false; self.watchTargetId = null
+				postJson(WATCH_STOP_ROUTE, { clientId: self.clientId }).catch(function () {})
+			}
+			if (immediate) stop()
+			else { if (this.watchStopTimer) window.clearTimeout(this.watchStopTimer); this.watchStopTimer = window.setTimeout(stop, 1500) }
+		}
+		LivePreviewController.prototype._destroyVideo = function () {
+			if (this.videoCleanup) try { this.videoCleanup() } catch (e) {}
+			this.videoCleanup = null; this.liveVideo = null
+		}
+		LivePreviewController.prototype.setLiveVideo = function (video, targetId) {
+			this._destroyVideo()
+			this.liveVideo = video; this.liveImg = video; this.liveImgTargetId = targetId
+			if (!video || this.backend !== 'ffmpeg' || this.streamState !== 'streaming') return
+			var self = this
+			this.videoCleanup = createMsePlayer(video, this.streamGeneration, this.streamMime, function (message) {
+				self.streamState = 'failed'; self.streamMessage = message; self._recompute()
+			})
 		}
 		LivePreviewController.prototype.setLiveImg = function (img, targetId) {
 			this.liveImg = img
@@ -2091,6 +2198,15 @@ window.__ModuleLoader__.load({
 					}
 				} catch (e) {}
 			})
+			this.sse.addEventListener('capture-status', function (ev) {
+				try {
+					var status = JSON.parse(ev.data)
+					var generationChanged = self.streamGeneration !== (status.generation || 0)
+					self.backend = status.backend || 'cdp'; self.streamState = status.state || 'idle'; self.streamMessage = status.message || status.code || ''; self.streamGeneration = status.generation || 0; self.streamMime = status.mime || self.streamMime
+					if (generationChanged || self.backend !== 'ffmpeg') self._destroyVideo()
+					self._recompute()
+				} catch (e) {}
+			})
 			// Debounced reconnect fallback: EventSource auto-reconnects on
 			// error; we also kick off a one-shot /api/ego/spaces fetch so the
 			// panel re-syncs immediately after a successful reconnect, without
@@ -2112,6 +2228,7 @@ window.__ModuleLoader__.load({
 		}
 		LivePreviewController.prototype.applyFrame = function (targetId, dataUrl, vw, vh) {
 			if (this.disposed) return
+			this.frameCache.delete(targetId)
 			this.frameCache.set(targetId, dataUrl)
 			var MAX_CACHED_FRAMES = 12
 			if (this.frameCache.size > MAX_CACHED_FRAMES) {
@@ -2171,8 +2288,8 @@ window.__ModuleLoader__.load({
 			if (!Number.isFinite(vw) || !Number.isFinite(vh)) return null
 			var img = this.liveImg
 			var rect = img.getBoundingClientRect()
-			var natW = img.naturalWidth || rect.width
-			var natH = img.naturalHeight || rect.height
+			var natW = img.naturalWidth || img.videoWidth || rect.width
+			var natH = img.naturalHeight || img.videoHeight || rect.height
 			if (!natW || !natH) return null
 			var scale = Math.min(rect.width / natW, rect.height / natH)
 			var contentW = natW * scale
@@ -2202,6 +2319,7 @@ window.__ModuleLoader__.load({
 				this.pinned = null
 			}
 			this._recompute()
+			this._syncWatch(this.selectedTabId || this.currentActiveId)
 		}
 		LivePreviewController.prototype.closeTab = function (targetId) {
 			var self = this
@@ -2362,6 +2480,7 @@ window.__ModuleLoader__.load({
 			var state = useSnapshotRef.current(function (s) { return s })
 
 			var imgRef = React.useRef(null)
+			var videoRef = React.useRef(null)
 
 			React.useEffect(function () {
 				controller.start()
@@ -2377,16 +2496,17 @@ window.__ModuleLoader__.load({
 				if (imgRef.current && state.currentTargetId != null) {
 					controller.setLiveImg(imgRef.current, state.currentTargetId)
 				}
-			}, [state.currentTargetId, controller])
+				if (videoRef.current && state.currentTargetId != null) controller.setLiveVideo(videoRef.current, state.currentTargetId)
+			}, [state.currentTargetId, state.backend, state.streamGeneration, state.streamState, controller])
 
 			// Native wheel listener (React onWheel is passive, can't preventDefault)
 			React.useEffect(function () {
-				var img = imgRef.current
+				var img = imgRef.current || videoRef.current
 				if (!img) return
 				var handler = function (e) { controller.handleWheel(e) }
 				img.addEventListener('wheel', handler, { passive: false })
 				return function () { img.removeEventListener('wheel', handler) }
-			}, [controller, state.currentTargetId])
+			}, [controller, state.currentTargetId, state.backend, state.streamGeneration])
 
 			var h = React.createElement
 
@@ -2487,7 +2607,12 @@ window.__ModuleLoader__.load({
 					)
 				)
 			} else {
-				var liveImg = currentSpace.thumbnail
+				var liveImg = state.backend === 'ffmpeg'
+					? h('video', {
+						ref: videoRef, key: 'livevideo-' + state.streamGeneration, className: 'dsh-ego-side-liveimg', muted: true, autoPlay: true, playsInline: true,
+						onPointerDown: function (e) { controller.handlePointerDown(e) }, onPointerMove: function (e) { controller.handlePointerMove(e) }, onPointerUp: function (e) { controller.handlePointerUp(e) }, onPointerCancel: function (e) { controller.handlePointerUp(e) }, onDoubleClick: function (e) { controller.handleDoubleClick(e) },
+					})
+					: currentSpace.thumbnail
 					? h('img', {
 						ref: imgRef,
 						key: 'liveimg',
@@ -2501,13 +2626,13 @@ window.__ModuleLoader__.load({
 						onPointerCancel: function (e) { controller.handlePointerUp(e) },
 						onDoubleClick: function (e) { controller.handleDoubleClick(e) },
 					})
-					: h('div', { className: 'dsh-ego-side-liveurl' }, '（暂无截图 — about:blank 或浏览器未渲染）')
+					: h('div', { className: 'dsh-ego-side-liveurl' }, state.streamMessage || '（暂无截图 — about:blank 或浏览器未渲染）')
 
 				body = h('div', { className: 'dsh-ego-side-body' },
 					h('div', { className: 'dsh-ego-side-liveview' },
 						h('div', { className: 'dsh-ego-side-livebadge' },
 							h('span', { className: 'dsh-ego-side-state-dot' + (state.pinned ? ' pin' : state.busy ? ' busy' : '') }),
-							h('span', { style: { flex: 1 } }, state.pinned ? '已固定查看' : '正在实时浏览'),
+							h('span', { style: { flex: 1 } }, (state.backend === 'ffmpeg' ? 'FFmpeg · H.264' : 'CDP') + ' · ' + (state.streamState === 'failed' ? (state.streamMessage || '失败') : state.streamState)),
 							state.pinned
 								? h('button', {
 									className: 'dsh-ego-side-back', type: 'button',

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,96 +1,53 @@
-// lib/config.js — composition-layer schema, resolved config shape, and resolver.
-//
-// The composition `Config` (cordis.patch.yml) is the first-boot seed; the
-// settings user layer composes on top of it at runtime. `resolveConfig`
-// normalises any combination of partial source values (composition, user
-// layer, or both) into a fully-populated shape the tool registration and
-// gateway can consume.
 import z from "schemastery";
 
-/**
- * Schemastery schema for the composition entry and the `ego-browser` settings
- * namespace. Exposed as the plugin's `Config` export so cordis's loader
- * validates the composition layer and `ctx.settings.register()` validates the
- * user layer.
- */
+const backend = z.union(["auto", "cdp", "ffmpeg"]);
+const profile = z.union(["low", "balanced", "high"]);
+const encoder = z.union([
+  "auto", "software", "h264_nvenc", "h264_qsv", "h264_amf",
+  "h264_videotoolbox", "h264_vaapi",
+]);
+
+// Defaults live in resolveConfig so a persisted legacy value is not hidden by
+// a schema default before the one-release migration runs.
 export const Config = z.object({
-  /**
-   * Path to the Chrome/Chromium/Edge binary. Empty string means "auto-detect"
-   * (scan PATH + common fixed locations via `findChromeBinary()`). Set this
-   * when auto-detection fails or you want to pin a specific browser.
-   */
-  chromePath: z.string().default("").description(
-    "Path to the Chrome/Chromium binary. Empty = auto-detect.",
-  ),
-  /**
-   * Cap on live-frame fan-out (frames/sec) from the cast worker to the watch
-   * panel. 0 = uncapped (full browser repaint cadence). >0 = at most N
-   * frames/sec; the watched (active) tab is never throttled, only background
-   * repainting tabs. Lower this to save bandwidth/CPU on dynamic pages.
-   * Range 0–60; default 0.
-   */
-  castFpsCap: z.number().min(0).max(60).step(1).default(0).description(
-    "Max frames/sec to push (0 = uncapped, active tab never throttled). Default 0.",
-  ),
-  /**
-   * JPEG quality (1–100) for screencast frames and screenshot backstop.
-   * Lower = smaller payload, more compression artifacts. Range 1–100;
-   * default 55.
-   */
-  screencastQuality: z.number().min(1).max(100).step(1).default(55).description(
-    "JPEG quality for screencast frames (1-100). Default 55.",
-  ),
-  /**
-   * Max width (CSS px) of each pushed screencast frame. The browser scales
-   * down to fit. Lower = smaller payload, less detail. Range 320–1920;
-   * default 960.
-   */
-  screencastMaxWidth: z.number().min(320).max(1920).step(40).default(960).description(
-    "Max width of screencast frames in px (320-1920). Default 960.",
-  ),
-  /**
-   * How long (ms) a page may go without a pushed screencast frame before the
-   * periodic backstop issues a forced captureScreenshot for it. Also serves
-   * as the minimum interval between forced captures for the same target.
-   * Lower = more frequent backstop frames (higher CPU/CDP load). Range
-   * 200–10000; default 5000.
-   */
-  backstopIntervalMs: z.number().min(200).max(10000).step(100).default(5000).description(
-    "Backstop interval in ms — how long before a stale page gets a forced screenshot. Default 5000.",
-  ),
+  chromePath: z.string().description("Path to Chrome/Chromium. Empty = auto-detect."),
+  captureBackend: backend.description("Capture backend: auto, cdp, or ffmpeg."),
+  streamProfile: profile.description("Capture quality profile."),
+  cdpFps: z.number().min(5).max(30).step(1).description("CDP preview FPS."),
+  cdpQuality: z.number().min(1).max(100).step(1).description("CDP JPEG quality."),
+  cdpMaxWidth: z.number().min(320).max(1920).step(40).description("CDP frame max width."),
+  cdpBackstopIntervalMs: z.number().min(1000).max(10000).step(100).description("CDP recovery screenshot interval."),
+  ffmpegFps: z.number().min(5).max(30).step(1).description("FFmpeg video FPS."),
+  ffmpegMaxWidth: z.number().min(320).max(1920).step(40).description("FFmpeg video max width."),
+  ffmpegEncoder: encoder.description("FFmpeg H.264 encoder."),
+  ffmpegPath: z.string().description("Custom FFmpeg path. Empty = bundled binary."),
+  // Deprecated read-compatible keys. The settings UI only writes canonical keys.
+  castFpsCap: z.number().min(0).max(60).step(1),
+  screencastQuality: z.number().min(1).max(100).step(1),
+  screencastMaxWidth: z.number().min(320).max(1920).step(40),
+  backstopIntervalMs: z.number().min(200).max(10000).step(100),
 });
 
-/**
- * Resolve config with fallbacks for missing / invalid values.
- * @param {Partial<ReturnType<typeof Config>>} config - raw config from cordis.yml or settings scope.
- * @returns {{ chromePath: string, castFpsCap: number, screencastQuality: number, screencastMaxWidth: number, backstopIntervalMs: number }} a fully-populated config view.
- */
-export function resolveConfig(config) {
-  const chromePath =
-    typeof config?.chromePath === "string" ? config.chromePath : "";
-  const castFpsCap =
-    typeof config?.castFpsCap === "number" &&
-    Number.isFinite(config.castFpsCap) &&
-    config.castFpsCap >= 0 && config.castFpsCap <= 60
-      ? config.castFpsCap
-      : 0;
-  const screencastQuality =
-    typeof config?.screencastQuality === "number" &&
-    Number.isFinite(config.screencastQuality) &&
-    config.screencastQuality >= 1 && config.screencastQuality <= 100
-      ? config.screencastQuality
-      : 55;
-  const screencastMaxWidth =
-    typeof config?.screencastMaxWidth === "number" &&
-    Number.isFinite(config.screencastMaxWidth) &&
-    config.screencastMaxWidth >= 320 && config.screencastMaxWidth <= 1920
-      ? config.screencastMaxWidth
-      : 960;
-  const backstopIntervalMs =
-    typeof config?.backstopIntervalMs === "number" &&
-    Number.isFinite(config.backstopIntervalMs) &&
-    config.backstopIntervalMs >= 200 && config.backstopIntervalMs <= 10000
-      ? config.backstopIntervalMs
-      : 5000;
-  return { chromePath, castFpsCap, screencastQuality, screencastMaxWidth, backstopIntervalMs };
+const finiteIn = (value, min, max) => typeof value === "number" && Number.isFinite(value) && value >= min && value <= max;
+const oneOf = (value, values, fallback) => values.includes(value) ? value : fallback;
+
+export function resolveConfig(config = {}) {
+  const legacyFps = finiteIn(config.castFpsCap, 0, 60)
+    ? (config.castFpsCap === 0 ? 20 : Math.max(5, Math.min(30, config.castFpsCap)))
+    : 20;
+  const selectedProfile = oneOf(config.streamProfile, ["low", "balanced", "high"], "balanced");
+  const profileDefaults = selectedProfile === "low" ? { fps: 15, width: 960 } : selectedProfile === "high" ? { fps: 30, width: 1600 } : { fps: 20, width: 1280 };
+  return {
+    chromePath: typeof config.chromePath === "string" ? config.chromePath : "",
+    captureBackend: oneOf(config.captureBackend, ["auto", "cdp", "ffmpeg"], "auto"),
+    streamProfile: selectedProfile,
+    cdpFps: finiteIn(config.cdpFps, 5, 30) ? config.cdpFps : legacyFps,
+    cdpQuality: finiteIn(config.cdpQuality, 1, 100) ? config.cdpQuality : (finiteIn(config.screencastQuality, 1, 100) ? config.screencastQuality : 55),
+    cdpMaxWidth: finiteIn(config.cdpMaxWidth, 320, 1920) ? config.cdpMaxWidth : (finiteIn(config.screencastMaxWidth, 320, 1920) ? config.screencastMaxWidth : 960),
+    cdpBackstopIntervalMs: finiteIn(config.cdpBackstopIntervalMs, 1000, 10000) ? config.cdpBackstopIntervalMs : (finiteIn(config.backstopIntervalMs, 200, 10000) ? Math.max(1000, config.backstopIntervalMs) : 3000),
+    ffmpegFps: finiteIn(config.ffmpegFps, 5, 30) ? config.ffmpegFps : profileDefaults.fps,
+    ffmpegMaxWidth: finiteIn(config.ffmpegMaxWidth, 320, 1920) ? config.ffmpegMaxWidth : profileDefaults.width,
+    ffmpegEncoder: oneOf(config.ffmpegEncoder, ["auto", "software", "h264_nvenc", "h264_qsv", "h264_amf", "h264_videotoolbox", "h264_vaapi"], "auto"),
+    ffmpegPath: typeof config.ffmpegPath === "string" ? config.ffmpegPath : "",
+  };
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,7 +3,7 @@ import z from "schemastery";
 const backend = z.union(["auto", "cdp", "ffmpeg"]);
 const profile = z.union(["low", "balanced", "high"]);
 const encoder = z.union([
-  "auto", "software", "h264_nvenc", "h264_qsv", "h264_amf",
+  "auto", "software", "h264_mf", "h264_nvenc", "h264_qsv", "h264_amf",
   "h264_videotoolbox", "h264_vaapi",
 ]);
 
@@ -19,6 +19,7 @@ export const Config = z.object({
   cdpBackstopIntervalMs: z.number().min(1000).max(10000).step(100).description("CDP recovery screenshot interval."),
   ffmpegFps: z.number().min(5).max(30).step(1).description("FFmpeg video FPS."),
   ffmpegMaxWidth: z.number().min(320).max(1920).step(40).description("FFmpeg video max width."),
+  ffmpegBitrateKbps: z.number().min(500).max(20000).step(250).description("FFmpeg target video bitrate in kbps."),
   ffmpegEncoder: encoder.description("FFmpeg H.264 encoder."),
   ffmpegPath: z.string().description("Custom FFmpeg path. Empty = bundled binary."),
   // Deprecated read-compatible keys. The settings UI only writes canonical keys.
@@ -36,7 +37,11 @@ export function resolveConfig(config = {}) {
     ? (config.castFpsCap === 0 ? 20 : Math.max(5, Math.min(30, config.castFpsCap)))
     : 20;
   const selectedProfile = oneOf(config.streamProfile, ["low", "balanced", "high"], "balanced");
-  const profileDefaults = selectedProfile === "low" ? { fps: 15, width: 960 } : selectedProfile === "high" ? { fps: 30, width: 1600 } : { fps: 20, width: 1280 };
+  const profileDefaults = selectedProfile === "low"
+    ? { fps: 15, width: 960, bitrateKbps: 2000 }
+    : selectedProfile === "high"
+      ? { fps: 30, width: 1600, bitrateKbps: 8000 }
+      : { fps: 20, width: 1280, bitrateKbps: 4000 };
   return {
     chromePath: typeof config.chromePath === "string" ? config.chromePath : "",
     captureBackend: oneOf(config.captureBackend, ["auto", "cdp", "ffmpeg"], "auto"),
@@ -47,7 +52,8 @@ export function resolveConfig(config = {}) {
     cdpBackstopIntervalMs: finiteIn(config.cdpBackstopIntervalMs, 1000, 10000) ? config.cdpBackstopIntervalMs : (finiteIn(config.backstopIntervalMs, 200, 10000) ? Math.max(1000, config.backstopIntervalMs) : 3000),
     ffmpegFps: finiteIn(config.ffmpegFps, 5, 30) ? config.ffmpegFps : profileDefaults.fps,
     ffmpegMaxWidth: finiteIn(config.ffmpegMaxWidth, 320, 1920) ? config.ffmpegMaxWidth : profileDefaults.width,
-    ffmpegEncoder: oneOf(config.ffmpegEncoder, ["auto", "software", "h264_nvenc", "h264_qsv", "h264_amf", "h264_videotoolbox", "h264_vaapi"], "auto"),
+    ffmpegBitrateKbps: finiteIn(config.ffmpegBitrateKbps, 500, 20000) ? config.ffmpegBitrateKbps : profileDefaults.bitrateKbps,
+    ffmpegEncoder: oneOf(config.ffmpegEncoder, ["auto", "software", "h264_mf", "h264_nvenc", "h264_qsv", "h264_amf", "h264_videotoolbox", "h264_vaapi"], "auto"),
     ffmpegPath: typeof config.ffmpegPath === "string" ? config.ffmpegPath : "",
   };
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -21,7 +21,8 @@ export const Config = z.object({
   ffmpegMaxWidth: z.number().min(320).max(1920).step(40).description("FFmpeg video max width."),
   ffmpegBitrateKbps: z.number().min(500).max(20000).step(250).description("FFmpeg target video bitrate in kbps."),
   ffmpegEncoder: encoder.description("FFmpeg H.264 encoder."),
-  ffmpegPath: z.string().description("Custom FFmpeg path. Empty = bundled binary."),
+  ffmpegPath: z.string().description("Custom FFmpeg path. Empty = detect PATH or managed install."),
+  githubMirror: z.string().description("HTTPS base replacing https://github.com for managed downloads."),
   // Deprecated read-compatible keys. The settings UI only writes canonical keys.
   castFpsCap: z.number().min(0).max(60).step(1),
   screencastQuality: z.number().min(1).max(100).step(1),
@@ -55,5 +56,6 @@ export function resolveConfig(config = {}) {
     ffmpegBitrateKbps: finiteIn(config.ffmpegBitrateKbps, 500, 20000) ? config.ffmpegBitrateKbps : profileDefaults.bitrateKbps,
     ffmpegEncoder: oneOf(config.ffmpegEncoder, ["auto", "software", "h264_mf", "h264_nvenc", "h264_qsv", "h264_amf", "h264_videotoolbox", "h264_vaapi"], "auto"),
     ffmpegPath: typeof config.ffmpegPath === "string" ? config.ffmpegPath : "",
+    githubMirror: typeof config.githubMirror === "string" ? config.githubMirror : "",
   };
 }

--- a/lib/ffmpeg-installation.js
+++ b/lib/ffmpeg-installation.js
@@ -1,0 +1,333 @@
+import { createHash, randomUUID } from "node:crypto";
+import { createReadStream, createWriteStream } from "node:fs";
+import { access, chmod, copyFile, mkdir, open, readdir, rename, rm, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { homedir } from "node:os";
+import { isIP } from "node:net";
+import { dirname, join, normalize, resolve, sep } from "node:path";
+import { pipeline } from "node:stream/promises";
+import { createGunzip } from "node:zlib";
+import { spawn as nodeSpawn } from "node:child_process";
+import { platformManifest, rewriteGithubUrl } from "./ffmpeg-manifest.js";
+import { probeFfmpeg } from "../bin/ffmpeg-probe.mjs";
+
+export function defaultFfmpegCacheRoot(home = homedir()) {
+  return join(home, ".dsh", "cache", "ego-browser", "ffmpeg");
+}
+
+const SHARED_MANAGERS_KEY = Symbol.for("@dsh-external/ego-browser.ffmpeg-installation-managers");
+const sharedManagers = globalThis[SHARED_MANAGERS_KEY] || (globalThis[SHARED_MANAGERS_KEY] = new Map());
+
+export function getSharedFfmpegInstallationManager(options = {}) {
+  const platform = options.platform || process.platform;
+  const arch = options.arch || process.arch;
+  const cacheRoot = options.cacheRoot || defaultFfmpegCacheRoot();
+  const key = `${platform}:${arch}:${cacheRoot}`;
+  if (!sharedManagers.has(key)) sharedManagers.set(key, new FfmpegInstallationManager({ ...options, platform, arch, cacheRoot }));
+  return sharedManagers.get(key);
+}
+
+export class FfmpegInstallationManager {
+  constructor({ getConfig = () => ({}), platform = process.platform, arch = process.arch, env = process.env, cacheRoot = defaultFfmpegCacheRoot(), fetchImpl = globalThis.fetch, spawn = nodeSpawn } = {}) {
+    this.getConfig = getConfig;
+    this.platform = platform;
+    this.arch = arch;
+    this.env = env;
+    this.cacheRoot = cacheRoot;
+    this.fetch = fetchImpl;
+    this.spawn = spawn;
+    this.manifest = platformManifest(platform, arch);
+    this.installPromise = null;
+    this.checkPromise = null;
+    this.checkKey = null;
+    this.statusValue = this.#baseStatus();
+  }
+
+  #baseStatus() {
+    const unsupported = this.platform === "linux" && (this.env.XDG_SESSION_TYPE === "wayland" || this.env.WAYLAND_DISPLAY);
+    return {
+      state: unsupported ? "unsupported" : "missing", source: null, path: null, version: null, encoder: null,
+      progress: null, canDownload: !unsupported && !!this.manifest, canSelectFfmpeg: false,
+      updateAvailable: false, reason: unsupported ? "Wayland capture is not supported" : null, candidates: [],
+      platform: this.platform, arch: this.arch, buildId: this.manifest?.buildId || null,
+    };
+  }
+
+  status() { return structuredClone(this.statusValue); }
+
+  managedPath() {
+    if (!this.manifest) return null;
+    return join(this.cacheRoot, `${this.platform}-${this.arch}`, this.manifest.buildId, this.manifest.executableName);
+  }
+
+  async check({ configuredPath, requestedEncoder = "auto" } = {}) {
+    if (this.installPromise) return this.status();
+    const key = JSON.stringify([configuredPath ?? "", requestedEncoder]);
+    if (this.checkPromise) {
+      if (this.checkKey === key) return this.checkPromise;
+      await this.checkPromise.catch(() => {});
+    }
+    if (this.statusValue.state === "unsupported") return this.status();
+    this.checkKey = key;
+    const promise = this.#check(configuredPath, requestedEncoder).finally(() => {
+      if (this.checkPromise === promise) { this.checkPromise = null; this.checkKey = null; }
+    });
+    this.checkPromise = promise;
+    return this.checkPromise;
+  }
+
+  async #check(configuredPath, requestedEncoder = "auto") {
+    this.#set({ state: "checking", reason: null, progress: null, canSelectFfmpeg: false });
+    const custom = configuredPath ?? this.getConfig().ffmpegPath ?? "";
+    const candidates = [];
+    if (custom) candidates.push({ source: "custom", path: custom });
+    candidates.push({ source: "system", path: "ffmpeg" });
+    const managed = this.managedPath();
+    if (managed) candidates.push({ source: "managed", path: managed });
+    const results = [];
+    for (const candidate of candidates) {
+      try {
+        const probe = await probeFfmpeg(candidate.path, { platform: this.platform, env: this.env, spawn: this.spawn, requestedEncoder });
+        results.push({ ...candidate, usable: true, version: probe.version, encoder: probe.encoder });
+        this.#set({
+          state: "ready", source: candidate.source, path: candidate.path, version: probe.version, encoder: probe.encoder,
+          canSelectFfmpeg: true, canDownload: !!this.manifest, reason: null, candidates: results,
+          updateAvailable: candidate.source === "managed" && !normalize(candidate.path).includes(normalize(this.manifest?.buildId || "")),
+        });
+        return this.status();
+      } catch (error) {
+        results.push({ ...candidate, usable: false, code: error.code || "ffmpeg-unavailable", reason: error.message });
+      }
+    }
+    this.#set({ ...this.#baseStatus(), state: "missing", candidates: results, reason: results[0]?.reason || "No compatible FFmpeg installation was found" });
+    return this.status();
+  }
+
+  async resolvedPath() {
+    const status = this.statusValue.state === "ready" ? this.status() : await this.check();
+    return status.canSelectFfmpeg ? status.path : null;
+  }
+
+  install({ githubMirror, configuredPath, requestedEncoder = "auto" } = {}) {
+    if (this.installPromise) return this.installPromise;
+    if (!this.manifest) return Promise.reject(codedError("ffmpeg-platform-unsupported", `No managed FFmpeg build for ${this.platform}-${this.arch}`));
+    this.installPromise = this.#install(githubMirror ?? this.getConfig().githubMirror ?? "", configuredPath ?? this.getConfig().ffmpegPath ?? "", requestedEncoder)
+      .finally(() => { this.installPromise = null; });
+    return this.installPromise;
+  }
+
+  startInstall(options = {}) {
+    void this.install(options).catch(() => {});
+    return this.status();
+  }
+
+  async #install(githubMirror, configuredPath, requestedEncoder) {
+    const manifest = this.manifest;
+    const platformRoot = join(this.cacheRoot, `${this.platform}-${this.arch}`);
+    const tempRoot = join(platformRoot, `.install-${randomUUID()}`);
+    const archivePath = join(tempRoot, `archive.${manifest.archiveType === "gzip" ? "gz" : "pkg"}`);
+    const extractedPath = join(tempRoot, manifest.executableName);
+    const finalRoot = join(platformRoot, manifest.buildId);
+    const finalPath = join(finalRoot, manifest.executableName);
+    let releaseLock = null;
+    let backup = null;
+    let published = false;
+    try {
+      await mkdir(platformRoot, { recursive: true });
+      releaseLock = await acquireInstallLock(platformRoot);
+      await cleanupInterruptedInstalls(platformRoot);
+      if (manifest.archiveType === "tar") await ensureTarAvailable(this.spawn);
+      await mkdir(tempRoot, { recursive: true });
+      const url = rewriteGithubUrl(manifest.url, githubMirror);
+      this.#set({ state: "downloading", reason: null, progress: { receivedBytes: 0, totalBytes: manifest.size, percent: 0 }, canSelectFfmpeg: false });
+      const digest = await downloadFile(url, archivePath, {
+        fetchImpl: this.fetch, expectedSize: manifest.size,
+        onProgress: (progress) => this.#set({ state: "downloading", progress }),
+      });
+      this.#set({ state: "verifying", progress: null });
+      if (digest !== manifest.sha256) throw codedError("ffmpeg-checksum-mismatch", "Downloaded FFmpeg archive failed SHA-256 verification");
+      this.#set({ state: "extracting" });
+      if (manifest.archiveType === "gzip") {
+        await pipeline(createReadStream(archivePath), createGunzip(), createWriteStream(extractedPath, { mode: 0o755 }));
+      } else {
+        await extractWithTar(archivePath, tempRoot, extractedPath, manifest.archiveExecutable, this.spawn);
+      }
+      if (this.platform !== "win32") await chmod(extractedPath, 0o755);
+      if (this.platform === "darwin") await prepareMacExecutable(extractedPath, this.arch, this.spawn);
+      this.#set({ state: "probing" });
+      const probe = await probeFfmpeg(extractedPath, { platform: this.platform, env: this.env, spawn: this.spawn, requestedEncoder });
+      const executableSha256 = await hashFile(extractedPath);
+      await writeFile(join(tempRoot, "install.json"), JSON.stringify({
+        provider: manifest.provider, buildId: manifest.buildId, archiveSha256: manifest.sha256,
+        executableSha256, installedAt: new Date().toISOString(), version: probe.version, encoder: probe.encoder,
+      }, null, 2));
+      await rm(archivePath, { force: true });
+      backup = `${finalRoot}.old-${randomUUID()}`;
+      let hadExisting = false;
+      try { await rename(finalRoot, backup); hadExisting = true; } catch (error) { if (error.code !== "ENOENT") throw error; }
+      await mkdir(dirname(finalRoot), { recursive: true });
+      await rename(tempRoot, finalRoot);
+      published = true;
+      await access(finalPath, this.platform === "win32" ? constants.F_OK : constants.X_OK);
+      if (hadExisting) await rm(backup, { recursive: true, force: true });
+      backup = null;
+      return await this.#check(configuredPath, requestedEncoder);
+    } catch (error) {
+      if (published) await rm(finalRoot, { recursive: true, force: true }).catch(() => {});
+      if (backup) await rename(backup, finalRoot).catch(() => {});
+      await rm(tempRoot, { recursive: true, force: true }).catch(() => {});
+      this.#set({ state: "failed", reason: error.message, progress: null, canSelectFfmpeg: false, canDownload: true });
+      throw error;
+    } finally {
+      await releaseLock?.();
+    }
+  }
+
+  #set(patch) { this.statusValue = { ...this.statusValue, ...patch }; }
+}
+
+async function acquireInstallLock(platformRoot) {
+  const lockPath = join(platformRoot, ".install.lock");
+  const token = randomUUID();
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const handle = await open(lockPath, "wx");
+      await handle.writeFile(JSON.stringify({ token, pid: process.pid, createdAt: new Date().toISOString() }));
+      return async () => {
+        await handle.close().catch(() => {});
+        const owner = await import("node:fs/promises").then((fs) => fs.readFile(lockPath, "utf8")).then(JSON.parse).catch(() => null);
+        if (owner?.token === token) await rm(lockPath, { force: true }).catch(() => {});
+      };
+    } catch (error) {
+      if (error.code !== "EEXIST") throw error;
+      const owner = await import("node:fs/promises").then((fs) => fs.readFile(lockPath, "utf8")).then(JSON.parse).catch(() => null);
+      if (!owner?.pid || !isProcessAlive(owner.pid)) { await rm(lockPath, { force: true }); continue; }
+      throw codedError("ffmpeg-install-busy", "Another FFmpeg installation is already running");
+    }
+  }
+  throw codedError("ffmpeg-install-busy", "Another FFmpeg installation is already running");
+}
+
+function isProcessAlive(pid) {
+  try { process.kill(Number(pid), 0); return true; }
+  catch (error) { return error?.code === "EPERM"; }
+}
+
+async function cleanupInterruptedInstalls(platformRoot) {
+  const entries = await readdir(platformRoot, { withFileTypes: true }).catch((error) => error.code === "ENOENT" ? [] : Promise.reject(error));
+  await Promise.all(entries.filter((entry) => entry.isDirectory() && entry.name.startsWith(".install-")).map((entry) => rm(join(platformRoot, entry.name), { recursive: true, force: true })));
+}
+
+export async function downloadFile(url, target, { fetchImpl = globalThis.fetch, expectedSize = null, onProgress = () => {}, maxBytes = 250 * 1024 * 1024 } = {}) {
+  let current = url;
+  let response;
+  for (let redirects = 0; redirects <= 5; redirects += 1) {
+    assertSafeDownloadUrl(current);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 15000);
+    try { response = await fetchImpl(current, { redirect: "manual", signal: controller.signal }); }
+    finally { clearTimeout(timer); }
+    if (![301, 302, 303, 307, 308].includes(response.status)) break;
+    const location = response.headers.get("location");
+    if (!location) throw codedError("ffmpeg-download-failed", "FFmpeg download redirect omitted Location");
+    current = new URL(location, current).toString();
+    await response.body?.cancel().catch(() => {});
+    if (!current.startsWith("https://")) throw codedError("ffmpeg-download-failed", "FFmpeg download refused a non-HTTPS redirect");
+    if (redirects === 5) throw codedError("ffmpeg-download-failed", "Too many FFmpeg download redirects");
+  }
+  if (!response?.ok || !response.body) throw codedError("ffmpeg-download-failed", `FFmpeg download failed with HTTP ${response?.status || 0}`);
+  const declared = Number(response.headers.get("content-length")) || expectedSize || null;
+  const hash = createHash("sha256");
+  const file = await import("node:fs/promises").then((fs) => fs.open(target, "w"));
+  let received = 0;
+  const reader = response.body.getReader();
+  try {
+    while (true) {
+      const { done, value } = await readChunk(reader, 30000);
+      if (done) break;
+      const buffer = Buffer.from(value);
+      received += buffer.length;
+      if (received > maxBytes) throw codedError("ffmpeg-download-failed", "FFmpeg archive exceeds the allowed size");
+      hash.update(buffer);
+      await file.write(buffer);
+      onProgress({ receivedBytes: received, totalBytes: declared, percent: declared ? Math.min(100, Math.round(received * 100 / declared)) : null });
+    }
+  } finally { await reader.cancel().catch(() => {}); await file.close(); }
+  return hash.digest("hex");
+}
+
+async function ensureTarAvailable(spawn) {
+  try { await runCommand("tar", ["--version"], spawn, 5000); }
+  catch { throw codedError("ffmpeg-extractor-unavailable", "The managed FFmpeg archive requires the system tar extractor"); }
+}
+
+function assertSafeDownloadUrl(value) {
+  const url = new URL(value);
+  const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (url.protocol !== "https:" || host === "localhost" || host.endsWith(".localhost") || isPrivateIp(host)) {
+    throw codedError("ffmpeg-download-failed", "FFmpeg downloads require a public HTTPS destination");
+  }
+}
+
+function isPrivateIp(host) {
+  const family = isIP(host);
+  if (family === 4) {
+    const [a, b] = host.split(".").map(Number);
+    return a === 10 || a === 127 || a === 0 || (a === 169 && b === 254) || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168);
+  }
+  if (family === 6) return host === "::1" || host.startsWith("fe80:") || host.startsWith("fc") || host.startsWith("fd");
+  return false;
+}
+
+async function extractWithTar(archivePath, tempRoot, destination, matcher, spawn) {
+  const listing = await runCommand("tar", ["-tf", archivePath], spawn, 15000);
+  const entries = listing.stdout.split(/\r?\n/).filter(Boolean);
+  const matches = entries.filter((entry) => safeArchiveEntry(entry) && matcher.test(entry));
+  if (matches.length !== 1) throw codedError("ffmpeg-executable-missing", `Expected one FFmpeg executable in archive, found ${matches.length}`);
+  const entry = matches[0];
+  await runCommand("tar", ["-xf", archivePath, "-C", tempRoot, entry], spawn, 60000);
+  const extracted = resolve(tempRoot, normalize(entry));
+  if (!extracted.startsWith(resolve(tempRoot) + sep)) throw codedError("ffmpeg-archive-unsafe", "FFmpeg archive path escaped the install directory");
+  await copyFile(extracted, destination);
+}
+
+function safeArchiveEntry(entry) {
+  const value = entry.replaceAll("\\", "/");
+  return value !== "" && !value.startsWith("/") && !/^[A-Za-z]:/.test(value) && !value.split("/").includes("..");
+}
+
+async function prepareMacExecutable(path, arch, spawn) {
+  await runCommand("xattr", ["-d", "com.apple.quarantine", path], spawn, 5000).catch(() => {});
+  if (arch === "arm64") await runCommand("codesign", ["--force", "--sign", "-", path], spawn, 15000).catch(() => {});
+}
+
+async function hashFile(path) {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(path)) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+function readChunk(reader, timeoutMs) {
+  return new Promise((resolvePromise, reject) => {
+    const timer = setTimeout(() => reject(codedError("ffmpeg-download-timeout", "FFmpeg download stalled")), timeoutMs);
+    reader.read().then(
+      (value) => { clearTimeout(timer); resolvePromise(value); },
+      (error) => { clearTimeout(timer); reject(error); },
+    );
+  });
+}
+
+function runCommand(command, argv, spawn, timeoutMs) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, argv, { shell: false, windowsHide: true, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = ""; let stderr = ""; let settled = false;
+    const finish = (callback, value) => { if (settled) return; settled = true; clearTimeout(timer); callback(value); };
+    child.stdout?.on("data", (chunk) => { stdout += chunk; });
+    child.stderr?.on("data", (chunk) => { stderr += chunk; });
+    child.once("error", (error) => finish(reject, error));
+    child.once("exit", (code) => code === 0 ? finish(resolvePromise, { stdout, stderr }) : finish(reject, codedError("ffmpeg-archive-invalid", stderr || `${command} exited with ${code}`)));
+    const timer = setTimeout(() => { try { child.kill("SIGKILL"); } catch {}; finish(reject, codedError("ffmpeg-archive-invalid", `${command} timed out`)); }, timeoutMs);
+  });
+}
+
+function codedError(code, message) { const error = new Error(message); error.code = code; return error; }

--- a/lib/ffmpeg-manifest.js
+++ b/lib/ffmpeg-manifest.js
@@ -1,0 +1,64 @@
+const BTBN_TAG = "autobuild-2026-08-17-13-05";
+const BTBN_BASE = `https://github.com/BtbN/FFmpeg-Builds/releases/download/${BTBN_TAG}`;
+const STATIC_BASE = "https://github.com/eugeneware/ffmpeg-static/releases/download/b6.1.1";
+
+export const FFMPEG_MANIFEST = Object.freeze({
+  "win32-x64": Object.freeze({
+    provider: "btbn", buildId: BTBN_TAG, archiveType: "tar", size: 170641412,
+    url: `${BTBN_BASE}/ffmpeg-N-126188-g426841da9d-win64-gpl.zip`,
+    sha256: "423d30b197e52e20e0702278a30bc63e006cc383c968935874c4c13dda9eb299",
+    executableName: "ffmpeg.exe", archiveExecutable: /(?:^|\/)bin\/ffmpeg\.exe$/i,
+  }),
+  "win32-arm64": Object.freeze({
+    provider: "btbn", buildId: BTBN_TAG, archiveType: "tar", size: 116275753,
+    url: `${BTBN_BASE}/ffmpeg-N-126188-g426841da9d-winarm64-gpl.zip`,
+    sha256: "451d181c0774f19dc7c30711911f3aad4f4ee4feb1cecb7b5efc1b895e093c67",
+    executableName: "ffmpeg.exe", archiveExecutable: /(?:^|\/)bin\/ffmpeg\.exe$/i,
+  }),
+  "linux-x64": Object.freeze({
+    provider: "btbn", buildId: BTBN_TAG, archiveType: "tar", size: 127977972,
+    url: `${BTBN_BASE}/ffmpeg-N-126188-g426841da9d-linux64-gpl.tar.xz`,
+    sha256: "646080fba1f295446fdf35fbdd4bad6ab934a30f9fcb86f3e96ad50eaff06c82",
+    executableName: "ffmpeg", archiveExecutable: /(?:^|\/)bin\/ffmpeg$/,
+  }),
+  "linux-arm64": Object.freeze({
+    provider: "btbn", buildId: BTBN_TAG, archiveType: "tar", size: 109615592,
+    url: `${BTBN_BASE}/ffmpeg-N-126188-g426841da9d-linuxarm64-gpl.tar.xz`,
+    sha256: "7cda2218fe0107e449631eb6b850146a4522ebf4ed13733010d0aada9858b119",
+    executableName: "ffmpeg", archiveExecutable: /(?:^|\/)bin\/ffmpeg$/,
+  }),
+  "darwin-x64": Object.freeze({
+    provider: "evermeet", buildId: "ffmpeg-static-b6.1.1", archiveType: "gzip", size: 25296431,
+    url: `${STATIC_BASE}/ffmpeg-darwin-x64.gz`,
+    sha256: "929b375c1182d956c51f7ac25e0b2b0411fb01f6f407aa15c9758efeb4242106",
+    executableName: "ffmpeg",
+  }),
+  "darwin-arm64": Object.freeze({
+    provider: "osxexperts", buildId: "ffmpeg-static-b6.1.1", archiveType: "gzip", size: 19246198,
+    url: `${STATIC_BASE}/ffmpeg-darwin-arm64.gz`,
+    sha256: "8923876afa8db5585022d7860ec7e589af192f441c56793971276d450ed3bbfa",
+    executableName: "ffmpeg",
+  }),
+});
+
+export function platformManifest(platform = process.platform, arch = process.arch) {
+  return FFMPEG_MANIFEST[`${platform}-${arch}`] || null;
+}
+
+export function rewriteGithubUrl(url, mirror = "") {
+  if (!mirror || !url.startsWith("https://github.com/")) return url;
+  let parsed;
+  try { parsed = new URL(mirror); }
+  catch { throw codedError("ffmpeg-mirror-invalid", "GitHub mirror must be a valid HTTPS URL"); }
+  if (parsed.protocol !== "https:" || parsed.username || parsed.password || parsed.search || parsed.hash) {
+    throw codedError("ffmpeg-mirror-invalid", "GitHub mirror must be an HTTPS base URL without credentials, query, or fragment");
+  }
+  const base = parsed.toString().replace(/\/+$/, "");
+  return `${base}${url.slice("https://github.com".length)}`;
+}
+
+function codedError(code, message) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -22,7 +22,11 @@ import { SETTINGS_NAMESPACE } from "./settings.js";
 const API_PREFIX = "/ego/api";
 
 /** Config keys the `set` endpoint accepts (allow-list; unknown keys are dropped). */
-const ALLOWED_KEYS = new Set(["chromePath", "castFpsCap", "screencastQuality", "screencastMaxWidth", "backstopIntervalMs"]);
+const ALLOWED_KEYS = new Set([
+  "chromePath", "captureBackend", "streamProfile", "cdpFps", "cdpQuality",
+  "cdpMaxWidth", "cdpBackstopIntervalMs", "ffmpegFps", "ffmpegMaxWidth",
+  "ffmpegEncoder", "ffmpegPath",
+]);
 
 /**
  * Register the `/ego/api` HTTP route on the host's web server.

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -24,7 +24,7 @@ const API_PREFIX = "/ego/api";
 /** Config keys the `set` endpoint accepts (allow-list; unknown keys are dropped). */
 const ALLOWED_KEYS = new Set([
   "chromePath", "captureBackend", "streamProfile", "cdpFps", "cdpQuality",
-  "cdpMaxWidth", "cdpBackstopIntervalMs", "ffmpegFps", "ffmpegMaxWidth",
+  "cdpMaxWidth", "cdpBackstopIntervalMs", "ffmpegFps", "ffmpegMaxWidth", "ffmpegBitrateKbps",
   "ffmpegEncoder", "ffmpegPath",
 ]);
 

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -17,6 +17,7 @@
 // Errors carry { ok: false, error: { code, message } }.
 import { resolveConfig } from "./config.js";
 import { SETTINGS_NAMESPACE } from "./settings.js";
+import { rewriteGithubUrl } from "./ffmpeg-manifest.js";
 
 /** HTTP route prefix owning every ego-browser API request. */
 const API_PREFIX = "/ego/api";
@@ -25,7 +26,7 @@ const API_PREFIX = "/ego/api";
 const ALLOWED_KEYS = new Set([
   "chromePath", "captureBackend", "streamProfile", "cdpFps", "cdpQuality",
   "cdpMaxWidth", "cdpBackstopIntervalMs", "ffmpegFps", "ffmpegMaxWidth", "ffmpegBitrateKbps",
-  "ffmpegEncoder", "ffmpegPath",
+  "ffmpegEncoder", "ffmpegPath", "githubMirror",
 ]);
 
 /**
@@ -39,7 +40,7 @@ const ALLOWED_KEYS = new Set([
  * @param {{ source: () => { chromePath: string, castFpsCap: number, screencastQuality: number, screencastMaxWidth: number }, onChange: (cb: () => void) => void }} bridge
  *   the settings bridge the route reads through.
  */
-export function registerEgoBrowserGateway(ctx, bridge) {
+export function registerEgoBrowserGateway(ctx, bridge, ffmpegManager) {
   let settings;
   ctx.inject(["settings"], (sctx) => {
     settings = sctx.settings;
@@ -57,6 +58,20 @@ export function registerEgoBrowserGateway(ctx, bridge) {
           writeJson(res, 405, envelopeError("method-not-allowed", "POST only"));
           return;
         }
+        const origin = req.headers.origin;
+        if (origin) {
+          let originHost;
+          try { originHost = new URL(origin).host; }
+          catch { writeJson(res, 400, envelopeError("invalid-origin", "invalid Origin header")); return; }
+          if (!req.headers.host || originHost !== req.headers.host) {
+            writeJson(res, 403, envelopeError("origin-not-allowed", "same-origin requests only"));
+            return;
+          }
+        }
+        if (!String(req.headers["content-type"] || "").toLowerCase().startsWith("application/json")) {
+          writeJson(res, 415, envelopeError("content-type-not-supported", "application/json required"));
+          return;
+        }
         const pathname = new URL(req.url ?? "/", "http://dsh.internal").pathname;
         const method = pathname.startsWith(`${API_PREFIX}/`)
           ? pathname.slice(`${API_PREFIX}/`.length)
@@ -69,16 +84,29 @@ export function registerEgoBrowserGateway(ctx, bridge) {
           const body = await readJsonBody(req);
           if (method === "get") {
             const config = resolveConfig(bridge.source());
-            writeJson(res, 200, envelopeOk({ config }));
+            const ffmpegStatus = ffmpegManager ? await ffmpegManager.check({ configuredPath: config.ffmpegPath, requestedEncoder: config.ffmpegEncoder }) : null;
+            writeJson(res, 200, envelopeOk({ config, ffmpegStatus }));
           } else if (method === "set") {
-            const result = await handleSet(body, settings, bridge);
+            const result = await handleSet(body, settings, bridge, ffmpegManager);
             writeJson(res, 200, envelopeOk(result));
+          } else if (method === "ffmpeg-status") {
+            writeJson(res, 200, envelopeOk({ ffmpegStatus: ffmpegManager?.status() || null }));
+          } else if (method === "ffmpeg-check") {
+            const config = resolveConfig(bridge.source());
+            const ffmpegStatus = await ffmpegManager?.check({ configuredPath: config.ffmpegPath, requestedEncoder: config.ffmpegEncoder });
+            writeJson(res, 200, envelopeOk({ ffmpegStatus: ffmpegStatus || null }));
+          } else if (method === "ffmpeg-install") {
+            const config = resolveConfig(bridge.source());
+            const githubMirror = typeof body.githubMirror === "string" ? body.githubMirror : config.githubMirror;
+            const ffmpegStatus = ffmpegManager?.startInstall({ githubMirror, configuredPath: config.ffmpegPath, requestedEncoder: config.ffmpegEncoder });
+            writeJson(res, 200, envelopeOk({ ffmpegStatus: ffmpegStatus || null }));
           } else {
             writeJson(res, 404, envelopeError("not-found", `unknown ego-browser API method "${method}"`));
           }
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
-          writeJson(res, 500, envelopeError("internal", message));
+          const status = error?.code === "ffmpeg-unavailable" ? 409 : error?.code === "ffmpeg-mirror-invalid" ? 400 : 500;
+          writeJson(res, status, envelopeError(error?.code || "internal", message));
         }
       },
     });
@@ -89,7 +117,7 @@ export function registerEgoBrowserGateway(ctx, bridge) {
  * Handle the `set` method: validate the patch, write the user layer, return
  * the new resolved config.
  */
-async function handleSet(body, settings, bridge) {
+async function handleSet(body, settings, bridge, ffmpegManager) {
   const patch = extractPatch(body);
   if (Object.keys(patch).length === 0) {
     return { config: resolveConfig(bridge.source()) };
@@ -99,8 +127,23 @@ async function handleSet(body, settings, bridge) {
       "ego-browser: settings service is unavailable — configuration cannot be written",
     );
   }
+  const current = resolveConfig(bridge.source());
+  const next = resolveConfig({ ...current, ...patch });
+  if (patch.githubMirror) rewriteGithubUrl("https://github.com/example/repo/releases/download/tag/file", patch.githubMirror);
+  const mustValidateFfmpeg = patch.captureBackend === "ffmpeg" || ((Object.hasOwn(patch, "ffmpegPath") || Object.hasOwn(patch, "ffmpegEncoder")) && next.captureBackend === "ffmpeg");
+  if (mustValidateFfmpeg && ffmpegManager) {
+    const status = await ffmpegManager.check({ configuredPath: next.ffmpegPath, requestedEncoder: next.ffmpegEncoder });
+    if (!status.canSelectFfmpeg) {
+      const error = new Error(status.reason || "FFmpeg is not installed or does not satisfy capture requirements");
+      error.code = "ffmpeg-unavailable";
+      throw error;
+    }
+  }
   await settings.update(SETTINGS_NAMESPACE, patch);
-  return { config: resolveConfig(bridge.source()) };
+  const ffmpegStatus = Object.hasOwn(patch, "ffmpegPath") && ffmpegManager
+    ? await ffmpegManager.check({ configuredPath: next.ffmpegPath, requestedEncoder: next.ffmpegEncoder })
+    : ffmpegManager?.status() || null;
+  return { config: resolveConfig(bridge.source()), ffmpegStatus };
 }
 
 /**
@@ -128,10 +171,14 @@ function extractPatch(body) {
 }
 
 /** Read and parse a JSON body from a node:http request. */
-async function readJsonBody(req) {
+async function readJsonBody(req, maxBytes = 16384) {
   const chunks = [];
+  let bytes = 0;
   for await (const chunk of req) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    bytes += buffer.length;
+    if (bytes > maxBytes) throw new Error("request body too large");
+    chunks.push(buffer);
   }
   const text = Buffer.concat(chunks).toString("utf8");
   if (text === "") return {};

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -24,7 +24,7 @@
  *     the ego-lite roadmap, PR #202).
  */
 export declare const name = "ego-browser";
-export declare const inject: readonly ["tools", "subprocess"];
+export declare const inject: readonly ["tools", "subprocess", "webServer"];
 interface LoggerLike {
     info(message: string): void;
     warn(message: string): void;
@@ -92,22 +92,35 @@ export interface Config {
      * (ego-browser card) or the composition layer (cordis.patch.yml).
      */
     chromePath?: string;
+    captureBackend?: "auto" | "cdp" | "ffmpeg";
+    streamProfile?: "low" | "balanced" | "high";
+    cdpFps?: number;
+    cdpQuality?: number;
+    cdpMaxWidth?: number;
+    cdpBackstopIntervalMs?: number;
+    ffmpegFps?: number;
+    ffmpegMaxWidth?: number;
+    ffmpegEncoder?: "auto" | "software" | "h264_nvenc" | "h264_qsv" | "h264_amf" | "h264_videotoolbox" | "h264_vaapi";
+    ffmpegPath?: string;
     /**
      * Cap on live-frame fan-out (frames/sec) from the cast worker to the
      * watch panel. 0 = uncapped (full browser repaint cadence). >0 = at
      * most N frames/sec; the watched (active) tab is never throttled, only
      * background repainting tabs. Range 0–60; default 0.
      */
+    /** @deprecated Use cdpFps. */
     castFpsCap?: number;
     /**
      * JPEG quality (1–100) for screencast frames and screenshot backstop.
      * Range 1–100; default 55.
      */
+    /** @deprecated Use cdpQuality. */
     screencastQuality?: number;
     /**
      * Max width (CSS px) of each pushed screencast frame. Range 320–1920;
      * default 960.
      */
+    /** @deprecated Use cdpMaxWidth. */
     screencastMaxWidth?: number;
     /**
      * How long (ms) a page may go without a pushed screencast frame before
@@ -115,6 +128,7 @@ export interface Config {
      * as the minimum interval between forced captures for the same target.
      * Range 200–10000; default 5000.
      */
+    /** @deprecated Use cdpBackstopIntervalMs. */
     backstopIntervalMs?: number;
     /**
      * Path or command name of the ego-browser CLI.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -100,7 +100,8 @@ export interface Config {
     cdpBackstopIntervalMs?: number;
     ffmpegFps?: number;
     ffmpegMaxWidth?: number;
-    ffmpegEncoder?: "auto" | "software" | "h264_nvenc" | "h264_qsv" | "h264_amf" | "h264_videotoolbox" | "h264_vaapi";
+    ffmpegBitrateKbps?: number;
+    ffmpegEncoder?: "auto" | "software" | "h264_mf" | "h264_nvenc" | "h264_qsv" | "h264_amf" | "h264_videotoolbox" | "h264_vaapi";
     ffmpegPath?: string;
     /**
      * Cap on live-frame fan-out (frames/sec) from the cast worker to the
@@ -146,6 +147,12 @@ export interface Config {
     graceMs?: number;
 }
 export declare const Config: {};
+export declare function createActiveSpaceTracker(defaultSpace?: string | number): {
+    current(): string | number;
+    opened(args: { name?: string | number }, result: { id?: string | number; name?: string }): void;
+    selected(space: string | number): void;
+    closed(space: string | number, done: boolean): void;
+};
 /** Find a usable Chrome/Edge/Brave binary by scanning PATH + common fixed locations. */
 export declare function findChromeBinary(): string | undefined;
 /** Build the env handed to `ego-browser nodejs` spawns (platform-injectable for testing). */

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -103,6 +103,7 @@ export interface Config {
     ffmpegBitrateKbps?: number;
     ffmpegEncoder?: "auto" | "software" | "h264_mf" | "h264_nvenc" | "h264_qsv" | "h264_amf" | "h264_videotoolbox" | "h264_vaapi";
     ffmpegPath?: string;
+    githubMirror?: string;
     /**
      * Cap on live-frame fan-out (frames/sec) from the cast worker to the
      * watch panel. 0 = uncapped (full browser repaint cadence). >0 = at

--- a/lib/index.js
+++ b/lib/index.js
@@ -80,6 +80,24 @@ const DEFAULT_SPACE = "dsh-agent";
 const DEFAULT_MAX_OUTPUT_BYTES = 4 * 1024 * 1024;
 const DEFAULT_GRACE_MS = 15_000;
 const TOOL_TIMEOUT_MS = 120_000;
+export function createActiveSpaceTracker(defaultSpace = DEFAULT_SPACE) {
+  let activeSpace = defaultSpace;
+  let activeName = typeof defaultSpace === "string" ? defaultSpace : null;
+  return {
+    current: () => activeSpace,
+    opened: (args, result) => {
+      activeName = result?.name ?? str(args?.name, defaultSpace) ?? null;
+      activeSpace = result?.id ?? activeName ?? defaultSpace;
+    },
+    selected: (space) => { if (space !== undefined && space !== "") { activeSpace = space; activeName = typeof space === "string" ? space : null; } },
+    closed: (space, done) => {
+      if (done && (String(space) === String(activeSpace) || (activeName !== null && String(space) === String(activeName)))) {
+        activeSpace = defaultSpace;
+        activeName = typeof defaultSpace === "string" ? defaultSpace : null;
+      }
+    },
+  };
+}
 // ── serialization ───────────────────────────────────────────────────────────
 /**
  * The ego-lite host is a single persistent browser shared by every tool call;
@@ -510,6 +528,7 @@ function defineEgoTool(ctx, cfg, opts) {
           runEgoScript(ctx.subprocess, script, exec, cfg)
         );
         if (!result.ok) throw new Error(result.error);
+        if (typeof opts.afterExecute === "function") opts.afterExecute(args, result.value);
         // Value is JSON.parse output of our own payload — fits the tool JSON contract.
         return result.value;
       }),
@@ -532,19 +551,22 @@ export function apply(ctx, config = {}) {
   // via getters so every spawn reads the latest value without re-registration.
   const settingKeys = [
     "chromePath", "captureBackend", "streamProfile", "cdpFps", "cdpQuality",
-    "cdpMaxWidth", "cdpBackstopIntervalMs", "ffmpegFps", "ffmpegMaxWidth",
+    "cdpMaxWidth", "cdpBackstopIntervalMs", "ffmpegFps", "ffmpegMaxWidth", "ffmpegBitrateKbps",
     "ffmpegEncoder", "ffmpegPath", "castFpsCap", "screencastQuality",
     "screencastMaxWidth", "backstopIntervalMs",
   ];
   const entry = Object.fromEntries(settingKeys.filter((key) => config[key] !== undefined).map((key) => [key, config[key]]));
   const bridge = installEgoBrowserSettings(ctx, entry);
 
+  const spaceTracker = createActiveSpaceTracker(config.defaultSpace ?? DEFAULT_SPACE);
   const cfg = {
     egoBin:
       config.egoBin !== undefined && config.egoBin !== ""
         ? config.egoBin
         : DEFAULT_EGO_BIN,
-    defaultSpace: config.defaultSpace ?? DEFAULT_SPACE,
+    configuredDefaultSpace: config.defaultSpace ?? DEFAULT_SPACE,
+    spaceTracker,
+    get defaultSpace() { return this.spaceTracker.current(); },
     maxOutputBytes: config.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,
     graceMs: config.graceMs ?? DEFAULT_GRACE_MS,
     // Live getter: reads from the settings bridge so GUI edits take effect on
@@ -560,6 +582,7 @@ export function apply(ctx, config = {}) {
     get cdpBackstopIntervalMs() { return resolveConfig(bridge.source()).cdpBackstopIntervalMs; },
     get ffmpegFps() { return resolveConfig(bridge.source()).ffmpegFps; },
     get ffmpegMaxWidth() { return resolveConfig(bridge.source()).ffmpegMaxWidth; },
+    get ffmpegBitrateKbps() { return resolveConfig(bridge.source()).ffmpegBitrateKbps; },
     get ffmpegEncoder() { return resolveConfig(bridge.source()).ffmpegEncoder; },
     get ffmpegPath() { return resolveConfig(bridge.source()).ffmpegPath; },
   };
@@ -786,17 +809,30 @@ function registerAuthFlush(ctx, cfg, reg) {
 }
 /** The 11 structured action tools that drive `ego-browser nodejs`. */
 function registerActionTools(ctx, cfg, reg) {
-  const t = (opts) => defineEgoTool(ctx, cfg, opts);
+  const t = (opts) => defineEgoTool(ctx, cfg, {
+    ...opts,
+    afterExecute: (args, result) => {
+      if (!result || result.ok === false) return;
+      if (opts.name === "ego_space_open") {
+        cfg.spaceTracker.opened(args, result);
+      } else if (opts.name === "ego_space_close") {
+        cfg.spaceTracker.closed(args.name, result.done);
+      } else if (args && args.space !== undefined && args.space !== "") {
+        cfg.spaceTracker.selected(args.space);
+      }
+      opts.afterExecute?.(args, result);
+    },
+  });
   const spaceParam = {
     type: "string",
     description:
-      "Task-space name or numeric id; defaults to the configured defaultSpace.",
+      "Task-space name or numeric id; defaults to the most recently opened or explicitly selected space.",
   };
   reg(
     t({
       name: "ego_space_open",
       description:
-        "Open (or reuse) an ego-lite task space — an isolated browsing context that inherits your login state. Returns the space id; pass it as `space` to other ego_* tools, or rely on the default space.",
+        "Open (or reuse) an ego-lite task space — an isolated browsing context that inherits your login state. It becomes the active space for later ego_* calls that omit `space`.",
       parameters: {
         name: {
           type: "string",

--- a/lib/index.js
+++ b/lib/index.js
@@ -530,18 +530,13 @@ export function apply(ctx, config = {}) {
   // Install the settings bridge first: the live config source (composition
   // entry + user-layer overrides) feeds `chromePath` + cast settings into cfg
   // via getters so every spawn reads the latest value without re-registration.
-  const entry = resolveConfig({
-    chromePath:
-      typeof config.chromePath === "string" ? config.chromePath : "",
-    castFpsCap:
-      typeof config.castFpsCap === "number" ? config.castFpsCap : undefined,
-    screencastQuality:
-      typeof config.screencastQuality === "number" ? config.screencastQuality : undefined,
-    screencastMaxWidth:
-      typeof config.screencastMaxWidth === "number" ? config.screencastMaxWidth : undefined,
-    backstopIntervalMs:
-      typeof config.backstopIntervalMs === "number" ? config.backstopIntervalMs : undefined,
-  });
+  const settingKeys = [
+    "chromePath", "captureBackend", "streamProfile", "cdpFps", "cdpQuality",
+    "cdpMaxWidth", "cdpBackstopIntervalMs", "ffmpegFps", "ffmpegMaxWidth",
+    "ffmpegEncoder", "ffmpegPath", "castFpsCap", "screencastQuality",
+    "screencastMaxWidth", "backstopIntervalMs",
+  ];
+  const entry = Object.fromEntries(settingKeys.filter((key) => config[key] !== undefined).map((key) => [key, config[key]]));
   const bridge = installEgoBrowserSettings(ctx, entry);
 
   const cfg = {
@@ -555,22 +550,18 @@ export function apply(ctx, config = {}) {
     // Live getter: reads from the settings bridge so GUI edits take effect on
     // the next spawn without restarting the plugin.
     get chromePath() {
-      return bridge.source().chromePath || "";
+      return resolveConfig(bridge.source()).chromePath;
     },
-    // Live getters for the cast worker's screencast parameters. The cast
-    // server reads these to push hot-update config to a running worker.
-    get castFpsCap() {
-      return bridge.source().castFpsCap ?? 0;
-    },
-    get screencastQuality() {
-      return bridge.source().screencastQuality ?? 55;
-    },
-    get screencastMaxWidth() {
-      return bridge.source().screencastMaxWidth ?? 960;
-    },
-    get backstopIntervalMs() {
-      return bridge.source().backstopIntervalMs ?? 5000;
-    },
+    get captureBackend() { return resolveConfig(bridge.source()).captureBackend; },
+    get streamProfile() { return resolveConfig(bridge.source()).streamProfile; },
+    get cdpFps() { return resolveConfig(bridge.source()).cdpFps; },
+    get cdpQuality() { return resolveConfig(bridge.source()).cdpQuality; },
+    get cdpMaxWidth() { return resolveConfig(bridge.source()).cdpMaxWidth; },
+    get cdpBackstopIntervalMs() { return resolveConfig(bridge.source()).cdpBackstopIntervalMs; },
+    get ffmpegFps() { return resolveConfig(bridge.source()).ffmpegFps; },
+    get ffmpegMaxWidth() { return resolveConfig(bridge.source()).ffmpegMaxWidth; },
+    get ffmpegEncoder() { return resolveConfig(bridge.source()).ffmpegEncoder; },
+    get ffmpegPath() { return resolveConfig(bridge.source()).ffmpegPath; },
   };
   const reg = (tool) => {
     const dispose = ctx.tools.register(tool);

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,6 +45,7 @@ import { Config as ConfigSchema } from "./config.js";
 import { resolveConfig } from "./config.js";
 import { installEgoBrowserSettings } from "./settings.js";
 import { registerEgoBrowserGateway } from "./gateway.js";
+import { getSharedFfmpegInstallationManager } from "./ffmpeg-installation.js";
 export const name = "ego-browser";
 // Platform-aware host services: the web shell exposes `webServer`, other Web
 // hosts expose `httpServer`. Declare both as optional so the plugin mounts on
@@ -552,11 +553,14 @@ export function apply(ctx, config = {}) {
   const settingKeys = [
     "chromePath", "captureBackend", "streamProfile", "cdpFps", "cdpQuality",
     "cdpMaxWidth", "cdpBackstopIntervalMs", "ffmpegFps", "ffmpegMaxWidth", "ffmpegBitrateKbps",
-    "ffmpegEncoder", "ffmpegPath", "castFpsCap", "screencastQuality",
+    "ffmpegEncoder", "ffmpegPath", "githubMirror", "castFpsCap", "screencastQuality",
     "screencastMaxWidth", "backstopIntervalMs",
   ];
   const entry = Object.fromEntries(settingKeys.filter((key) => config[key] !== undefined).map((key) => [key, config[key]]));
   const bridge = installEgoBrowserSettings(ctx, entry);
+  const ffmpegManager = getSharedFfmpegInstallationManager();
+  const initialFfmpegConfig = resolveConfig(bridge.source());
+  void ffmpegManager.check({ configuredPath: initialFfmpegConfig.ffmpegPath, requestedEncoder: initialFfmpegConfig.ffmpegEncoder }).catch(() => {});
 
   const spaceTracker = createActiveSpaceTracker(config.defaultSpace ?? DEFAULT_SPACE);
   const cfg = {
@@ -585,6 +589,7 @@ export function apply(ctx, config = {}) {
     get ffmpegBitrateKbps() { return resolveConfig(bridge.source()).ffmpegBitrateKbps; },
     get ffmpegEncoder() { return resolveConfig(bridge.source()).ffmpegEncoder; },
     get ffmpegPath() { return resolveConfig(bridge.source()).ffmpegPath; },
+    get githubMirror() { return resolveConfig(bridge.source()).githubMirror; },
   };
   const reg = (tool) => {
     const dispose = ctx.tools.register(tool);
@@ -605,7 +610,7 @@ export function apply(ctx, config = {}) {
   // inject resolves through fiber.store and is fully supported by cordis.]
   if (typeof ctx.webServer?.register === "function") {
     try {
-      initCastServer(ctx, cfg, bridge);
+      initCastServer(ctx, cfg, bridge, ffmpegManager);
     } catch (err) {
       ctx.logger?.warn?.(
         `ego-browser: cast server init failed: ${err?.message ?? err}`
@@ -616,7 +621,7 @@ export function apply(ctx, config = {}) {
     // bypassing the host's settings-RPC allowlist. Same webServer the cast
     // server uses; guarded so a headless host without webServer is a no-op.
     try {
-      registerEgoBrowserGateway(ctx, bridge);
+      registerEgoBrowserGateway(ctx, bridge, ffmpegManager);
     } catch (err) {
       ctx.logger?.warn?.(
         `ego-browser: settings gateway init failed: ${err?.message ?? err}`

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -20,6 +20,9 @@ import { Config } from "./config.js";
 /** Settings namespace under which ego-browser config persists. */
 export const SETTINGS_NAMESPACE = settingsNamespace("ego-browser");
 
+const SHARED_SCOPE_KEY = Symbol.for("@dsh-external/ego-browser.settings-scope");
+const sharedScope = globalThis[SHARED_SCOPE_KEY] || (globalThis[SHARED_SCOPE_KEY] = { scope: null, refs: 0 });
+
 /**
  * Mirror of the dsh-settings internal `isUnloading` guard. The cordis const
  * enum for fiber state is erased at compile time, so the literal states are
@@ -50,33 +53,40 @@ export function installEgoBrowserSettings(ctx, entry) {
     for (const listener of [...listeners]) listener();
   };
   ctx.inject(["settings"], (sctx) => {
-    let scope;
-    try {
-      scope = sctx.settings.register(SETTINGS_NAMESPACE, Config, {
-        base: entry,
-      });
-    } catch (error) {
-      if (
-        !(error instanceof Error) ||
-        !error.message.includes("already registered")
-      )
-        throw error;
-      ctx.logger("ego-browser")?.debug(
-        "settings namespace already registered — entry-source fallback",
-      );
-      return;
+    let scope = sharedScope.scope;
+    if (!scope) {
+      try {
+        scope = sctx.settings.register(SETTINGS_NAMESPACE, Config, {
+          base: entry,
+        });
+        sharedScope.scope = scope;
+      } catch (error) {
+        if (
+          !(error instanceof Error) ||
+          !error.message.includes("already registered")
+        )
+          throw error;
+        ctx.logger("ego-browser")?.warn(
+          "settings namespace already registered outside the shared bridge",
+        );
+        return;
+      }
     }
+    sharedScope.refs += 1;
     source = () => scope.get();
+    const offScopeWatch = scope.watch(() => {
+      if (isUnloading(ctx)) return;
+      notify();
+    });
     sctx.effect(() => () => {
+      offScopeWatch?.();
+      sharedScope.refs = Math.max(0, sharedScope.refs - 1);
+      if (sharedScope.refs === 0 && sharedScope.scope === scope) sharedScope.scope = null;
       if (isUnloading(ctx)) return;
       source = () => entry;
       notify();
     });
     notify();
-    scope.watch(() => {
-      if (isUnloading(ctx)) return;
-      notify();
-    });
   });
   return {
     source: () => source(),

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -40,8 +40,8 @@ function isUnloading(ctx) {
  * concurrent fibers of this plugin, and only the first registration owns the
  * namespace.
  * @param {import("@deepseek-ai/cordis").Context} ctx - host context.
- * @param {{ chromePath: string }} entry - composition-layer config (cordis.patch.yml seed).
- * @returns {{ source: () => { chromePath: string, castFpsCap: number, screencastQuality: number, screencastMaxWidth: number, backstopIntervalMs: number }, onChange: (cb: () => void) => void }}
+ * @param {Record<string, unknown>} entry - raw composition-layer config seed.
+ * @returns {{ source: () => Record<string, unknown>, onChange: (cb: () => void) => () => void }}
  */
 export function installEgoBrowserSettings(ctx, entry) {
   const listeners = new Set();
@@ -82,6 +82,7 @@ export function installEgoBrowserSettings(ctx, entry) {
     source: () => source(),
     onChange: (cb) => {
       listeners.add(cb);
+      return () => listeners.delete(cb);
     },
   };
 }

--- a/package.json
+++ b/package.json
@@ -26,13 +26,12 @@
     }
   },
   "scripts": {
-    "build": "node --check lib/index.js && node --check lib/client.js && node --check lib/config.js && node --check lib/settings.js && node --check lib/gateway.js && node --check lib/cast-server.js && node --check bin/ego-cast-worker.mjs && node --check bin/cdp-client.mjs && node --check bin/capture-cdp.mjs && node --check bin/capture-manager.mjs && node --check bin/capture-ffmpeg.mjs && node --check bin/capture-platform.mjs && node --check bin/mp4-fragments.mjs && echo build-ok",
+    "build": "node --check lib/index.js && node --check lib/client.js && node --check lib/config.js && node --check lib/settings.js && node --check lib/gateway.js && node --check lib/cast-server.js && node --check lib/ffmpeg-manifest.js && node --check lib/ffmpeg-installation.js && node --check bin/ego-cast-worker.mjs && node --check bin/cdp-client.mjs && node --check bin/capture-cdp.mjs && node --check bin/capture-manager.mjs && node --check bin/capture-ffmpeg.mjs && node --check bin/ffmpeg-probe.mjs && node --check bin/capture-platform.mjs && node --check bin/mp4-fragments.mjs && echo build-ok",
     "typecheck": "node --check lib/index.js && echo typecheck-ok",
     "test": "node --test tests/*.test.mjs"
   },
   "dependencies": {
-    "@deepseek-ai/schemastery": "link:../dsh/vendor/schemastery",
-    "ffmpeg-static": "5.2.0"
+    "@deepseek-ai/schemastery": "link:../dsh/vendor/schemastery"
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.0-rc.7",

--- a/package.json
+++ b/package.json
@@ -26,19 +26,23 @@
     }
   },
   "scripts": {
-    "build": "node --check lib/index.js && node --check lib/client.js && node --check lib/config.js && node --check lib/settings.js && node --check lib/gateway.js && node --check lib/index.d.ts && echo build-ok",
+    "build": "node --check lib/index.js && node --check lib/client.js && node --check lib/config.js && node --check lib/settings.js && node --check lib/gateway.js && node --check lib/cast-server.js && node --check bin/ego-cast-worker.mjs && node --check bin/cdp-client.mjs && node --check bin/capture-cdp.mjs && node --check bin/capture-manager.mjs && node --check bin/capture-ffmpeg.mjs && node --check bin/capture-platform.mjs && node --check bin/mp4-fragments.mjs && echo build-ok",
     "typecheck": "node --check lib/index.js && echo typecheck-ok",
     "test": "node --test tests/*.test.mjs"
   },
+  "dependencies": {
+    "@deepseek-ai/schemastery": "link:../dsh/vendor/schemastery",
+    "ffmpeg-static": "5.2.0"
+  },
   "peerDependencies": {
-    "@deepseek-ai/dsh-tools": "^0.0.1",
-    "@deepseek-ai/dsh-settings": "^0.0.1",
     "@deepseek-ai/cordis": "^4.0.0-rc.7",
-    "@deepseek-ai/dsh-client-runtime": "^0.0.1",
-    "@deepseek-ai/dsh-client-web-react": "^0.0.1",
-    "@deepseek-ai/dsh-client-ui-slots": "^0.0.1",
     "@deepseek-ai/dsh-client-locale": "^0.0.1",
+    "@deepseek-ai/dsh-client-runtime": "^0.0.1",
     "@deepseek-ai/dsh-client-ui-settings-plugins": "^0.0.1",
+    "@deepseek-ai/dsh-client-ui-slots": "^0.0.1",
+    "@deepseek-ai/dsh-client-web-react": "^0.0.1",
+    "@deepseek-ai/dsh-settings": "^0.0.1",
+    "@deepseek-ai/dsh-tools": "^0.0.1",
     "react": "^18.2.0",
     "schemastery": "^3.18.0"
   },

--- a/tests/active-space.test.mjs
+++ b/tests/active-space.test.mjs
@@ -1,0 +1,26 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createActiveSpaceTracker } from "../lib/index.js";
+
+describe("active ego task space", () => {
+  it("routes omitted-space calls to the most recently opened space", () => {
+    const tracker = createActiveSpaceTracker("dsh-agent");
+    tracker.opened({ name: "open bilibili" }, { ok: true, id: 45, name: "open bilibili" });
+    assert.equal(tracker.current(), 45);
+  });
+
+  it("tracks explicit selection and resets after closing the active space", () => {
+    const tracker = createActiveSpaceTracker("dsh-agent");
+    tracker.selected("research");
+    assert.equal(tracker.current(), "research");
+    tracker.closed("research", true);
+    assert.equal(tracker.current(), "dsh-agent");
+  });
+
+  it("resets an ID-backed active space when closed by its name", () => {
+    const tracker = createActiveSpaceTracker("dsh-agent");
+    tracker.opened({ name: "task" }, { ok: true, id: 45, name: "task" });
+    tracker.closed("task", true);
+    assert.equal(tracker.current(), "dsh-agent");
+  });
+});

--- a/tests/capture-cdp.test.mjs
+++ b/tests/capture-cdp.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { CdpCaptureBackend } from "../bin/capture-cdp.mjs";
+import { CdpCaptureBackend, TargetSessions } from "../bin/capture-cdp.mjs";
 
 class FakeCdp {
   constructor() { this.handlers = new Map(); this.calls = []; }
@@ -10,6 +10,18 @@ class FakeCdp {
 }
 
 describe("CDP capture backend", () => {
+  it("dispatches text, control keys, and modifiers", async () => {
+    const calls = [];
+    const sessions = { call: async (targetId, method, params) => calls.push({ targetId, method, params }) };
+    await TargetSessions.prototype.sendInput.call(sessions, "target", { type: "insertText", text: "中文" });
+    await TargetSessions.prototype.sendInput.call(sessions, "target", { type: "keyDown", key: "a", code: "KeyA", modifiers: 2, windowsVirtualKeyCode: 65 });
+    await TargetSessions.prototype.sendInput.call(sessions, "target", { type: "keyUp", key: "a", code: "KeyA", modifiers: 2, windowsVirtualKeyCode: 65 });
+    assert.deepEqual(calls.map((call) => call.method), ["Input.insertText", "Input.dispatchKeyEvent", "Input.dispatchKeyEvent"]);
+    assert.equal(calls[0].params.text, "中文");
+    assert.equal(calls[1].params.modifiers, 2);
+    assert.equal(calls[1].params.windowsVirtualKeyCode, 65);
+  });
+
   it("ACKs with the frame id while routing on the flattened target session", async () => {
     const cdp = new FakeCdp();
     const session = { targetId: "target-1", sessionId: "target-session", viewportW: 800, viewportH: 600 };

--- a/tests/capture-cdp.test.mjs
+++ b/tests/capture-cdp.test.mjs
@@ -1,0 +1,36 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { CdpCaptureBackend } from "../bin/capture-cdp.mjs";
+
+class FakeCdp {
+  constructor() { this.handlers = new Map(); this.calls = []; }
+  on(method, handler) { this.handlers.set(method, handler); return () => this.handlers.delete(method); }
+  async call(method, params, sessionId) { this.calls.push({ method, params, sessionId }); return {}; }
+  emit(method, params, sessionId) { this.handlers.get(method)?.(params, sessionId); }
+}
+
+describe("CDP capture backend", () => {
+  it("ACKs with the frame id while routing on the flattened target session", async () => {
+    const cdp = new FakeCdp();
+    const session = { targetId: "target-1", sessionId: "target-session", viewportW: 800, viewportH: 600 };
+    const sessions = { ensure: async () => session, get: () => session, updateViewport: async () => session };
+    const frames = [];
+    const backend = new CdpCaptureBackend({ cdp, sessions, getConfig: () => ({ cdpFps: 20, cdpQuality: 55, cdpMaxWidth: 960, cdpBackstopIntervalMs: 10000 }), onStatus: () => {}, onJpegFrame: (frame) => frames.push(frame) });
+    await backend.start({ targetId: "target-1" });
+    cdp.emit("Page.screencastFrame", { sessionId: 42, data: "jpeg", metadata: { visibleViewportWidth: 800, visibleViewportHeight: 600 } }, "target-session");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.ok(cdp.calls.some((call) => call.method === "Page.screencastFrameAck" && call.params.sessionId === 42 && call.sessionId === "target-session"));
+    assert.equal(frames.at(-1).data, "jpeg");
+    await backend.stop();
+  });
+
+  it("stops the old target before starting a switched target", async () => {
+    const cdp = new FakeCdp();
+    const sessions = { ensure: async (targetId) => ({ targetId, sessionId: `session-${targetId}` }), get: () => null, updateViewport: async () => ({}) };
+    const backend = new CdpCaptureBackend({ cdp, sessions, getConfig: () => ({ cdpFps: 20, cdpQuality: 55, cdpMaxWidth: 960, cdpBackstopIntervalMs: 10000 }), onStatus: () => {}, onJpegFrame: () => {} });
+    await backend.start({ targetId: "a" });
+    await backend.switchTarget({ targetId: "b" });
+    assert.deepEqual(cdp.calls.filter((call) => call.method.includes("Screencast")).map((call) => [call.method, call.sessionId]), [["Page.startScreencast", "session-a"], ["Page.stopScreencast", "session-a"], ["Page.startScreencast", "session-b"]]);
+    await backend.stop();
+  });
+});

--- a/tests/capture-ffmpeg.test.mjs
+++ b/tests/capture-ffmpeg.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
-import { codecFromAvcInit, selectEncoder } from "../bin/capture-ffmpeg.mjs";
+import { assertCaptureSupport, codecFromAvcInit, selectEncoder } from "../bin/capture-ffmpeg.mjs";
 
 function probeSpawn(calls, working) {
   return (_path, argv) => {
@@ -10,6 +10,20 @@ function probeSpawn(calls, working) {
     const encoder = argv[argv.indexOf("-c:v") + 1];
     calls.push(encoder);
     queueMicrotask(() => child.emit("exit", encoder === working ? 0 : 1));
+    return child;
+  };
+}
+
+function outputSpawn(output, code = 0) {
+  return () => {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => {};
+    queueMicrotask(() => {
+      child.stdout.emit("data", Buffer.from(output));
+      child.emit("exit", code);
+    });
     return child;
   };
 }
@@ -24,6 +38,32 @@ describe("FFmpeg encoder probing", () => {
 
   it("reports an unavailable explicit encoder", async () => {
     await assert.rejects(selectEncoder("ffmpeg", "h264_nvenc", probeSpawn([], "none")), (error) => error.code === "ffmpeg-encoder-unavailable");
+  });
+
+  it("uses Media Foundation hardware encoding first on Windows", async () => {
+    const calls = [];
+    const selected = await selectEncoder("ffmpeg", "auto", (path, argv) => {
+      const child = new EventEmitter();
+      child.kill = () => {};
+      calls.push(argv);
+      queueMicrotask(() => child.emit("exit", argv.includes("h264_mf") ? 0 : 1));
+      return child;
+    }, {
+      source: { sourceType: "window-hwnd", hwnd: "123", captureWidth: 1264, captureHeight: 805 },
+      fps: 30,
+      maxWidth: 1280,
+    }, "win32");
+    assert.equal(selected, "h264_mf");
+    assert.ok(calls[0].includes("-hw_encoding"));
+    assert.ok(calls[0].some((arg) => arg.includes("gfxcapture=hwnd=123")));
+  });
+
+  it("rejects Windows FFmpeg builds without gfxcapture", async () => {
+    await assert.doesNotReject(assertCaptureSupport("ffmpeg", "win32", outputSpawn("Filter gfxcapture\n")));
+    await assert.rejects(
+      assertCaptureSupport("ffmpeg", "win32", outputSpawn("Unknown filter 'gfxcapture'.")),
+      (error) => error.code === "ffmpeg-gfxcapture-unavailable",
+    );
   });
 
   it("derives the MSE codec from avcC", () => {

--- a/tests/capture-ffmpeg.test.mjs
+++ b/tests/capture-ffmpeg.test.mjs
@@ -1,0 +1,33 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { codecFromAvcInit, selectEncoder } from "../bin/capture-ffmpeg.mjs";
+
+function probeSpawn(calls, working) {
+  return (_path, argv) => {
+    const child = new EventEmitter();
+    child.kill = () => {};
+    const encoder = argv[argv.indexOf("-c:v") + 1];
+    calls.push(encoder);
+    queueMicrotask(() => child.emit("exit", encoder === working ? 0 : 1));
+    return child;
+  };
+}
+
+describe("FFmpeg encoder probing", () => {
+  it("uses a real probe result and falls back to software", async () => {
+    const calls = [];
+    const selected = await selectEncoder("ffmpeg", "auto", probeSpawn(calls, "libx264"));
+    assert.equal(selected, "libx264");
+    assert.equal(calls.at(-1), "libx264");
+  });
+
+  it("reports an unavailable explicit encoder", async () => {
+    await assert.rejects(selectEncoder("ffmpeg", "h264_nvenc", probeSpawn([], "none")), (error) => error.code === "ffmpeg-encoder-unavailable");
+  });
+
+  it("derives the MSE codec from avcC", () => {
+    const init = Buffer.concat([Buffer.from("xxxxavcC", "ascii"), Buffer.from([1, 0x64, 0, 0x28])]);
+    assert.equal(codecFromAvcInit(init), "avc1.640028");
+  });
+});

--- a/tests/capture-manager.test.mjs
+++ b/tests/capture-manager.test.mjs
@@ -1,0 +1,80 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { CaptureManager } from "../bin/capture-manager.mjs";
+
+describe("CaptureManager", () => {
+  it("runs one backend and increments generation on target switch", async () => {
+    const events = [];
+    const factory = ({ generation }) => ({
+      start: async ({ targetId }) => events.push(["start", targetId, generation]),
+      stop: async (reason) => events.push(["stop", reason, generation]),
+      updateConfig: async () => {},
+    });
+    const manager = new CaptureManager({ backendFactories: { cdp: factory }, getConfig: () => ({ captureBackend: "cdp" }), onStatus: () => {}, leaseTtlMs: 60000 });
+    await manager.startWatch({ clientId: "one", targetId: "a" });
+    await manager.switchWatch({ clientId: "one", targetId: "b" });
+    assert.deepEqual(events.slice(0, 3), [["start", "a", 1], ["stop", "backend-change", 1], ["start", "b", 2]]);
+    assert.equal(manager.status().generation, 2);
+    await manager.dispose();
+  });
+
+  it("does not silently replace an explicit unavailable backend", async () => {
+    const manager = new CaptureManager({ backendFactories: { cdp: () => ({ start: async () => {}, stop: async () => {}, updateConfig: async () => {} }) }, getConfig: () => ({ captureBackend: "ffmpeg" }), onStatus: () => {}, leaseTtlMs: 60000 });
+    await manager.startWatch({ clientId: "one", backend: "ffmpeg", targetId: "a" });
+    assert.equal(manager.status().backend, "ffmpeg");
+    assert.equal(manager.status().state, "failed");
+    await manager.dispose();
+  });
+
+  it("renews an existing lease without stealing the shared target", async () => {
+    const starts = [];
+    const factory = () => ({ start: async ({ targetId }) => starts.push(targetId), stop: async () => {}, updateConfig: async () => {} });
+    const manager = new CaptureManager({ backendFactories: { cdp: factory }, getConfig: () => ({ captureBackend: "cdp" }), onStatus: () => {}, leaseTtlMs: 60000 });
+    await manager.startWatch({ clientId: "one", targetId: "a" });
+    await manager.startWatch({ clientId: "two", targetId: "b" });
+    await manager.startWatch({ clientId: "one", targetId: "a" });
+    assert.deepEqual(starts, ["a", "b"]);
+    await manager.dispose();
+  });
+
+  it("serializes overlapping activations", async () => {
+    const events = [];
+    let releaseFirst;
+    const firstGate = new Promise((resolve) => { releaseFirst = resolve; });
+    const factory = ({ generation }) => ({
+      start: async ({ targetId }) => { events.push(`start-${targetId}`); if (generation === 1) await firstGate; events.push(`finish-${targetId}`); },
+      stop: async () => events.push(`stop-${generation}`), updateConfig: async () => {},
+    });
+    const manager = new CaptureManager({ backendFactories: { cdp: factory }, getConfig: () => ({ captureBackend: "cdp" }), onStatus: () => {}, leaseTtlMs: 60000 });
+    const first = manager.startWatch({ clientId: "one", targetId: "a" });
+    const second = manager.startWatch({ clientId: "two", targetId: "b" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.deepEqual(events, ["start-a"]);
+    releaseFirst();
+    await Promise.all([first, second]);
+    assert.deepEqual(events, ["start-a", "finish-a", "stop-1", "start-b", "finish-b"]);
+    await manager.dispose();
+  });
+
+  it("ignores late status from an obsolete backend and cleans failed starts", async () => {
+    const statusCallbacks = [];
+    let disposed = 0;
+    let attempt = 0;
+    const factory = ({ onStatus }) => {
+      statusCallbacks.push(onStatus);
+      attempt += 1;
+      return {
+        start: async () => { if (attempt === 1) throw new Error("boom"); },
+        stop: async () => {}, dispose: async () => { disposed += 1; }, updateConfig: async () => {},
+      };
+    };
+    const manager = new CaptureManager({ backendFactories: { cdp: factory }, getConfig: () => ({ captureBackend: "cdp" }), onStatus: () => {}, leaseTtlMs: 60000 });
+    await manager.startWatch({ clientId: "one", targetId: "a" });
+    assert.equal(disposed, 1);
+    await manager.switchWatch({ clientId: "one", targetId: "b" });
+    statusCallbacks[0]({ backend: "cdp", state: "failed", message: "late" });
+    assert.equal(manager.status().targetId, "b");
+    assert.notEqual(manager.status().message, "late");
+    await manager.dispose();
+  });
+});

--- a/tests/capture-manager.test.mjs
+++ b/tests/capture-manager.test.mjs
@@ -26,11 +26,22 @@ describe("CaptureManager", () => {
     await manager.dispose();
   });
 
-  it("does not silently replace an explicit unavailable backend", async () => {
+  it("falls back to CDP with a visible reason when FFmpeg is unavailable", async () => {
     const manager = new CaptureManager({ backendFactories: { cdp: () => ({ start: async () => {}, stop: async () => {}, updateConfig: async () => {} }) }, getConfig: () => ({ captureBackend: "ffmpeg" }), onStatus: () => {}, leaseTtlMs: 60000 });
     await manager.startWatch({ clientId: "one", backend: "ffmpeg", targetId: "a" });
-    assert.equal(manager.status().backend, "ffmpeg");
+    assert.equal(manager.status().backend, "cdp");
+    assert.equal(manager.status().code, "ffmpeg-fallback-cdp");
+    assert.match(manager.status().message, /FFmpeg unavailable/);
+    await manager.dispose();
+  });
+
+  it("does not claim a successful fallback when CDP also fails", async () => {
+    const failing = (message) => () => ({ start: async () => { throw new Error(message); }, stop: async () => {}, dispose: async () => {} });
+    const manager = new CaptureManager({ backendFactories: { ffmpeg: failing("ffmpeg failed"), cdp: failing("cdp failed") }, getConfig: () => ({ captureBackend: "ffmpeg" }), onStatus: () => {}, leaseTtlMs: 60000 });
+    await manager.startWatch({ clientId: "one", backend: "ffmpeg", targetId: "a" });
     assert.equal(manager.status().state, "failed");
+    assert.equal(manager.status().message, "cdp failed");
+    assert.notEqual(manager.status().code, "ffmpeg-fallback-cdp");
     await manager.dispose();
   });
 

--- a/tests/capture-manager.test.mjs
+++ b/tests/capture-manager.test.mjs
@@ -3,6 +3,14 @@ import assert from "node:assert/strict";
 import { CaptureManager } from "../bin/capture-manager.mjs";
 
 describe("CaptureManager", () => {
+  it("keeps leases alive across background timer throttling", async () => {
+    const now = 1000;
+    const manager = new CaptureManager({ backendFactories: {}, getConfig: () => ({ captureBackend: "cdp" }), onStatus: () => {}, now: () => now, leaseTtlMs: 120000 });
+    await manager.startWatch({ clientId: "one", targetId: "a" });
+    assert.equal(manager.leases.get("one").expiresAt, now + 120000);
+    await manager.dispose();
+  });
+
   it("runs one backend and increments generation on target switch", async () => {
     const events = [];
     const factory = ({ generation }) => ({
@@ -23,6 +31,31 @@ describe("CaptureManager", () => {
     await manager.startWatch({ clientId: "one", backend: "ffmpeg", targetId: "a" });
     assert.equal(manager.status().backend, "ffmpeg");
     assert.equal(manager.status().state, "failed");
+    await manager.dispose();
+  });
+
+  it("publishes the configured backend while capture is idle", async () => {
+    let configured = "cdp";
+    const manager = new CaptureManager({ backendFactories: {}, getConfig: () => ({ captureBackend: configured }), onStatus: () => {}, leaseTtlMs: 60000 });
+    configured = "ffmpeg";
+    await manager.updateConfig();
+    assert.equal(manager.status().backend, "ffmpeg");
+    assert.equal(manager.status().state, "idle");
+    await manager.dispose();
+  });
+
+  it("retries a failed backend for an existing lease", async () => {
+    let attempts = 0;
+    const factory = () => ({
+      start: async () => { attempts += 1; if (attempts === 1) throw new Error("transient"); },
+      stop: async () => {}, dispose: async () => {}, updateConfig: async () => {},
+    });
+    const manager = new CaptureManager({ backendFactories: { ffmpeg: factory }, getConfig: () => ({ captureBackend: "ffmpeg" }), onStatus: () => {}, leaseTtlMs: 60000 });
+    await manager.startWatch({ clientId: "one", targetId: "a" });
+    assert.equal(manager.status().state, "failed");
+    await manager.startWatch({ clientId: "one", targetId: "a" });
+    assert.equal(attempts, 2);
+    assert.ok(manager.backend);
     await manager.dispose();
   });
 
@@ -64,14 +97,16 @@ describe("CaptureManager", () => {
       statusCallbacks.push(onStatus);
       attempt += 1;
       return {
-        start: async () => { if (attempt === 1) throw new Error("boom"); },
+        start: async () => { if (attempt === 1) { const error = new Error("boom"); error.code = "probe-failed"; throw error; } },
         stop: async () => {}, dispose: async () => { disposed += 1; }, updateConfig: async () => {},
       };
     };
     const manager = new CaptureManager({ backendFactories: { cdp: factory }, getConfig: () => ({ captureBackend: "cdp" }), onStatus: () => {}, leaseTtlMs: 60000 });
     await manager.startWatch({ clientId: "one", targetId: "a" });
     assert.equal(disposed, 1);
+    assert.equal(manager.status().code, "probe-failed");
     await manager.switchWatch({ clientId: "one", targetId: "b" });
+    assert.equal(manager.status().code, null);
     statusCallbacks[0]({ backend: "cdp", state: "failed", message: "late" });
     assert.equal(manager.status().targetId, "b");
     assert.notEqual(manager.status().message, "late");

--- a/tests/capture-platform.test.mjs
+++ b/tests/capture-platform.test.mjs
@@ -1,0 +1,21 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildCaptureInput, buildEncoderArgs } from "../bin/capture-platform.mjs";
+
+const source = { captureX: 10, captureY: 20, captureWidth: 800, captureHeight: 600 };
+
+describe("FFmpeg argv generation", () => {
+  it("uses argv values without a shell on Windows and X11", () => {
+    assert.deepEqual(buildCaptureInput({ platform: "win32", source, fps: 20 }).slice(0, 4), ["-f", "gdigrab", "-framerate", "20"]);
+    assert.ok(buildCaptureInput({ platform: "linux", env: { DISPLAY: ":9" }, source, fps: 15 }).includes(":9+10,20"));
+  });
+
+  it("reports unsupported bundled Wayland capture", () => {
+    assert.throws(() => buildCaptureInput({ platform: "linux", env: { XDG_SESSION_TYPE: "wayland" }, source, fps: 20 }), (error) => error.code === "unsupported-ffmpeg-pipewire");
+  });
+
+  it("builds low-latency fragmented MP4 encoder args", () => {
+    const args = buildEncoderArgs({ encoder: "libx264", fps: 20, maxWidth: 1280 });
+    assert.ok(args.includes("zerolatency")); assert.ok(args.includes("empty_moov+default_base_moof+frag_keyframe")); assert.equal(args.at(-1), "pipe:1");
+  });
+});

--- a/tests/capture-platform.test.mjs
+++ b/tests/capture-platform.test.mjs
@@ -1,13 +1,26 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { buildCaptureInput, buildEncoderArgs } from "../bin/capture-platform.mjs";
+import { buildCaptureInput, buildEncoderArgs, resolveCaptureSource, selectWindowCandidate } from "../bin/capture-platform.mjs";
 
 const source = { captureX: 10, captureY: 20, captureWidth: 800, captureHeight: 600 };
+const windowSource = { sourceType: "window-hwnd", hwnd: "12345", captureWidth: 1264, captureHeight: 805, cropTop: 87 };
 
 describe("FFmpeg argv generation", () => {
-  it("uses argv values without a shell on Windows and X11", () => {
-    assert.deepEqual(buildCaptureInput({ platform: "win32", source, fps: 20 }).slice(0, 4), ["-f", "gdigrab", "-framerate", "20"]);
+  it("uses gfxcapture HWND on Windows and argv values on X11", () => {
+    const windowsArgs = buildCaptureInput({ platform: "win32", source: windowSource, fps: 30, maxWidth: 1280, encoder: "h264_mf" });
+    assert.equal(windowsArgs[0], "-filter_complex");
+    assert.match(windowsArgs[1], /gfxcapture=hwnd=12345/);
+    assert.match(windowsArgs[1], /crop_top=87/);
+    assert.match(windowsArgs[1], /fps=30,setpts=N\/\(30\*TB\)/);
+    assert.doesNotMatch(windowsArgs[1], /desktop/);
     assert.ok(buildCaptureInput({ platform: "linux", env: { DISPLAY: ":9" }, source, fps: 15 }).includes(":9+10,20"));
+  });
+
+  it("downloads D3D11 frames only for software encoding", () => {
+    const hardware = buildCaptureInput({ platform: "win32", source: windowSource, fps: 30, maxWidth: 960, encoder: "h264_mf" })[1];
+    const software = buildCaptureInput({ platform: "win32", source: windowSource, fps: 30, maxWidth: 960, encoder: "libx264" })[1];
+    assert.doesNotMatch(hardware, /hwdownload/);
+    assert.match(software, /hwdownload,format=bgra,format=yuv420p/);
   });
 
   it("reports unsupported bundled Wayland capture", () => {
@@ -17,5 +30,46 @@ describe("FFmpeg argv generation", () => {
   it("builds low-latency fragmented MP4 encoder args", () => {
     const args = buildEncoderArgs({ encoder: "libx264", fps: 20, maxWidth: 1280 });
     assert.ok(args.includes("zerolatency")); assert.ok(args.includes("empty_moov+default_base_moof+frag_keyframe")); assert.equal(args.at(-1), "pipe:1");
+  });
+
+  it("builds the Windows Media Foundation low-latency output", () => {
+    const args = buildEncoderArgs({ encoder: "h264_mf", fps: 30, maxWidth: 1280, bitrateKbps: 4000, source: windowSource, platform: "win32" });
+    assert.ok(args.includes("-hw_encoding"));
+    assert.ok(args.includes("display_remoting"));
+    assert.ok(args.includes("empty_moov+default_base_moof+frag_keyframe+skip_trailer"));
+    assert.equal(args[args.indexOf("-frag_duration") + 1], "100000");
+    assert.equal(args[args.indexOf("-b:v") + 1], "4000k");
+    assert.equal(args[args.indexOf("-maxrate") + 1], "5000k");
+    assert.equal(args[args.indexOf("-bufsize") + 1], "8000k");
+  });
+
+  it("matches a target to the Chrome HWND by title and bounds", () => {
+    const windows = [
+      { hwnd: 1, title: "Other - Google Chrome", x: 0, y: 0, width: 1280, height: 900 },
+      { hwnd: 2, title: "Target page - Google Chrome", x: 400, y: 100, width: 1280, height: 900 },
+    ];
+    assert.equal(selectWindowCandidate(windows, { left: 395, top: 99, width: 1280, height: 900 }, "Target page").hwnd, 2);
+  });
+
+  it("keeps exact CDP geometry authoritative over a distant title match", () => {
+    const windows = [
+      { hwnd: 1, title: "Visible page - Google Chrome", x: 395, y: 99, width: 1280, height: 900 },
+      { hwnd: 2, title: "Target page - Google Chrome", x: 1800, y: 400, width: 1000, height: 700 },
+    ];
+    assert.equal(selectWindowCandidate(windows, { left: 395, top: 99, width: 1280, height: 900 }, "Target page").hwnd, 1);
+  });
+
+  it("rejects a background tab instead of streaming the visible tab", async () => {
+    const sessions = {
+      call: async () => ({ result: { value: { screenX: 0, screenY: 0, outerWidth: 1280, outerHeight: 900, innerWidth: 1264, innerHeight: 805, devicePixelRatio: 1, title: "Requested tab" } } }),
+      cdp: { call: async (method) => method === "Browser.getWindowForTarget" ? { windowId: 7 } : { bounds: { left: 10, top: 10, width: 1280, height: 900 } } },
+    };
+    await assert.rejects(
+      resolveCaptureSource({
+        sessions, targetId: "target", browserPid: 42, platform: "win32",
+        windowEnumerator: async () => [{ hwnd: 9, title: "Visible tab - Google Chrome", x: 10, y: 10, width: 1280, height: 900, clientWidth: 1264, clientHeight: 892 }],
+      }),
+      (error) => error.code === "ffmpeg-target-not-visible",
+    );
   });
 });

--- a/tests/cast-server.test.mjs
+++ b/tests/cast-server.test.mjs
@@ -1,0 +1,30 @@
+import { after, before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { proxyPost } from "../lib/cast-server.js";
+
+describe("cast server worker proxy", () => {
+  let server;
+  let port;
+
+  before(async () => {
+    server = createServer(async (req, res) => {
+      for await (const _chunk of req) {}
+      const payload = JSON.stringify({ ok: false, code: "capture-target-stale" });
+      res.writeHead(409, { "content-type": "application/json", "content-length": Buffer.byteLength(payload) });
+      res.end(payload);
+    });
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    port = server.address().port;
+  });
+
+  after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  it("preserves the worker HTTP status and JSON error", async () => {
+    const result = await proxyPost(port, "/api/input", { targetId: "missing" });
+    assert.equal(result.status, 409);
+    assert.equal(result.body.code, "capture-target-stale");
+  });
+});

--- a/tests/client-input.test.mjs
+++ b/tests/client-input.test.mjs
@@ -1,0 +1,19 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("../lib/client.js", import.meta.url), "utf8");
+
+describe("watch panel input and capture status", () => {
+  it("provides local keyboard proxies for floating and sidebar views", () => {
+    assert.match(source, /function createKeyboardProxy\(send\)/);
+    assert.match(source, /compositionend/);
+    assert.match(source, /send\([^,]+, 'insertText'/);
+    assert.equal((source.match(/keyboardProxy\.focusAt\(e,/g) || []).length, 2);
+  });
+
+  it("does not gate control input on stream state or default missing status to CDP", () => {
+    assert.doesNotMatch(source, /status\.backend \|\| 'cdp'/);
+    assert.doesNotMatch(source, /targetValid[^\n]+streamState !== 'streaming'/);
+  });
+});

--- a/tests/client-input.test.mjs
+++ b/tests/client-input.test.mjs
@@ -16,4 +16,10 @@ describe("watch panel input and capture status", () => {
     assert.doesNotMatch(source, /status\.backend \|\| 'cdp'/);
     assert.doesNotMatch(source, /targetValid[^\n]+streamState !== 'streaming'/);
   });
+
+  it("keeps the FFmpeg option disabled until installation is ready", () => {
+    assert.match(source, /disabled: !ffmpegStatus\.canSelectFfmpeg/);
+    assert.match(source, /ffmpeg-install/);
+    assert.match(source, /githubMirror/);
+  });
 });

--- a/tests/config.test.mjs
+++ b/tests/config.test.mjs
@@ -1,0 +1,36 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { resolveConfig } from "../lib/config.js";
+
+describe("dual capture config", () => {
+  it("returns canonical defaults", () => {
+    assert.deepEqual(resolveConfig({}), {
+      chromePath: "", captureBackend: "auto", streamProfile: "balanced",
+      cdpFps: 20, cdpQuality: 55, cdpMaxWidth: 960, cdpBackstopIntervalMs: 3000,
+      ffmpegFps: 20, ffmpegMaxWidth: 1280, ffmpegEncoder: "auto", ffmpegPath: "",
+    });
+  });
+
+  it("migrates legacy CDP fields and lets canonical fields win", () => {
+    assert.deepEqual(resolveConfig({ castFpsCap: 60, screencastQuality: 70, screencastMaxWidth: 1200, backstopIntervalMs: 5000 }), {
+      chromePath: "", captureBackend: "auto", streamProfile: "balanced",
+      cdpFps: 30, cdpQuality: 70, cdpMaxWidth: 1200, cdpBackstopIntervalMs: 5000,
+      ffmpegFps: 20, ffmpegMaxWidth: 1280, ffmpegEncoder: "auto", ffmpegPath: "",
+    });
+    assert.equal(resolveConfig({ cdpFps: 15, castFpsCap: 30 }).cdpFps, 15);
+  });
+
+  it("falls back for invalid enums and numbers", () => {
+    const config = resolveConfig({ captureBackend: "bad", cdpFps: 99, ffmpegEncoder: "bad" });
+    assert.equal(config.captureBackend, "auto");
+    assert.equal(config.cdpFps, 20);
+    assert.equal(config.ffmpegEncoder, "auto");
+  });
+
+  it("applies stream profiles unless advanced FFmpeg fields override them", () => {
+    assert.equal(resolveConfig({ streamProfile: "low" }).ffmpegFps, 15);
+    assert.equal(resolveConfig({ streamProfile: "high" }).ffmpegMaxWidth, 1600);
+    assert.equal(resolveConfig({ streamProfile: "high", ffmpegFps: 12 }).ffmpegFps, 12);
+    assert.equal(resolveConfig({ backstopIntervalMs: 200 }).cdpBackstopIntervalMs, 1000);
+  });
+});

--- a/tests/config.test.mjs
+++ b/tests/config.test.mjs
@@ -7,7 +7,7 @@ describe("dual capture config", () => {
     assert.deepEqual(resolveConfig({}), {
       chromePath: "", captureBackend: "auto", streamProfile: "balanced",
       cdpFps: 20, cdpQuality: 55, cdpMaxWidth: 960, cdpBackstopIntervalMs: 3000,
-      ffmpegFps: 20, ffmpegMaxWidth: 1280, ffmpegEncoder: "auto", ffmpegPath: "",
+      ffmpegFps: 20, ffmpegMaxWidth: 1280, ffmpegBitrateKbps: 4000, ffmpegEncoder: "auto", ffmpegPath: "",
     });
   });
 
@@ -15,7 +15,7 @@ describe("dual capture config", () => {
     assert.deepEqual(resolveConfig({ castFpsCap: 60, screencastQuality: 70, screencastMaxWidth: 1200, backstopIntervalMs: 5000 }), {
       chromePath: "", captureBackend: "auto", streamProfile: "balanced",
       cdpFps: 30, cdpQuality: 70, cdpMaxWidth: 1200, cdpBackstopIntervalMs: 5000,
-      ffmpegFps: 20, ffmpegMaxWidth: 1280, ffmpegEncoder: "auto", ffmpegPath: "",
+      ffmpegFps: 20, ffmpegMaxWidth: 1280, ffmpegBitrateKbps: 4000, ffmpegEncoder: "auto", ffmpegPath: "",
     });
     assert.equal(resolveConfig({ cdpFps: 15, castFpsCap: 30 }).cdpFps, 15);
   });
@@ -30,6 +30,9 @@ describe("dual capture config", () => {
   it("applies stream profiles unless advanced FFmpeg fields override them", () => {
     assert.equal(resolveConfig({ streamProfile: "low" }).ffmpegFps, 15);
     assert.equal(resolveConfig({ streamProfile: "high" }).ffmpegMaxWidth, 1600);
+    assert.equal(resolveConfig({ streamProfile: "low" }).ffmpegBitrateKbps, 2000);
+    assert.equal(resolveConfig({ streamProfile: "high" }).ffmpegBitrateKbps, 8000);
+    assert.equal(resolveConfig({ streamProfile: "high", ffmpegBitrateKbps: 6000 }).ffmpegBitrateKbps, 6000);
     assert.equal(resolveConfig({ streamProfile: "high", ffmpegFps: 12 }).ffmpegFps, 12);
     assert.equal(resolveConfig({ backstopIntervalMs: 200 }).cdpBackstopIntervalMs, 1000);
   });

--- a/tests/config.test.mjs
+++ b/tests/config.test.mjs
@@ -7,7 +7,7 @@ describe("dual capture config", () => {
     assert.deepEqual(resolveConfig({}), {
       chromePath: "", captureBackend: "auto", streamProfile: "balanced",
       cdpFps: 20, cdpQuality: 55, cdpMaxWidth: 960, cdpBackstopIntervalMs: 3000,
-      ffmpegFps: 20, ffmpegMaxWidth: 1280, ffmpegBitrateKbps: 4000, ffmpegEncoder: "auto", ffmpegPath: "",
+      ffmpegFps: 20, ffmpegMaxWidth: 1280, ffmpegBitrateKbps: 4000, ffmpegEncoder: "auto", ffmpegPath: "", githubMirror: "",
     });
   });
 
@@ -15,7 +15,7 @@ describe("dual capture config", () => {
     assert.deepEqual(resolveConfig({ castFpsCap: 60, screencastQuality: 70, screencastMaxWidth: 1200, backstopIntervalMs: 5000 }), {
       chromePath: "", captureBackend: "auto", streamProfile: "balanced",
       cdpFps: 30, cdpQuality: 70, cdpMaxWidth: 1200, cdpBackstopIntervalMs: 5000,
-      ffmpegFps: 20, ffmpegMaxWidth: 1280, ffmpegBitrateKbps: 4000, ffmpegEncoder: "auto", ffmpegPath: "",
+      ffmpegFps: 20, ffmpegMaxWidth: 1280, ffmpegBitrateKbps: 4000, ffmpegEncoder: "auto", ffmpegPath: "", githubMirror: "",
     });
     assert.equal(resolveConfig({ cdpFps: 15, castFpsCap: 30 }).cdpFps, 15);
   });

--- a/tests/ffmpeg-installation.test.mjs
+++ b/tests/ffmpeg-installation.test.mjs
@@ -1,0 +1,90 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { EventEmitter } from "node:events";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import { gzipSync } from "node:zlib";
+import { FfmpegInstallationManager, downloadFile } from "../lib/ffmpeg-installation.js";
+
+const roots = [];
+afterEach(async () => { await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true }))); });
+
+function fakeSpawn(handler) {
+  return (command, argv) => {
+    const child = new EventEmitter();
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.kill = () => {};
+    queueMicrotask(() => {
+      const result = handler(command, argv);
+      child.stdout.end(result.stdout || "");
+      child.stderr.end(result.stderr || "");
+      child.emit("exit", result.code ?? 0);
+    });
+    return child;
+  };
+}
+
+describe("FFmpeg installation manager", () => {
+  it("prefers a compatible system binary after an invalid custom path", async () => {
+    const spawn = fakeSpawn((command, argv) => {
+      if (command === "bad-custom") return { code: 1 };
+      if (argv[0] === "-version") return { stdout: "ffmpeg version system\n" };
+      if (argv.includes("filter=gfxcapture")) return { stdout: "Filter gfxcapture\n" };
+      return { code: argv.includes("h264_mf") ? 0 : 1 };
+    });
+    const manager = new FfmpegInstallationManager({ platform: "win32", arch: "x64", getConfig: () => ({ ffmpegPath: "bad-custom" }), spawn });
+    const status = await manager.check();
+    assert.equal(status.source, "system");
+    assert.equal(status.path, "ffmpeg");
+    assert.equal(status.canSelectFfmpeg, true);
+    assert.equal(status.candidates[0].usable, false);
+  });
+
+  it("downloads, verifies, installs, and selects a managed gzip build", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ego-ffmpeg-test-")); roots.push(root);
+    const binary = Buffer.from("fake-ffmpeg-binary");
+    const archive = gzipSync(binary);
+    const sha256 = createHash("sha256").update(archive).digest("hex");
+    const spawn = fakeSpawn((command, argv) => {
+      if (command === "ffmpeg") return { code: 1 };
+      if (argv[0] === "-version") return { stdout: "ffmpeg version managed\n" };
+      if (argv.includes("-devices")) return { stdout: "D  avfoundation\n" };
+      return { code: argv.includes("h264_videotoolbox") ? 0 : 1 };
+    });
+    const manager = new FfmpegInstallationManager({
+      platform: "darwin", arch: "x64", cacheRoot: root, getConfig: () => ({ ffmpegPath: "", githubMirror: "" }), spawn,
+      fetchImpl: async () => new Response(archive, { status: 200, headers: { "content-length": String(archive.length) } }),
+    });
+    manager.manifest = { provider: "test", buildId: "pinned", archiveType: "gzip", size: archive.length, url: "https://downloads.invalid/ffmpeg.gz", sha256, executableName: "ffmpeg" };
+    const status = await manager.install();
+    assert.equal(status.source, "managed");
+    assert.equal(status.canSelectFfmpeg, true);
+    assert.deepEqual(await readFile(manager.managedPath()), binary);
+  });
+
+  it("rejects a checksum mismatch without publishing an install", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ego-ffmpeg-test-")); roots.push(root);
+    const manager = new FfmpegInstallationManager({ platform: "darwin", arch: "x64", cacheRoot: root, fetchImpl: async () => new Response(Buffer.from("bad"), { status: 200 }) });
+    manager.manifest = { provider: "test", buildId: "pinned", archiveType: "gzip", size: 3, url: "https://downloads.invalid/ffmpeg.gz", sha256: "0".repeat(64), executableName: "ffmpeg" };
+    await assert.rejects(() => manager.install(), { code: "ffmpeg-checksum-mismatch" });
+    assert.equal(manager.status().state, "failed");
+  });
+});
+
+describe("FFmpeg downloader", () => {
+  it("reports progress and returns the streamed SHA-256", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ego-ffmpeg-test-")); roots.push(root);
+    const data = Buffer.from("download-body");
+    const progress = [];
+    const digest = await downloadFile("https://downloads.invalid/file", join(root, "file"), {
+      fetchImpl: async () => new Response(data, { status: 200, headers: { "content-length": String(data.length) } }),
+      onProgress: (value) => progress.push(value),
+    });
+    assert.equal(digest, createHash("sha256").update(data).digest("hex"));
+    assert.equal(progress.at(-1).percent, 100);
+  });
+});

--- a/tests/ffmpeg-manifest.test.mjs
+++ b/tests/ffmpeg-manifest.test.mjs
@@ -1,0 +1,22 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { platformManifest, rewriteGithubUrl } from "../lib/ffmpeg-manifest.js";
+
+describe("managed FFmpeg manifest", () => {
+  it("selects pinned platform builds", () => {
+    const windows = platformManifest("win32", "x64");
+    assert.equal(windows.buildId, "autobuild-2026-08-17-13-05");
+    assert.match(windows.url, /releases\/download\/autobuild-2026-08-17-13-05\//);
+    assert.match(windows.sha256, /^[a-f0-9]{64}$/);
+    assert.equal(platformManifest("freebsd", "x64"), null);
+  });
+
+  it("replaces only the GitHub origin with an HTTPS mirror", () => {
+    const source = "https://github.com/BtbN/FFmpeg-Builds/releases/download/tag/file.zip";
+    assert.equal(rewriteGithubUrl(source, "https://gh-proxy.com/github.com/"), "https://gh-proxy.com/github.com/BtbN/FFmpeg-Builds/releases/download/tag/file.zip");
+    assert.equal(rewriteGithubUrl(source, "https://ghm.xyz"), "https://ghm.xyz/BtbN/FFmpeg-Builds/releases/download/tag/file.zip");
+    assert.equal(rewriteGithubUrl("https://evermeet.cx/ffmpeg/a.zip", "https://ghm.xyz"), "https://evermeet.cx/ffmpeg/a.zip");
+    assert.throws(() => rewriteGithubUrl(source, "http://mirror.invalid"), { code: "ffmpeg-mirror-invalid" });
+    assert.throws(() => rewriteGithubUrl(source, "https://user:pass@mirror.invalid"), { code: "ffmpeg-mirror-invalid" });
+  });
+});

--- a/tests/ffmpeg-probe.test.mjs
+++ b/tests/ffmpeg-probe.test.mjs
@@ -1,0 +1,46 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { probeFfmpeg } from "../bin/ffmpeg-probe.mjs";
+
+function fakeSpawn(handler) {
+  return (command, argv) => {
+    const child = new EventEmitter();
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    child.kill = () => {};
+    queueMicrotask(() => {
+      const result = handler(command, argv);
+      if (result.stdout) child.stdout.end(result.stdout); else child.stdout.end();
+      if (result.stderr) child.stderr.end(result.stderr); else child.stderr.end();
+      child.emit("exit", result.code ?? 0);
+    });
+    return child;
+  };
+}
+
+describe("managed FFmpeg capability probe", () => {
+  it("requires gfxcapture and selects a working Windows encoder", async () => {
+    const spawn = fakeSpawn((_command, argv) => {
+      if (argv[0] === "-version") return { stdout: "ffmpeg version test\n" };
+      if (argv.includes("filter=gfxcapture")) return { stdout: "Filter gfxcapture\n" };
+      return { code: argv.includes("h264_mf") ? 0 : 1 };
+    });
+    assert.deepEqual(await probeFfmpeg("ffmpeg.exe", { platform: "win32", spawn }), { version: "ffmpeg version test", encoder: "h264_mf" });
+  });
+
+  it("rejects Wayland before selecting an encoder", async () => {
+    const spawn = fakeSpawn((_command, argv) => argv[0] === "-version" ? { stdout: "ffmpeg version test\n" } : { stdout: "x11grab\n" });
+    await assert.rejects(() => probeFfmpeg("ffmpeg", { platform: "linux", env: { WAYLAND_DISPLAY: "wayland-0" }, spawn }), { code: "ffmpeg-platform-unsupported" });
+  });
+
+  it("validates an explicitly requested encoder", async () => {
+    const spawn = fakeSpawn((_command, argv) => {
+      if (argv[0] === "-version") return { stdout: "ffmpeg version test\n" };
+      if (argv.includes("filter=gfxcapture")) return { stdout: "Filter gfxcapture\n" };
+      return { code: 1 };
+    });
+    await assert.rejects(() => probeFfmpeg("ffmpeg.exe", { platform: "win32", spawn, requestedEncoder: "h264_mf" }), { code: "ffmpeg-encoder-unavailable" });
+  });
+});

--- a/tests/mp4-fragments.test.mjs
+++ b/tests/mp4-fragments.test.mjs
@@ -1,0 +1,30 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Mp4FragmentParser } from "../bin/mp4-fragments.mjs";
+
+function box(type, payload = "") {
+  const body = Buffer.from(payload);
+  const result = Buffer.alloc(8 + body.length);
+  result.writeUInt32BE(result.length, 0); result.write(type, 4, 4, "ascii"); body.copy(result, 8);
+  return result;
+}
+
+describe("fragmented MP4 parser", () => {
+  it("reassembles arbitrary stdout chunks", () => {
+    const init = [], fragments = [];
+    const parser = new Mp4FragmentParser({ onInit: (value) => init.push(value), onFragment: (value) => fragments.push(value) });
+    const stream = Buffer.concat([box("ftyp", "a"), box("moov", "b"), box("moof", "c"), box("mdat", "d")]);
+    for (let i = 0; i < stream.length; i += 3) parser.push(stream.subarray(i, i + 3));
+    parser.end();
+    assert.equal(init.length, 1); assert.equal(fragments.length, 1);
+    assert.equal(init[0].toString("hex"), Buffer.concat([box("ftyp", "a"), box("moov", "b")]).toString("hex"));
+  });
+
+  it("rejects invalid and truncated boxes", () => {
+    const parser = new Mp4FragmentParser({ onInit: () => {}, onFragment: () => {} });
+    assert.throws(() => parser.push(Buffer.from([0, 0, 0, 4, 102, 116, 121, 112])), /invalid MP4 box size/);
+    const truncated = new Mp4FragmentParser({ onInit: () => {}, onFragment: () => {} });
+    truncated.push(box("ftyp").subarray(0, 7));
+    assert.throws(() => truncated.end(), /truncated MP4 stream/);
+  });
+});

--- a/tests/settings.test.mjs
+++ b/tests/settings.test.mjs
@@ -1,0 +1,31 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { installEgoBrowserSettings } from "../lib/settings.js";
+
+describe("ego-browser settings bridge", () => {
+  it("shares one registered scope across plugin fibers", () => {
+    const value = { captureBackend: "ffmpeg", ffmpegPath: "C:\\ffmpeg.exe" };
+    const watchers = new Set();
+    let registrations = 0;
+    const scope = {
+      get: () => value,
+      watch: (callback) => { watchers.add(callback); return () => watchers.delete(callback); },
+    };
+    const settings = {
+      register: () => { registrations += 1; if (registrations > 1) throw new Error('settings namespace "ego-browser" is already registered'); return scope; },
+    };
+    const context = (service) => ({
+      fiber: { state: 0 },
+      inject: (_names, callback) => callback({ settings: service, effect: (factory) => factory() }),
+      logger: () => ({ warn: () => {} }),
+    });
+
+    const first = installEgoBrowserSettings(context(settings), {});
+    const second = installEgoBrowserSettings(context({ ...settings }), {});
+
+    assert.equal(registrations, 1);
+    assert.equal(first.source().captureBackend, "ffmpeg");
+    assert.equal(second.source().ffmpegPath, "C:\\ffmpeg.exe");
+    assert.equal(watchers.size, 2);
+  });
+});


### PR DESCRIPTION
## Summary
- split realtime preview into CDP JPEG and FFmpeg H.264/fMP4 backends
- use Windows gfxcapture(HWND) so covered or moved Chrome windows do not leak the foreground desktop
- add bitrate controls, Media Foundation hardware encoding, background-safe leases, proxy error preservation, and bounded video backpressure
- add direct mouse, keyboard, shortcut, paste, and Chinese IME control through CDP
- converge capture status from watch responses, SSE, spaces, and status endpoints
- track the active ego task space so space_open followed by navigate does not leave an about:blank window

## Verification
- npm test: 57 tests passed
- npm run build: passed
- live Windows validation: gfxcapture + h264_mf at 30 FPS / 4 Mbps
- DSH minimized for 15 seconds without capture generation restart
- stale input target returns 409 instead of opaque 500

## WIP / follow-up
- Windows FFmpeg currently requires a recent build with the gfxcapture filter configured through ffmpegPath
- bundled-binary distribution and broader macOS/Linux soak testing remain before merge
- additional multi-client and long-running UX validation is still planned