### PR TITLE
fix: adapt to DSH rc.8 (web-react rename + keyed slot registration)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -38,9 +38,27 @@ window.__ModuleLoader__.load({
 		// from the profile's node_modules (declared as peerDependencies).
 		var React = require('react')
 		var runtimeClient = require('@deepseek-ai/dsh-client-runtime/client')
-		var webReact = require('@deepseek-ai/dsh-client-web-react')
 		var createSnapshotStore = runtimeClient.createSnapshotStore
-		var bindSnapshotSelector = webReact.bindSnapshotSelector
+		// bindSnapshotSelector inlined from dsh-client-ui-renderer (shell-only
+		// glue; business plugins depend on runtime + ui-slots only). Uses
+		// React 18's built-in useSyncExternalStore with per-snapshot selector
+		// memoization via useRef.
+		var useSyncExternalStore = React.useSyncExternalStore
+		var useRef = React.useRef
+		function bindSnapshotSelector(source) {
+			var subscribe = function (fn) { return source.subscribe(fn) }
+			var getSnapshot = function () { return source.getSnapshot() }
+			return function useSelector(sel, eq) {
+				var snapshot = useSyncExternalStore(subscribe, getSnapshot)
+				var prevSnapshotRef = useRef()
+				var prevSelectedRef = useRef()
+				if (prevSnapshotRef.current !== snapshot) {
+					prevSnapshotRef.current = snapshot
+					prevSelectedRef.current = sel(snapshot)
+				}
+				return prevSelectedRef.current
+			}
+		}
 
 		const inject = ['slots', 'locale', 'connection']
 
@@ -927,6 +945,7 @@ window.__ModuleLoader__.load({
 			ctx.slots.inject('settings.plugin.item', function* () {
 				yield ctx.slots.register({
 					name: 'settings.plugin.item',
+					key: SETTINGS_NS,
 					id: 'ego-browser',
 					order: 60,
 					locale: SETTINGS_NS,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
       "platform": "web",
       "inject": [
         "@deepseek-ai/dsh-client-runtime",
-        "@deepseek-ai/dsh-client-web-react",
         "@deepseek-ai/dsh-client-ui-slots",
         "@deepseek-ai/dsh-client-locale",
         "@deepseek-ai/dsh-client-ui-settings-plugins"
@@ -39,7 +38,6 @@
     "@deepseek-ai/dsh-client-runtime": "^0.0.1",
     "@deepseek-ai/dsh-client-ui-settings-plugins": "^0.0.1",
     "@deepseek-ai/dsh-client-ui-slots": "^0.0.1",
-    "@deepseek-ai/dsh-client-web-react": "^0.0.1",
     "@deepseek-ai/dsh-settings": "^0.0.1",
     "@deepseek-ai/dsh-tools": "^0.0.1",
     "react": "^18.2.0",


### PR DESCRIPTION
DSH rc.8 renamed `@deepseek-ai/dsh-client-web-react` to `@deepseek-ai/dsh-client-ui-renderer` and no longer exports `bindSnapshotSelector` from the package root. Additionally, the `settings.plugin.item` slot changed from `kind: 'list'` to `kind: 'keyed'`, requiring a `key` option on registration.

Without this fix, the plugin fails to load on rc.8 with:

```
client-modules: require("@deepseek-ai/dsh-client-web-react") missed the module table
```

## Changes

### `lib/client.js`
- Inlined `bindSnapshotSelector` using React 18's built-in `useSyncExternalStore` (with per-snapshot selector memoization via `useRef`), removing the `require('@deepseek-ai/dsh-client-web-react')` dependency entirely
- Added `key: SETTINGS_NS` to the `settings.plugin.item` slot registration (rc.8 changed this slot from `list` to `keyed`)

### `package.json`
- Removed `@deepseek-ai/dsh-client-web-react` from `dsh.client.inject`
- Removed `@deepseek-ai/dsh-client-web-react` from `peerDependencies`

## Testing

- `node --check lib/client.js` passes
- Loaded successfully in DSH rc.8 WebUI with all plugins working
