### PR TITLE
feat: user-configurable ego-browser CLI and Chrome launch args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 观察窗落地双画面管线：修复 CDP 协议根因，并加入可选 FFmpeg H.264/fMP4 后端。
 
 ### 新增 / 优化
+- **用户自定义启动参数**：设置卡新增 `ego-browser CLI 附加参数` 与 `Chrome 启动附加参数` 两个字段。前者追加到 `ego-browser nodejs` argv，下一次 `ego_*` 工具调用即生效；后者经 `EGO_LINUX_EXTRA_ARGS` 桥接到 vendored runtime 的 `launch()`，仅浏览器下次冷启动生效（浏览器是单例常驻——需 `ego-browser --stop` 或重启 DSH 才会重新启动）。两边都拉黑会破坏插件自管控制面的标志（`--status`/`--stop`/`--help`/`--user-data-dir`/`--remote-debugging-port`/`--headless`/`--proxy-server` 等）；`--proxy-server` 请走 `EGO_LINUX_PROXY`。`ego_doctor` 报告当前生效参数。
 - FFmpeg 改为显式按需安装：CDP 不再依赖或安装 `ffmpeg-static`。设置页优先检测自定义路径、系统 PATH 和托管缓存，兼容性检查完成前禁用 FFmpeg 选项，并提供固定版本、SHA-256 校验的一键下载。
 - 新增 `githubMirror`，用用户填写的 HTTPS 基址替换 `https://github.com`；Windows/Linux 固定 BtbN release tag，macOS 固定平台资产。下载进入 `~/.dsh/cache/ego-browser/ffmpeg/` 临时目录，校验、解压和能力探测全部成功后才原子发布。
 - 观察画面新增局部键盘输入代理：普通文本和粘贴走 `Input.insertText`，中文 IME 在 composition 完成后一次发送，控制键和快捷键走 `Input.dispatchKeyEvent`。只在点击观察画面后聚焦，不抢 DSH 自身输入。

--- a/docs/plans/2026-08-20-custom-cli-args-design.md
+++ b/docs/plans/2026-08-20-custom-cli-args-design.md
@@ -1,0 +1,84 @@
+# 自定义 CLI 启动参数 — 设计文档
+
+> 日期：2026-08-20｜分支：`feat/custom-cli-args`（基于 `origin/master` @ `f83f08d`）
+
+## 目标
+
+允许用户在 ego-browser 设置面板中追加两类启动参数：
+
+1. **ego-browser CLI 参数**（如 `--sdk-path <file>`）——拼到 `runEgoScript` 的 `argv` 末尾，每次 `ego_*` 工具调用即生效。
+2. **Chrome 浏览器启动参数**（如 `--proxy-server=...`、`--disable-features=...`）——经 env 桥接到 vendored runtime 的 `chrome.mjs::launch()`，拼到 Chrome `args` 末尾，仅在浏览器下次冷启动时生效（浏览器是单例常驻进程）。
+
+## 背景
+
+- `runEgoScript`（`lib/index.js:386`）当前固定 argv = `[node, egoBin, "nodejs"]`，无扩展点。
+- `chrome.mjs::launch()`（`runtime/ego-linux/src/chrome.mjs:375`）的 `args` 数组由 `LAUNCH_FLAGS` + profile/port/headless/proxy 组成，无用户扩展点；`EGO_LINUX_PROXY` 是已有的 env 桥接先例。
+- vendored runtime 已经被本地补丁（见 `runtime/PATCHES.md`），新增一处补丁符合既有做法。
+
+## 方案
+
+### 字段（`lib/config.js`）
+
+新增两个 `z.string()` 字段，默认 `""`：
+
+| 字段 | 作用 | 生效时机 |
+|---|---|---|
+| `egoCliArgs` | 追加到 `ego-browser nodejs` argv 末尾 | 下次 `ego_*` 工具调用 |
+| `chromeArgs` | 经 `EGO_LINUX_EXTRA_ARGS` 桥接到 Chrome 启动 args | 浏览器下次冷启动 |
+
+### 安全护栏
+
+**ego-CLI 侧拉黑**：会抢在 heredoc 前退出的子命令/帮助开关——
+`--status`、`--stop`、`--open`、`--spaces`、`--spaces-daemon`、`--prune-spaces`、`--import-chrome-profile`、`--install-desktop-entry`、`--help`、`-h`。
+（`--headless` 与 `--sdk-path` 允许，但 `--headless` 已由 `EGO_LINUX_HEADLESS` 管理，hint 提示用户优先走 env。）
+
+**Chrome 侧拉黑**：插件自管的控制面标志——
+`--user-data-dir`、`--remote-debugging-port`、`--remote-allow-origins`、`--headless`、`--no-startup-window`、`--proxy-server`、`--proxy-bypass-list`。
+（这些已由 `LAUNCH_FLAGS`/`EGO_LINUX_PROXY` 接管，用户重写会破坏 CDP 控制与 profile 隔离。`--proxy-server` 走 `EGO_LINUX_PROXY`。）
+
+切分采用 shell-like tokenize（单/双引号、反斜杠转义），与 `EGO_LINUX_PROXY` 等 env 值不切分的语义不同（那是一整个值，这里是一串参数）。
+
+### 改动清单
+
+| 文件 | 改动 |
+|---|---|
+| `lib/config.js` | `Config` 加 `egoCliArgs`/`chromeArgs` 字段；`resolveConfig` 带默认 `""`；新增导出 `tokenizeArgs`/`EGO_CLI_BLOCKED`/`CHROME_BLOCKED` 供测试 |
+| `lib/index.js` | `settingKeys` 加两项；`cfg` 加两个 live getter；`runEgoScript` argv 追加切分后的 `egoCliArgs`；`resolveEgoEnv` 设 `EGO_LINUX_EXTRA_ARGS`（仅当非空） |
+| `runtime/ego-linux/src/chrome.mjs` | `launch()` 的 `args` 末尾 spread `EGO_LINUX_EXTRA_ARGS` 切分结果（复用与 lib 侧一致的 tokenize；为避免在 runtime 里再引一份实现，把 tokenize 放在 runtime 内的小函数） |
+| `lib/client.js` | 设置表单加两个 `SettingsField` + i18n key + hint（Chrome 字段注明"下次启动浏览器生效"） |
+| `lib/index.js` `ego_doctor` | 报告当前生效的 `egoCliArgs`/`chromeArgs`（脱敏打印） |
+| `tests/config.test.mjs` | 加 tokenize / 拉黑用例 |
+| `tests/env.test.mjs` | 加 `EGO_LINUX_EXTRA_ARGS` 注入用例（覆盖默认值、空值、用户已设的尊重） |
+| `runtime/PATCHES.md` | 登记 chrome.mjs 新补丁 |
+| `CHANGELOG.md` | 加版本条目 |
+
+### UX 不对称（必须提示）
+
+- ego-CLI 参数：保存后下一次 `ego_*` 工具调用立即生效。
+- Chrome 参数：浏览器是单例常驻；需 `ego_doctor` 里给出 `ego-browser --stop` 指令或重启 DSH 后下次冷启动才生效。设置卡 hint 与 doctor 报告都说明这一点。
+
+### 数据流
+
+```
+设置卡 → bridge.source() → resolveConfig() → cfg.egoCliArgs / cfg.chromeArgs
+                                                      │
+              ┌───────────────────────────────────────┴────────────────────────────┐
+              ▼                                                                       ▼
+      runEgoScript argv 追加 egoCliArgs 切分                  resolveEgoEnv 设 EGO_LINUX_EXTRA_ARGS=chromeArgs
+              │                                                                       │
+              ▼                                                                       ▼
+      ego-browser nodejs <...egoCliArgs> heredoc              chrome.mjs launch() args 末尾 spread extra
+```
+
+### 不做（YAGNI）
+
+- 不做 per-call 参数（用户级配置，非 agent 级）。
+- 不做参数合法性深度校验（只拉黑互斥项；其余照原样透传，用户自负）。
+- 不动 `EGO_LINUX_PROXY`（已有专门通道）。
+- 不为 macOS app 版 ego-browser 适配（本插件 runtime 是 ego-linux；macOS app 走原生 CLI，其 argv 由 app 自管，与本字段无关）。
+
+## 验证
+
+- `pnpm test`：config/env 测试全绿（含新增用例）。
+- `pnpm run build`：node --check 全过。
+- 手动：设置卡填 `--disable-features=Translate` → 重启浏览器 → `ego_doctor` 报告 Chrome args 含该项。

--- a/lib/client.js
+++ b/lib/client.js
@@ -71,6 +71,8 @@ window.__ModuleLoader__.load({
 			chromePathHint: 'Path to the Chrome/Chromium/Edge binary. Empty = auto-detect.',
 			captureBackend: 'Capture backend', streamProfile: 'Quality profile', cdpFps: 'CDP FPS', cdpQuality: 'CDP JPEG quality', cdpMaxWidth: 'CDP max width', cdpBackstopIntervalMs: 'CDP recovery interval', ffmpegFps: 'FFmpeg FPS', ffmpegMaxWidth: 'FFmpeg max width', ffmpegBitrateKbps: 'FFmpeg bitrate', ffmpegEncoder: 'FFmpeg encoder', ffmpegPath: 'FFmpeg binary path', githubMirror: 'GitHub mirror', fpsUnit: 'fps', pxUnit: 'px', kbpsUnit: 'kbps', msUnit: 'ms',
 			ffmpegTitle: 'FFmpeg installation', ffmpegReady: 'Ready', ffmpegMissing: 'No compatible FFmpeg found', ffmpegChecking: 'Checking local FFmpeg…', ffmpegDownloading: 'Downloading FFmpeg…', ffmpegVerifying: 'Verifying download…', ffmpegExtracting: 'Extracting FFmpeg…', ffmpegProbing: 'Checking capture capabilities…', ffmpegUnsupported: 'FFmpeg capture is unsupported on this platform', ffmpegFailed: 'FFmpeg installation failed', ffmpegSource: 'Source', ffmpegVersion: 'Version', ffmpegInstall: 'Download FFmpeg', ffmpegReinstall: 'Reinstall', ffmpegRecheck: 'Recheck', ffmpegRequired: 'FFmpeg (install required)', githubMirrorHint: 'Replaces https://github.com for GitHub downloads, for example https://gh-proxy.com/github.com.',
+			egoCliArgs: 'Extra ego-browser CLI args', egoCliArgsHint: 'Appended to `ego-browser nodejs` argv. Takes effect on the next ego_* call. Blocked: --status/--stop/--open/--spaces/--help (they exit before the heredoc runs). Use --headless via the headless env instead.',
+			chromeArgs: 'Extra Chrome launch args', chromeArgsHint: 'Appended to the Chrome launch argv. Takes effect on the next browser cold start (the browser is a singleton — run `ego-browser --stop` or restart DSH to relaunch). Blocked: --user-data-dir/--remote-debugging-port/--remote-allow-origins/--headless/--no-startup-window/--proxy-server (use EGO_LINUX_PROXY for the proxy).',
 			save: 'Save', saving: 'Saving…', discard: 'Discard',
 			unsaved: 'Unsaved', readOnly: 'Settings are read-only in this deployment.',
 			namespaceUnavailable: 'The ego-browser configuration channel is unavailable. Please retry later.',
@@ -84,6 +86,8 @@ window.__ModuleLoader__.load({
 			chromePathHint: 'Chrome/Chromium/Edge 可执行文件路径。留空 = 自动检测。',
 			captureBackend: '捕获后端', streamProfile: '画质档位', cdpFps: 'CDP 帧率', cdpQuality: 'CDP JPEG 质量', cdpMaxWidth: 'CDP 最大宽度', cdpBackstopIntervalMs: 'CDP 恢复截图间隔', ffmpegFps: 'FFmpeg 帧率', ffmpegMaxWidth: 'FFmpeg 最大宽度', ffmpegBitrateKbps: 'FFmpeg 码率', ffmpegEncoder: 'FFmpeg 编码器', ffmpegPath: 'FFmpeg 路径', githubMirror: 'GitHub 镜像源', fpsUnit: 'fps', pxUnit: 'px', kbpsUnit: 'kbps', msUnit: 'ms',
 			ffmpegTitle: 'FFmpeg 安装', ffmpegReady: '已就绪', ffmpegMissing: '未找到兼容的 FFmpeg', ffmpegChecking: '正在检测本机 FFmpeg…', ffmpegDownloading: '正在下载 FFmpeg…', ffmpegVerifying: '正在校验下载文件…', ffmpegExtracting: '正在解压 FFmpeg…', ffmpegProbing: '正在检查捕获能力…', ffmpegUnsupported: '当前平台不支持 FFmpeg 捕获', ffmpegFailed: 'FFmpeg 安装失败', ffmpegSource: '来源', ffmpegVersion: '版本', ffmpegInstall: '下载 FFmpeg', ffmpegReinstall: '重新下载', ffmpegRecheck: '重新检测', ffmpegRequired: 'FFmpeg（需要安装）', githubMirrorHint: '替换 https://github.com，例如 https://gh-proxy.com/github.com。',
+			egoCliArgs: 'ego-browser CLI 附加参数', egoCliArgsHint: '追加到 `ego-browser nodejs` argv。下一次 ego_* 工具调用即生效。禁止：--status/--stop/--open/--spaces/--help（会在 heredoc 执行前退出）。--headless 请走 headless 环境变量。',
+			chromeArgs: 'Chrome 启动附加参数', chromeArgsHint: '追加到 Chrome 启动 argv。仅在浏览器下次冷启动时生效（浏览器是单例常驻——需运行 `ego-browser --stop` 或重启 DSH 才会重新启动）。禁止：--user-data-dir/--remote-debugging-port/--remote-allow-origins/--headless/--no-startup-window/--proxy-server（代理请用 EGO_LINUX_PROXY）。',
 			save: '保存', saving: '保存中…', discard: '放弃',
 			unsaved: '未保存', readOnly: '当前部署下设置只读。',
 			namespaceUnavailable: 'ego-browser 配置通道不可用，请稍后重试。',
@@ -97,7 +101,7 @@ window.__ModuleLoader__.load({
 				status: 'idle',        // 'idle' | 'loading' | 'ready'
 				available: false,      // true after a successful /ego/api/get
 				writable: false,       // false when settings service is absent
-				draft: { chromePath: '', captureBackend: 'auto', streamProfile: 'balanced', cdpFps: '20', cdpQuality: '55', cdpMaxWidth: '960', cdpBackstopIntervalMs: '3000', ffmpegFps: '20', ffmpegMaxWidth: '1280', ffmpegBitrateKbps: '4000', ffmpegEncoder: 'auto', ffmpegPath: '', githubMirror: '' },
+				draft: { chromePath: '', captureBackend: 'auto', streamProfile: 'balanced', cdpFps: '20', cdpQuality: '55', cdpMaxWidth: '960', cdpBackstopIntervalMs: '3000', ffmpegFps: '20', ffmpegMaxWidth: '1280', ffmpegBitrateKbps: '4000', ffmpegEncoder: 'auto', ffmpegPath: '', githubMirror: '', egoCliArgs: '', chromeArgs: '' },
 				ffmpegStatus: { state: 'checking', canDownload: false, canSelectFfmpeg: false },
 				dirty: false,
 				applyState: { kind: 'idle' }, // 'idle' | 'saving' | 'saved' | 'error'
@@ -143,12 +147,13 @@ window.__ModuleLoader__.load({
 					s.status = 'ready'
 					s.available = true
 					s.writable = true
-				s.draft = {
-					chromePath: config.chromePath || '',
-					captureBackend: config.captureBackend === 'ffmpeg' && !ffmpegStatus.canSelectFfmpeg ? 'cdp' : (config.captureBackend || 'auto'), streamProfile: config.streamProfile || 'balanced',
-					cdpFps: String(config.cdpFps ?? 20), cdpQuality: String(config.cdpQuality ?? 55), cdpMaxWidth: String(config.cdpMaxWidth ?? 960), cdpBackstopIntervalMs: String(config.cdpBackstopIntervalMs ?? 3000),
-					ffmpegFps: String(config.ffmpegFps ?? 20), ffmpegMaxWidth: String(config.ffmpegMaxWidth ?? 1280), ffmpegBitrateKbps: String(config.ffmpegBitrateKbps ?? 4000), ffmpegEncoder: config.ffmpegEncoder || 'auto', ffmpegPath: config.ffmpegPath || '', githubMirror: config.githubMirror || '',
-				}
+			s.draft = {
+				chromePath: config.chromePath || '',
+				captureBackend: config.captureBackend === 'ffmpeg' && !ffmpegStatus.canSelectFfmpeg ? 'cdp' : (config.captureBackend || 'auto'), streamProfile: config.streamProfile || 'balanced',
+				cdpFps: String(config.cdpFps ?? 20), cdpQuality: String(config.cdpQuality ?? 55), cdpMaxWidth: String(config.cdpMaxWidth ?? 960), cdpBackstopIntervalMs: String(config.cdpBackstopIntervalMs ?? 3000),
+				ffmpegFps: String(config.ffmpegFps ?? 20), ffmpegMaxWidth: String(config.ffmpegMaxWidth ?? 1280), ffmpegBitrateKbps: String(config.ffmpegBitrateKbps ?? 4000), ffmpegEncoder: config.ffmpegEncoder || 'auto', ffmpegPath: config.ffmpegPath || '', githubMirror: config.githubMirror || '',
+				egoCliArgs: config.egoCliArgs || '', chromeArgs: config.chromeArgs || '',
+			}
 				s.ffmpegStatus = ffmpegStatus
 				s.dirty = false
 				s.applyState = { kind: 'idle' }
@@ -264,12 +269,13 @@ window.__ModuleLoader__.load({
 				self.staged.clear()
 				self.store.update(function (s) {
 				s.applyState = { kind: 'saved' }
-				s.draft = {
-					chromePath: config.chromePath || '',
-					captureBackend: config.captureBackend === 'ffmpeg' && ffmpegStatus && !ffmpegStatus.canSelectFfmpeg ? 'cdp' : (config.captureBackend || 'auto'), streamProfile: config.streamProfile || 'balanced',
-					cdpFps: String(config.cdpFps ?? 20), cdpQuality: String(config.cdpQuality ?? 55), cdpMaxWidth: String(config.cdpMaxWidth ?? 960), cdpBackstopIntervalMs: String(config.cdpBackstopIntervalMs ?? 3000),
-					ffmpegFps: String(config.ffmpegFps ?? 20), ffmpegMaxWidth: String(config.ffmpegMaxWidth ?? 1280), ffmpegBitrateKbps: String(config.ffmpegBitrateKbps ?? 4000), ffmpegEncoder: config.ffmpegEncoder || 'auto', ffmpegPath: config.ffmpegPath || '', githubMirror: config.githubMirror || '',
-				}
+			s.draft = {
+				chromePath: config.chromePath || '',
+				captureBackend: config.captureBackend === 'ffmpeg' && ffmpegStatus && !ffmpegStatus.canSelectFfmpeg ? 'cdp' : (config.captureBackend || 'auto'), streamProfile: config.streamProfile || 'balanced',
+				cdpFps: String(config.cdpFps ?? 20), cdpQuality: String(config.cdpQuality ?? 55), cdpMaxWidth: String(config.cdpMaxWidth ?? 960), cdpBackstopIntervalMs: String(config.cdpBackstopIntervalMs ?? 3000),
+				ffmpegFps: String(config.ffmpegFps ?? 20), ffmpegMaxWidth: String(config.ffmpegMaxWidth ?? 1280), ffmpegBitrateKbps: String(config.ffmpegBitrateKbps ?? 4000), ffmpegEncoder: config.ffmpegEncoder || 'auto', ffmpegPath: config.ffmpegPath || '', githubMirror: config.githubMirror || '',
+				egoCliArgs: config.egoCliArgs || '', chromeArgs: config.chromeArgs || '',
+			}
 				if (ffmpegStatus) s.ffmpegStatus = ffmpegStatus
 				s.dirty = false
 				})
@@ -461,6 +467,8 @@ window.__ModuleLoader__.load({
 						h(SettingsField, { id: 'plugin-config-ego-browser-ffpath', label: t('ffmpegPath'), value: state.draft.ffmpegPath, placeholder: 'ffmpeg', disabled: busy, onEdit: function (v) { controller.edit('ffmpegPath', v) },
 						}),
 						h(SettingsField, { id: 'plugin-config-ego-browser-ghmirror', label: t('githubMirror'), value: state.draft.githubMirror, hint: t('githubMirrorHint'), placeholder: 'https://gh-proxy.com/github.com', disabled: busy, onEdit: function (v) { controller.edit('githubMirror', v) } }),
+						h(SettingsField, { id: 'plugin-config-ego-browser-ego-cli-args', label: t('egoCliArgs'), value: state.draft.egoCliArgs, hint: t('egoCliArgsHint'), placeholder: '--sdk-path /path/to/harness.js', disabled: busy, onEdit: function (v) { controller.edit('egoCliArgs', v) } }),
+						h(SettingsField, { id: 'plugin-config-ego-browser-chrome-args', label: t('chromeArgs'), value: state.draft.chromeArgs, hint: t('chromeArgsHint'), placeholder: '--disable-features=Translate --window-size=1024,768', disabled: busy, onEdit: function (v) { controller.edit('chromeArgs', v) } }),
 						h('div', { className: 'dsh-ego-card__ffmpeg' },
 							h('div', { className: 'dsh-ego-card__ffmpeg-title' }, t('ffmpegTitle')),
 							h('div', { className: 'dsh-ego-card__ffmpeg-status', role: 'status' }, t(ffmpegLabelKey) + (ffmpegStatus.reason ? ': ' + ffmpegStatus.reason : '') + (progressText ? ' ' + progressText : '')),

--- a/lib/config.js
+++ b/lib/config.js
@@ -23,12 +23,139 @@ export const Config = z.object({
   ffmpegEncoder: encoder.description("FFmpeg H.264 encoder."),
   ffmpegPath: z.string().description("Custom FFmpeg path. Empty = detect PATH or managed install."),
   githubMirror: z.string().description("HTTPS base replacing https://github.com for managed downloads."),
+  // User-defined extra CLI args. Shell-like tokenize; mutually-exclusive
+  // control flags are stripped (see EGO_CLI_BLOCKED / CHROME_BLOCKED below).
+  egoCliArgs: z.string().description("Extra args appended to `ego-browser nodejs` argv. Takes effect on the next ego_* call."),
+  chromeArgs: z.string().description("Extra args appended to the Chrome launch argv. Takes effect on the next browser cold start (the browser is a singleton)."),
   // Deprecated read-compatible keys. The settings UI only writes canonical keys.
   castFpsCap: z.number().min(0).max(60).step(1),
   screencastQuality: z.number().min(1).max(100).step(1),
   screencastMaxWidth: z.number().min(320).max(1920).step(40),
   backstopIntervalMs: z.number().min(200).max(10000).step(100),
 });
+
+// ── user-defined extra CLI args ─────────────────────────────────────────────
+/**
+ * Flags the user must NOT put in `egoCliArgs`: these ego-browser subcommands
+ * exit before the heredoc runs (--status/--stop/--help/...) or steal the
+ * browser window (--open), so appending them would break every ego_* tool.
+ * `--headless` is managed by EGO_LINUX_HEADLESS; `--sdk-path` is allowed.
+ */
+export const EGO_CLI_BLOCKED = new Set([
+  "--status",
+  "--stop",
+  "--open",
+  "--spaces",
+  "--spaces-daemon",
+  "--prune-spaces",
+  "--import-chrome-profile",
+  "--install-desktop-entry",
+  "--help",
+  "-h",
+]);
+
+/**
+ * Flags the user must NOT put in `chromeArgs`: these are managed by the
+ * launcher / EGO_LINUX_PROXY and overriding them would break CDP control,
+ * profile isolation, or the proxy bypass list. `--proxy-server` should go
+ * through EGO_LINUX_PROXY (which also sets the bypass list).
+ */
+export const CHROME_BLOCKED = new Set([
+  "--user-data-dir",
+  "--remote-debugging-port",
+  "--remote-allow-origins",
+  "--headless",
+  "--no-startup-window",
+  "--proxy-server",
+  "--proxy-bypass-list",
+]);
+
+/**
+ * Shell-like tokenizer for user-supplied arg strings. Handles single/double
+ * quotes and backslash escapes; bare whitespace separates tokens. Returns []
+ * for empty/whitespace-only input. Used for both `egoCliArgs` and `chromeArgs`
+ * (mirrored in runtime/ego-linux/src/chrome.mjs for the Chrome side, since the
+ * runtime must not import from lib/).
+ */
+export function tokenizeArgs(input) {
+  if (typeof input !== "string") return [];
+  const out = [];
+  let cur = "";
+  let i = 0;
+  let quote = null;
+  while (i < input.length) {
+    const c = input[i];
+    if (quote) {
+      if (c === "\\") {
+        const next = input[i + 1];
+        if (next !== undefined) {
+          cur += next;
+          i += 2;
+          continue;
+        }
+      } else if (c === quote) {
+        quote = null;
+        i += 1;
+        continue;
+      }
+      cur += c;
+      i += 1;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      quote = c;
+      i += 1;
+      continue;
+    }
+    if (c === "\\") {
+      const next = input[i + 1];
+      if (next !== undefined) {
+        cur += next;
+        i += 2;
+        continue;
+      }
+      i += 1;
+      continue;
+    }
+    if (c === " " || c === "\t" || c === "\n" || c === "\r") {
+      if (cur !== "") {
+        out.push(cur);
+        cur = "";
+      }
+      i += 1;
+      continue;
+    }
+    cur += c;
+    i += 1;
+  }
+  if (cur !== "") out.push(cur);
+  return out;
+}
+
+/**
+ * Split a raw arg string into tokens, dropping any token (and, for `--flag
+ * value` pairs, its value) that appears in `blocked`. A "blocked" token with a
+ * `=` attached (e.g. `--headless=new`) is also dropped. Returns the surviving
+ * tokens. Exposed for tests and for the runtime to mirror.
+ */
+export function filterArgs(raw, blocked) {
+  const tokens = tokenizeArgs(raw);
+  const kept = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const tok = tokens[i];
+    const key = tok.includes("=") ? tok.slice(0, tok.indexOf("=")) : tok;
+    if (blocked.has(key)) {
+      // Drop a bare `--flag value` pair when the flag is blocklisted and the
+      // next token does not itself look like a flag (i.e. it is the value).
+      if (!tok.includes("=") && i + 1 < tokens.length && !tokens[i + 1].startsWith("-")) {
+        i += 1;
+      }
+      continue;
+    }
+    kept.push(tok);
+  }
+  return kept;
+}
 
 const finiteIn = (value, min, max) => typeof value === "number" && Number.isFinite(value) && value >= min && value <= max;
 const oneOf = (value, values, fallback) => values.includes(value) ? value : fallback;
@@ -57,5 +184,9 @@ export function resolveConfig(config = {}) {
     ffmpegEncoder: oneOf(config.ffmpegEncoder, ["auto", "software", "h264_mf", "h264_nvenc", "h264_qsv", "h264_amf", "h264_videotoolbox", "h264_vaapi"], "auto"),
     ffmpegPath: typeof config.ffmpegPath === "string" ? config.ffmpegPath : "",
     githubMirror: typeof config.githubMirror === "string" ? config.githubMirror : "",
+    // User-defined extra args: stored raw (string), filtered at the call site
+    // so a saved value is not silently mutated by a later blocklist change.
+    egoCliArgs: typeof config.egoCliArgs === "string" ? config.egoCliArgs : "",
+    chromeArgs: typeof config.chromeArgs === "string" ? config.chromeArgs : "",
   };
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,6 +43,7 @@ import { EGO_HELP_INDEX } from "./help.js";
 import { HUMAN_CHECK_PROBE } from "./captcha.js";
 import { Config as ConfigSchema } from "./config.js";
 import { resolveConfig } from "./config.js";
+import { EGO_CLI_BLOCKED, CHROME_BLOCKED, filterArgs } from "./config.js";
 import { installEgoBrowserSettings } from "./settings.js";
 import { registerEgoBrowserGateway } from "./gateway.js";
 import { getSharedFfmpegInstallationManager } from "./ffmpeg-installation.js";
@@ -303,6 +304,15 @@ export function resolveEgoEnv(cfg, { platform = process.platform, baseEnv = proc
   if (env.EGO_LINUX_HEADLESS === undefined && isHeadlessDetected(platform, env)) {
     env.EGO_LINUX_HEADLESS = "1";
   }
+  // User-configured extra Chrome args (settings field `chromeArgs`). Bridge to
+  // EGO_LINUX_EXTRA_ARGS, which the vendored runtime's launch() spreads into
+  // the Chrome argv. A user-set env var wins (escape hatch for power users).
+  // The value is the RAW string; the runtime tokenizes + filters it so the
+  // same blocklist applies on both sides of the boundary.
+  const configChromeArgs = cfg?.chromeArgs;
+  if (env.EGO_LINUX_EXTRA_ARGS === undefined && typeof configChromeArgs === "string" && configChromeArgs.trim() !== "") {
+    env.EGO_LINUX_EXTRA_ARGS = configChromeArgs;
+  }
   return env;
 }
 function describeStderr(stderr) {
@@ -386,9 +396,14 @@ function parseSentinel(stdout) {
 async function runEgoScript(subprocess, script, exec, cfg, graceOverrideMs) {
   let handle;
   try {
+    // User-configured extra ego-browser CLI args (settings field `egoCliArgs`).
+    // Filtered against EGO_CLI_BLOCKED so a saved value with a mutually-
+    // exclusive subcommand (--status/--stop/--help/...) cannot break every
+    // ego_* call by exiting before the heredoc runs.
+    const extraCliArgs = filterArgs(cfg.egoCliArgs ?? "", EGO_CLI_BLOCKED);
     handle = subprocess.spawn({
       // Run through the node interpreter so the vendored CLI needs no +x bit.
-      argv: [process.execPath, cfg.egoBin, "nodejs"],
+      argv: [process.execPath, cfg.egoBin, "nodejs", ...extraCliArgs],
       cwd: process.cwd(),
       env: resolveEgoEnv(cfg),
       stdio: {
@@ -553,8 +568,8 @@ export function apply(ctx, config = {}) {
   const settingKeys = [
     "chromePath", "captureBackend", "streamProfile", "cdpFps", "cdpQuality",
     "cdpMaxWidth", "cdpBackstopIntervalMs", "ffmpegFps", "ffmpegMaxWidth", "ffmpegBitrateKbps",
-    "ffmpegEncoder", "ffmpegPath", "githubMirror", "castFpsCap", "screencastQuality",
-    "screencastMaxWidth", "backstopIntervalMs",
+    "ffmpegEncoder", "ffmpegPath", "githubMirror", "egoCliArgs", "chromeArgs",
+    "castFpsCap", "screencastQuality", "screencastMaxWidth", "backstopIntervalMs",
   ];
   const entry = Object.fromEntries(settingKeys.filter((key) => config[key] !== undefined).map((key) => [key, config[key]]));
   const bridge = installEgoBrowserSettings(ctx, entry);
@@ -590,6 +605,10 @@ export function apply(ctx, config = {}) {
     get ffmpegEncoder() { return resolveConfig(bridge.source()).ffmpegEncoder; },
     get ffmpegPath() { return resolveConfig(bridge.source()).ffmpegPath; },
     get githubMirror() { return resolveConfig(bridge.source()).githubMirror; },
+    // User-defined extra CLI args (see lib/config.js). Live getters so GUI
+    // edits take effect on the next spawn / next browser cold start.
+    get egoCliArgs() { return resolveConfig(bridge.source()).egoCliArgs; },
+    get chromeArgs() { return resolveConfig(bridge.source()).chromeArgs; },
   };
   const reg = (tool) => {
     const dispose = ctx.tools.register(tool);
@@ -1855,6 +1874,14 @@ function registerHelpAndDoctor(ctx, cfg, reg) {
         } else {
           lines.push(`browser binary: ${chrome || "(none found — set chromePath in settings, or set EGO_LINUX_CHROME, or install Chrome/Edge/Brave)"}`);
         }
+        // User-configured extra CLI args (effective after filtering). ego-CLI
+        // args take effect on the next ego_* call; Chrome args only on the next
+        // browser cold start (the browser is a singleton — run `ego-browser
+        // --stop` or restart DSH to relaunch).
+        const cliArgs = filterArgs(cfg.egoCliArgs ?? "", EGO_CLI_BLOCKED);
+        const chrArgs = filterArgs(cfg.chromeArgs ?? "", CHROME_BLOCKED);
+        lines.push(`egoCliArgs (effective): ${cliArgs.length ? cliArgs.join(" ") : "(none)"}`);
+        lines.push(`chromeArgs (effective, next cold start): ${chrArgs.length ? chrArgs.join(" ") : "(none)"}`);
         // state dir + runtime state
         const isWin = process.platform === "win32";
         const e = process.env;

--- a/runtime/PATCHES.md
+++ b/runtime/PATCHES.md
@@ -13,6 +13,7 @@
 | `runtime/ego-linux/src/cursor.mjs` | 光标覆盖层默认名 `Claude` → `DeepSeek`（4 处：默认值 + 注释） | 品牌统一，`dacbd47` |
 | `runtime/ego-linux/src/chrome.mjs` | `resolveBinary()`: `candidate.includes("/")` → `isAbsolute(candidate)`；`which()`: Windows 用 `where` 替代 `which` | Windows 支持：POSIX `includes("/")` 不识别 `C:\\` 路径，`which` 在 Windows 不存在 |
 | `runtime/ego-linux/src/chrome.mjs` | `LAUNCH_FLAGS` 加 `--no-startup-window`；`launch()` 删除 `"about:blank"` 位置参数 | 消除单次 `ego_space_open` 开两个窗口：原位置参数在默认 browser context 开残留 tab，space tab 走独立 context 又开一个窗口，Chrome 把不同 context 隔离到不同窗口 → 用户看到两窗。`useSpace+ensureRealTab` 路由下不再需要 launch 残留 tab |
+| `runtime/ego-linux/src/chrome.mjs` | `launch()` 的 `args` 末尾 spread `filterChromeArgs(process.env.EGO_LINUX_EXTRA_ARGS ?? "")`；新增模块内 `CHROME_BLOCKED` 集合 + `tokenizeArgs`/`filterChromeArgs` 函数（与 `lib/config.js` 镜像，runtime 不 import lib/） | 用户自定义 Chrome 启动参数（设置字段 `chromeArgs`）：插件 `resolveEgoEnv` 把 `chromeArgs` 桥接到 `EGO_LINUX_EXTRA_ARGS`，runtime 切分 + 拉黑控制面标志（`--user-data-dir`/`--remote-debugging-port`/`--headless`/`--proxy-server` 等）后 spread 进 Chrome argv。仅浏览器下次冷启动生效 |
 | `runtime/ego-linux/src/paths.mjs` | Windows 用 `%LOCALAPPDATA%\\ego-lite-linux` 作为 DATA_DIR / STATE_DIR；`CHROME_CONFIG_CANDIDATES` 加 Windows 路径 | Windows 支持：XDG 变量在 Windows 不存在；`ego_doctor` 已预期 `%LOCALAPPDATA%` |
 | （其余 runtime 文件）| 与 vendoring 时一致 | 无后续本地改动 |
 
@@ -21,4 +22,5 @@
   非后续本地改动；如需调整走它。
 - **同步提醒**：`lib/index.js` 与 `bin/ego-cast-worker.mjs` 各有一份 humanCheck 探针（逻辑相似）——
   若改探针特征，两处都要同步。
+- **同步提醒**：`lib/config.js` 的 `tokenizeArgs`/`filterArgs`/`CHROME_BLOCKED` 与 `runtime/ego-linux/src/chrome.mjs` 的 `tokenizeArgs`/`filterChromeArgs`/`CHROME_BLOCKED` 是镜像副本（runtime 不 import lib/）——改一处必须同步另一处。
 - 若要跟进 ego-lite 上游，重点 diff 上表的 cursor.mjs；其余文件可直接与上游对齐。

--- a/runtime/ego-linux/src/chrome.mjs
+++ b/runtime/ego-linux/src/chrome.mjs
@@ -70,6 +70,67 @@ const LAUNCH_FLAGS = [
   "--no-startup-window",
 ];
 
+// ── user-defined extra Chrome args (mirrors lib/config.js) ──────────────────
+// The runtime must not import from lib/, so the blocklist + tokenizer are
+// duplicated here. Keep in sync with lib/config.js (EGO_CLI_BLOCKED is not
+// needed here — only the Chrome side runs in this process). See
+// runtime/PATCHES.md and docs/plans/2026-08-20-custom-cli-args-design.md.
+const CHROME_BLOCKED = new Set([
+  "--user-data-dir",
+  "--remote-debugging-port",
+  "--remote-allow-origins",
+  "--headless",
+  "--no-startup-window",
+  "--proxy-server",
+  "--proxy-bypass-list",
+]);
+
+function tokenizeArgs(input) {
+  if (typeof input !== "string") return [];
+  const out = [];
+  let cur = "";
+  let i = 0;
+  let quote = null;
+  while (i < input.length) {
+    const c = input[i];
+    if (quote) {
+      if (c === "\\") {
+        const next = input[i + 1];
+        if (next !== undefined) { cur += next; i += 2; continue; }
+      } else if (c === quote) { quote = null; i += 1; continue; }
+      cur += c; i += 1; continue;
+    }
+    if (c === '"' || c === "'") { quote = c; i += 1; continue; }
+    if (c === "\\") {
+      const next = input[i + 1];
+      if (next !== undefined) { cur += next; i += 2; continue; }
+      i += 1; continue;
+    }
+    if (c === " " || c === "\t" || c === "\n" || c === "\r") {
+      if (cur !== "") { out.push(cur); cur = ""; }
+      i += 1; continue;
+    }
+    cur += c; i += 1;
+  }
+  if (cur !== "") out.push(cur);
+  return out;
+}
+
+function filterChromeArgs(raw) {
+  const tokens = tokenizeArgs(raw);
+  const kept = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const tok = tokens[i];
+    const key = tok.includes("=") ? tok.slice(0, tok.indexOf("=")) : tok;
+    if (CHROME_BLOCKED.has(key)) {
+      if (!tok.includes("=") && i + 1 < tokens.length && !tokens[i + 1].startsWith("-")) i += 1;
+      continue;
+    }
+    kept.push(tok);
+  }
+  return kept;
+}
+
 /**
  * Is this directory *provably* absent?
  *
@@ -399,6 +460,11 @@ async function launch({ headless }) {
           "--proxy-bypass-list=<-loopback>;127.0.0.1;localhost;[::1];172.16.0.0/12;10.0.0.0/8;*.local",
         ]
       : []),
+    // User-configured extra Chrome args, bridged from the plugin's `chromeArgs`
+    // settings field via resolveEgoEnv(). Filtered against CHROME_BLOCKED
+    // (mirrored here — the runtime must not import from lib/) so a saved value
+    // cannot break CDP control / profile isolation / proxy bypass.
+    ...filterChromeArgs(process.env.EGO_LINUX_EXTRA_ARGS ?? ""),
   ];
   const child = spawn(binary, args, {
     detached: true,

--- a/tests/config.test.mjs
+++ b/tests/config.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { resolveConfig } from "../lib/config.js";
+import { resolveConfig, tokenizeArgs, filterArgs, EGO_CLI_BLOCKED, CHROME_BLOCKED } from "../lib/config.js";
 
 describe("dual capture config", () => {
   it("returns canonical defaults", () => {
@@ -8,6 +8,7 @@ describe("dual capture config", () => {
       chromePath: "", captureBackend: "auto", streamProfile: "balanced",
       cdpFps: 20, cdpQuality: 55, cdpMaxWidth: 960, cdpBackstopIntervalMs: 3000,
       ffmpegFps: 20, ffmpegMaxWidth: 1280, ffmpegBitrateKbps: 4000, ffmpegEncoder: "auto", ffmpegPath: "", githubMirror: "",
+      egoCliArgs: "", chromeArgs: "",
     });
   });
 
@@ -16,6 +17,7 @@ describe("dual capture config", () => {
       chromePath: "", captureBackend: "auto", streamProfile: "balanced",
       cdpFps: 30, cdpQuality: 70, cdpMaxWidth: 1200, cdpBackstopIntervalMs: 5000,
       ffmpegFps: 20, ffmpegMaxWidth: 1280, ffmpegBitrateKbps: 4000, ffmpegEncoder: "auto", ffmpegPath: "", githubMirror: "",
+      egoCliArgs: "", chromeArgs: "",
     });
     assert.equal(resolveConfig({ cdpFps: 15, castFpsCap: 30 }).cdpFps, 15);
   });
@@ -35,5 +37,95 @@ describe("dual capture config", () => {
     assert.equal(resolveConfig({ streamProfile: "high", ffmpegBitrateKbps: 6000 }).ffmpegBitrateKbps, 6000);
     assert.equal(resolveConfig({ streamProfile: "high", ffmpegFps: 12 }).ffmpegFps, 12);
     assert.equal(resolveConfig({ backstopIntervalMs: 200 }).cdpBackstopIntervalMs, 1000);
+  });
+});
+
+// ── user-defined extra CLI args (egoCliArgs / chromeArgs) ───────────────────
+
+describe("user-defined extra CLI args", () => {
+  it("resolveConfig defaults egoCliArgs / chromeArgs to empty strings", () => {
+    const c = resolveConfig({});
+    assert.equal(c.egoCliArgs, "");
+    assert.equal(c.chromeArgs, "");
+  });
+
+  it("resolveConfig passes through non-string as empty string", () => {
+    const c = resolveConfig({ egoCliArgs: 123, chromeArgs: null });
+    assert.equal(c.egoCliArgs, "");
+    assert.equal(c.chromeArgs, "");
+  });
+
+  it("resolveConfig preserves the raw string (filtering happens at call site)", () => {
+    const c = resolveConfig({ egoCliArgs: "--status --sdk-path /x", chromeArgs: "--headless --proxy-server=bad" });
+    // Stored raw; blocklist is applied by filterArgs at spawn time so a saved
+    // value is not silently mutated by a later blocklist change.
+    assert.equal(c.egoCliArgs, "--status --sdk-path /x");
+    assert.equal(c.chromeArgs, "--headless --proxy-server=bad");
+  });
+});
+
+describe("tokenizeArgs", () => {
+  it("returns [] for empty / whitespace-only input", () => {
+    assert.deepEqual(tokenizeArgs(""), []);
+    assert.deepEqual(tokenizeArgs("   "), []);
+    assert.deepEqual(tokenizeArgs("\t\n"), []);
+    assert.deepEqual(tokenizeArgs(undefined), []);
+    assert.deepEqual(tokenizeArgs(null), []);
+  });
+
+  it("splits on bare whitespace", () => {
+    assert.deepEqual(tokenizeArgs("--a --b c"), ["--a", "--b", "c"]);
+  });
+
+  it("preserves quoted tokens as single args", () => {
+    assert.deepEqual(tokenizeArgs('"--a value" --b'), ["--a value", "--b"]);
+    assert.deepEqual(tokenizeArgs("'path with spaces' --b"), ["path with spaces", "--b"]);
+  });
+
+  it("handles backslash escapes", () => {
+    assert.deepEqual(tokenizeArgs('a\\ b c'), ["a b", "c"]);
+    assert.deepEqual(tokenizeArgs('"a\\"b"'), ['a"b']);
+  });
+
+  it("keeps = attached to its flag", () => {
+    assert.deepEqual(tokenizeArgs("--proxy-server=http://host:7890 --x"), ["--proxy-server=http://host:7890", "--x"]);
+  });
+});
+
+describe("filterArgs", () => {
+  it("drops blocked bare flags and their value when value is non-flag", () => {
+    // --status is blocked and would exit before the heredoc; drop it.
+    const out = filterArgs("--status --sdk-path /x", EGO_CLI_BLOCKED);
+    assert.deepEqual(out, ["--sdk-path", "/x"]);
+  });
+
+  it("drops blocked =-form flags without consuming a value", () => {
+    const out = filterArgs("--headless=new --keep-me", CHROME_BLOCKED);
+    assert.deepEqual(out, ["--keep-me"]);
+  });
+
+  it("does not drop a value that happens to start with - after a blocked bare flag", () => {
+    // --headless is blocked; next token starts with -, so it is NOT its value.
+    const out = filterArgs("--headless --other", CHROME_BLOCKED);
+    assert.deepEqual(out, ["--other"]);
+  });
+
+  it("drops --proxy-server and its value (use EGO_LINUX_PROXY instead)", () => {
+    const out = filterArgs("--proxy-server=http://x --keep", CHROME_BLOCKED);
+    assert.deepEqual(out, ["--keep"]);
+  });
+
+  it("drops a bare --proxy-server plus its separate value", () => {
+    const out = filterArgs("--proxy-server http://x --keep", CHROME_BLOCKED);
+    assert.deepEqual(out, ["--keep"]);
+  });
+
+  it("preserves allowed args verbatim (order + quoting collapsed by tokenizer)", () => {
+    const out = filterArgs("--disable-features=Translate --window-size=800,600", CHROME_BLOCKED);
+    assert.deepEqual(out, ["--disable-features=Translate", "--window-size=800,600"]);
+  });
+
+  it("returns [] when all args are blocked", () => {
+    assert.deepEqual(filterArgs("--status --stop --help", EGO_CLI_BLOCKED), []);
   });
 });

--- a/tests/env.test.mjs
+++ b/tests/env.test.mjs
@@ -262,6 +262,84 @@ describe("resolveEgoEnv (headless detection)", () => {
   });
 });
 
+// ─── resolveEgoEnv: chromeArgs → EGO_LINUX_EXTRA_ARGS bridge ────────────────
+
+describe("resolveEgoEnv (chromeArgs bridge)", () => {
+  it("bridges cfg.chromeArgs to EGO_LINUX_EXTRA_ARGS (raw string)", () => {
+    const env = resolveEgoEnv(
+      { chromeArgs: "--disable-features=Translate --window-size=800,600" },
+      {
+        platform: "linux",
+        baseEnv: { HOME: "/root" },
+      },
+    );
+    assert.equal(env.EGO_LINUX_EXTRA_ARGS, "--disable-features=Translate --window-size=800,600");
+  });
+
+  it("does not set EGO_LINUX_EXTRA_ARGS when chromeArgs is empty", () => {
+    const env = resolveEgoEnv(
+      { chromeArgs: "" },
+      { platform: "linux", baseEnv: { HOME: "/root" } },
+    );
+    assert.equal(env.EGO_LINUX_EXTRA_ARGS, undefined);
+  });
+
+  it("does not set EGO_LINUX_EXTRA_ARGS when chromeArgs is whitespace-only", () => {
+    const env = resolveEgoEnv(
+      { chromeArgs: "   " },
+      { platform: "linux", baseEnv: { HOME: "/root" } },
+    );
+    assert.equal(env.EGO_LINUX_EXTRA_ARGS, undefined);
+  });
+
+  it("never overrides a user-set EGO_LINUX_EXTRA_ARGS (escape hatch)", () => {
+    const userSet = "--user-set-flag";
+    const env = resolveEgoEnv(
+      { chromeArgs: "--from-settings" },
+      {
+        platform: "linux",
+        baseEnv: { EGO_LINUX_EXTRA_ARGS: userSet, HOME: "/root" },
+      },
+    );
+    assert.equal(env.EGO_LINUX_EXTRA_ARGS, userSet);
+  });
+});
+
+// ─── runtime/ego-linux/src/chrome.mjs (EGO_LINUX_EXTRA_ARGS spread) ─────────
+// The runtime mirrors tokenizeArgs + CHROME_BLOCKED (it must not import from
+// lib/). Verify the launch() args array spreads EGO_LINUX_EXTRA_ARGS and that
+// blocked flags are stripped before reaching the Chrome process.
+
+describe("runtime chrome.mjs (EGO_LINUX_EXTRA_ARGS spread)", () => {
+  const readSrc = () =>
+    import("node:fs/promises").then((fs) =>
+      fs.readFile(
+        new URL("../runtime/ego-linux/src/chrome.mjs", import.meta.url),
+        "utf8",
+      ),
+    );
+
+  it("launch() spreads filterChromeArgs(process.env.EGO_LINUX_EXTRA_ARGS) into args", async () => {
+    const src = await readSrc();
+    assert.ok(
+      src.includes("...filterChromeArgs(process.env.EGO_LINUX_EXTRA_ARGS ?? \"\")"),
+      "chrome.mjs launch() should spread filterChromeArgs(EGO_LINUX_EXTRA_ARGS) into the args array",
+    );
+  });
+
+  it("defines a CHROME_BLOCKED set mirroring lib/config.js", async () => {
+    const src = await readSrc();
+    // Spot-check the critical control-plane flags are blocklisted in the
+    // runtime copy too (not just in lib/config.js).
+    for (const flag of ["--user-data-dir", "--remote-debugging-port", "--headless", "--proxy-server"]) {
+      assert.ok(
+        src.includes(`"${flag}"`),
+        `chrome.mjs CHROME_BLOCKED should include ${flag}`,
+      );
+    }
+  });
+});
+
 // ─── findChromeBinary ──────────────────────────────────────────────────────
 
 describe("findChromeBinary", () => {


### PR DESCRIPTION
# 自定义 CLI 启动参数 — 设计文档

> 日期：2026-08-20｜分支：`feat/custom-cli-args`（基于 `origin/master` @ `f83f08d`）

## 目标

允许用户在 ego-browser 设置面板中追加两类启动参数：

1. **ego-browser CLI 参数**（如 `--sdk-path <file>`）——拼到 `runEgoScript` 的 `argv` 末尾，每次 `ego_*` 工具调用即生效。
2. **Chrome 浏览器启动参数**（如 `--proxy-server=...`、`--disable-features=...`）——经 env 桥接到 vendored runtime 的 `chrome.mjs::launch()`，拼到 Chrome `args` 末尾，仅在浏览器下次冷启动时生效（浏览器是单例常驻进程）。

## 背景

- `runEgoScript`（`lib/index.js:386`）当前固定 argv = `[node, egoBin, "nodejs"]`，无扩展点。
- `chrome.mjs::launch()`（`runtime/ego-linux/src/chrome.mjs:375`）的 `args` 数组由 `LAUNCH_FLAGS` + profile/port/headless/proxy 组成，无用户扩展点；`EGO_LINUX_PROXY` 是已有的 env 桥接先例。
- vendored runtime 已经被本地补丁（见 `runtime/PATCHES.md`），新增一处补丁符合既有做法。

## 方案

### 字段（`lib/config.js`）

新增两个 `z.string()` 字段，默认 `""`：

| 字段 | 作用 | 生效时机 |
|---|---|---|
| `egoCliArgs` | 追加到 `ego-browser nodejs` argv 末尾 | 下次 `ego_*` 工具调用 |
| `chromeArgs` | 经 `EGO_LINUX_EXTRA_ARGS` 桥接到 Chrome 启动 args | 浏览器下次冷启动 |

### 安全护栏

**ego-CLI 侧拉黑**：会抢在 heredoc 前退出的子命令/帮助开关——
`--status`、`--stop`、`--open`、`--spaces`、`--spaces-daemon`、`--prune-spaces`、`--import-chrome-profile`、`--install-desktop-entry`、`--help`、`-h`。
（`--headless` 与 `--sdk-path` 允许，但 `--headless` 已由 `EGO_LINUX_HEADLESS` 管理，hint 提示用户优先走 env。）

**Chrome 侧拉黑**：插件自管的控制面标志——
`--user-data-dir`、`--remote-debugging-port`、`--remote-allow-origins`、`--headless`、`--no-startup-window`、`--proxy-server`、`--proxy-bypass-list`。
（这些已由 `LAUNCH_FLAGS`/`EGO_LINUX_PROXY` 接管，用户重写会破坏 CDP 控制与 profile 隔离。`--proxy-server` 走 `EGO_LINUX_PROXY`。）

切分采用 shell-like tokenize（单/双引号、反斜杠转义），与 `EGO_LINUX_PROXY` 等 env 值不切分的语义不同（那是一整个值，这里是一串参数）。

### 改动清单

| 文件 | 改动 |
|---|---|
| `lib/config.js` | `Config` 加 `egoCliArgs`/`chromeArgs` 字段；`resolveConfig` 带默认 `""`；新增导出 `tokenizeArgs`/`EGO_CLI_BLOCKED`/`CHROME_BLOCKED` 供测试 |
| `lib/index.js` | `settingKeys` 加两项；`cfg` 加两个 live getter；`runEgoScript` argv 追加切分后的 `egoCliArgs`；`resolveEgoEnv` 设 `EGO_LINUX_EXTRA_ARGS`（仅当非空） |
| `runtime/ego-linux/src/chrome.mjs` | `launch()` 的 `args` 末尾 spread `EGO_LINUX_EXTRA_ARGS` 切分结果（复用与 lib 侧一致的 tokenize；为避免在 runtime 里再引一份实现，把 tokenize 放在 runtime 内的小函数） |
| `lib/client.js` | 设置表单加两个 `SettingsField` + i18n key + hint（Chrome 字段注明"下次启动浏览器生效"） |
| `lib/index.js` `ego_doctor` | 报告当前生效的 `egoCliArgs`/`chromeArgs`（脱敏打印） |
| `tests/config.test.mjs` | 加 tokenize / 拉黑用例 |
| `tests/env.test.mjs` | 加 `EGO_LINUX_EXTRA_ARGS` 注入用例（覆盖默认值、空值、用户已设的尊重） |
| `runtime/PATCHES.md` | 登记 chrome.mjs 新补丁 |
| `CHANGELOG.md` | 加版本条目 |

### UX 不对称（必须提示）

- ego-CLI 参数：保存后下一次 `ego_*` 工具调用立即生效。
- Chrome 参数：浏览器是单例常驻；需 `ego_doctor` 里给出 `ego-browser --stop` 指令或重启 DSH 后下次冷启动才生效。设置卡 hint 与 doctor 报告都说明这一点。

### 数据流

```
设置卡 → bridge.source() → resolveConfig() → cfg.egoCliArgs / cfg.chromeArgs
                                                      │
              ┌───────────────────────────────────────┴────────────────────────────┐
              ▼                                                                       ▼
      runEgoScript argv 追加 egoCliArgs 切分                  resolveEgoEnv 设 EGO_LINUX_EXTRA_ARGS=chromeArgs
              │                                                                       │
              ▼                                                                       ▼
      ego-browser nodejs <...egoCliArgs> heredoc              chrome.mjs launch() args 末尾 spread extra
```

### 不做（YAGNI）

- 不做 per-call 参数（用户级配置，非 agent 级）。
- 不做参数合法性深度校验（只拉黑互斥项；其余照原样透传，用户自负）。
- 不动 `EGO_LINUX_PROXY`（已有专门通道）。
- 不为 macOS app 版 ego-browser 适配（本插件 runtime 是 ego-linux；macOS app 走原生 CLI，其 argv 由 app 自管，与本字段无关）。

## 验证

- `pnpm test`：config/env 测试全绿（含新增用例）。
- `pnpm run build`：node --check 全过。
- 手动：设置卡填 `--disable-features=Translate` → 重启浏览器 → `ego_doctor` 报告 Chrome args 含该项。
