### PR TITLE
feat: Windows stability test — local fixes (rc.8 dual-compat + gateway fix)

### DIFF
--- a/bin/ego-cast-worker.mjs
+++ b/bin/ego-cast-worker.mjs
@@ -296,6 +296,46 @@ async function main() {
         }
       }
       if (req.method === "POST" && url.pathname === "/api/close") { const { targetId } = await readJson(req); if (!active || !targetId) return sendJson(res, 400, { ok: false, error: "targetId required" }); await active.cdp.call("Target.closeTarget", { targetId }); return sendJson(res, 200, { ok: true }); }
+      if (req.method === "POST" && url.pathname === "/api/nav") {
+        // Forward a navigation/intent command to the real agent page. Body:
+        //   { targetId, action, url? }
+        // action: reload | goBack | goForward | stop | navigate | newTab
+        const body = await readJson(req);
+        if (!active) return sendJson(res, 400, { ok: false, error: "no live browser" });
+        const { targetId, action, url: navUrl } = body;
+        if (!action || typeof action !== "string") return sendJson(res, 400, { ok: false, error: "action required" });
+        try {
+          if (action === "newTab") {
+            const tt = await active.cdp.call("Target.getTargets");
+            const infos = (tt?.result?.targetInfos || []).filter((t) => t.type === "page");
+            if (!navUrl) {
+              const blank = infos.find((t) => t.url === "about:blank");
+              if (blank) return sendJson(res, 200, { ok: true, targetId: blank.targetId, created: false });
+            }
+            const nt = await active.cdp.call("Target.createTarget", { url: navUrl || "about:blank" });
+            return sendJson(res, 200, { ok: true, targetId: nt?.result?.targetId, created: !!nt?.result?.targetId });
+          }
+          if (!targetId) return sendJson(res, 400, { ok: false, error: "targetId required" });
+          let result;
+          if (action === "reload") result = await active.sessions.call(targetId, "Page.reload", { ignoreCache: false });
+          else if (action === "goBack") {
+            // Some Chrome builds no longer expose Page.goBack; fall back to the
+            // page's own history API.
+            try { result = await active.sessions.call(targetId, "Page.goBack", {}); }
+            catch (e) { result = await active.sessions.call(targetId, "Runtime.evaluate", { expression: "history.back()" }); }
+          }
+          else if (action === "goForward") {
+            try { result = await active.sessions.call(targetId, "Page.goForward", {}); }
+            catch (e) { result = await active.sessions.call(targetId, "Runtime.evaluate", { expression: "history.forward()" }); }
+          }
+          else if (action === "stop") result = await active.sessions.call(targetId, "Page.stopLoading", {});
+          else if (action === "navigate") result = await active.sessions.call(targetId, "Page.navigate", { url: navUrl });
+          else return sendJson(res, 400, { ok: false, error: `unknown action: ${action}` });
+          return sendJson(res, 200, { ok: true, result });
+        } catch (error) {
+          return sendJson(res, 500, { ok: false, error: String(error?.message || error) });
+        }
+      }
       if (req.method === "POST" && url.pathname === "/api/flush") { if (!active) return sendJson(res, 409, { ok: false, error: "no live browser" }); await active.cdp.call("Storage.flushCookies").catch(() => {}); return sendJson(res, 200, { ok: true }); }
       if (req.method === "GET" && url.pathname === "/api/stream") {
         res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive", "x-accel-buffering": "no" });

--- a/bin/ffmpeg-probe.mjs
+++ b/bin/ffmpeg-probe.mjs
@@ -1,4 +1,5 @@
 import { spawn as nodeSpawn } from "node:child_process";
+import { existsSync } from "node:fs";
 
 export function runFfmpegProbe(path, argv, { spawn = nodeSpawn, timeoutMs = 3000 } = {}) {
   return new Promise((resolve) => {
@@ -26,6 +27,11 @@ export async function probeFfmpeg(path, { platform = process.platform, env = pro
     if (!devices.ok || !/avfoundation/i.test(devices.output)) throw codedError("ffmpeg-capture-input-unavailable", "FFmpeg does not support avfoundation capture");
   } else if (platform === "linux") {
     if (env.XDG_SESSION_TYPE === "wayland" || env.WAYLAND_DISPLAY) throw codedError("ffmpeg-platform-unsupported", "Wayland capture is not supported");
+    // WSLg (Windows Subsystem for Linux GUI) exposes an Xwayland display that
+    // x11grab cannot read (XGetImage returns black). /mnt/wslg is the reliable
+    // marker for a WSLg session — without this, `auto` would pick ffmpeg and
+    // the watch panel would show a black screen.
+    if (existsSync("/mnt/wslg")) throw codedError("ffmpeg-platform-unsupported", "WSLg (Xwayland) capture is not supported");
     const devices = await runFfmpegProbe(path, ["-hide_banner", "-devices"], { spawn });
     if (!devices.ok || !/x11grab/i.test(devices.output)) throw codedError("ffmpeg-capture-input-unavailable", "FFmpeg does not support x11grab capture");
   }

--- a/lib/cast-server.js
+++ b/lib/cast-server.js
@@ -29,6 +29,8 @@ export const EGO_WATCH_STOP_ROUTE = '/api/ego/watch/stop';
 export const EGO_WATCH_STATUS_ROUTE = '/api/ego/watch/status';
 export const EGO_VIDEO_ROUTE = '/api/ego/video';
 export const EGO_VIDEO_STATUS_ROUTE = '/api/ego/video/status';
+export const EGO_NAV_ROUTE = '/api/ego/nav';
+export const EGO_FRAMEABLE_ROUTE = '/api/ego/frameable';
 
 // ── tool-call signal (auto-open sidebar Tab) ─────────────────────────────
 // Module-level counter bumped by markEgoToolCall() from the tool execute
@@ -492,6 +494,82 @@ export function initCastServer(ctx, cfg, bridge, ffmpegManager) {
       return sendJson(res, 200, result || { ok: false, state: 'idle', reason: 'worker not ready' });
     },
   });
+  // POST /api/ego/nav — forward a navigation/intent command (reload / goBack /
+  // goForward / stop / navigate / newTab) to the real agent page via the worker.
+  const disposeNav = server.register({
+    kind: 'exact',
+    path: EGO_NAV_ROUTE,
+    handler: async (req, res) => {
+      const port = await ensureWorker();
+      if (port === null) return sendJson(res, 400, { ok: false, error: 'no live agent browser' });
+      const body = await readJsonBody(req).catch(() => ({}));
+      const result = await proxyPost(port, '/api/nav', body);
+      if (!result) return sendJson(res, 500, { ok: false, error: 'worker nav failed' });
+      return sendJson(res, result.status, result.body);
+    },
+  });
+  // GET /api/ego/frameable?url=... — decide whether a target http(s) URL may be
+  // embedded in a side-panel <iframe>. Cross-origin servers send their
+  // X-Frame-Options / CSP (frame-ancestors) response headers to ANY requester,
+  // so a server-side HEAD/GET is enough to enforce the same gate a browser's
+  // iframe embed would. Used by EgoBrowserTab to prefer a REAL embedded render
+  // (high-fps / clickable) over the CDP screencast view when the site allows it.
+  const disposeFrameable = server.register({
+    kind: 'exact',
+    path: EGO_FRAMEABLE_ROUTE,
+    handler: async (req, res) => {
+      const u = new URL(req.url ?? '/', 'http://127.0.0.1');
+      const target = u.searchParams.get('url');
+      if (!target || !/^(https?):\/\//i.test(target)) {
+        return sendJson(res, 400, { ok: false, frameable: false, error: 'valid url (http/https) required' });
+      }
+      const parsed = new URL(target);
+      // Never proxy file: / about: / unsupported schemes — those can't embed anyway.
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return sendJson(res, 200, { ok: true, frameable: false, reason: 'unsupported-scheme' });
+      }
+      try {
+        const ctl = new AbortController();
+        const timer = setTimeout(() => ctl.abort(), 8000);
+        let res2;
+        try {
+          res2 = await fetch(target, {
+            method: 'HEAD',
+            redirect: 'follow',
+            signal: ctl.signal,
+            headers: { 'User-Agent': 'Mozilla/5.0' },
+          });
+        } catch (headErr) {
+          // Some servers reject HEAD; fall back to a limited GET that aborts
+          // early (don't download the body).
+          ctl.abort();
+          const ctl2 = new AbortController();
+          setTimeout(() => ctl2.abort(), 8000);
+          res2 = await fetch(target, { method: 'GET', redirect: 'follow', signal: ctl2.signal, headers: { 'Range': 'bytes=0-0', 'User-Agent': 'Mozilla/5.0' } });
+          await res2.body?.cancel?.().catch?.(() => {});
+        } finally {
+          clearTimeout(timer);
+        }
+        const h = res2.headers;
+        const xfo = h.get('x-frame-options');
+        const csp = h.get('content-security-policy') || '';
+        // CSP frame-ancestors forbids embedding (allow nothing but 'self'/none).
+        const faMatch = csp.match(/frame-ancestors[^;]*/i);
+        const fa = faMatch ? faMatch[0].trim() : null;
+        let frameable = true;
+        let reason = null;
+        if (xfo && /deny|sameorigin/i.test(xfo)) { frameable = false; reason = `X-Frame-Options: ${xfo}`; }
+        else if (fa && !/^\s*(\*|'none'|'self')/.test(fa.replace(/frame-ancestors/i, '').trim()) && /\s/.test(fa) && !/\/\*/.test(fa)) {
+          // A concrete (non-wildcard, non-self-only) frame-ancestors with a host
+          // list that doesn't include the panel origin blocks embedding.
+          frameable = false; reason = `CSP: ${fa}`;
+        }
+        return sendJson(res, 200, { ok: true, frameable, reason, status: res2.status, xfo, csp: fa });
+      } catch (err) {
+        return sendJson(res, 200, { ok: true, frameable: true, reason: 'probe-error-treat-as-frameable', error: String(err?.message || err) });
+      }
+    },
+  });
   const disposeVideo = server.register({
     kind: 'exact', path: EGO_VIDEO_ROUTE,
     handler: async (req, res) => {
@@ -511,6 +589,8 @@ export function initCastServer(ctx, cfg, bridge, ffmpegManager) {
     for (const dispose of watchRoutes) try { dispose() } catch {}
     try { disposeWatchStatus() } catch {}
     try { disposeVideoStatus() } catch {}
+    try { disposeNav() } catch {}
+    try { disposeFrameable() } catch {}
     try { disposeVideo() } catch {}
   });
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -61,9 +61,107 @@ window.__ModuleLoader__.load({
 		// from the profile's node_modules (declared as peerDependencies).
 		var React = require('react')
 		var runtimeClient = require('@deepseek-ai/dsh-client-runtime/client')
-		var webReact = require('@deepseek-ai/dsh-client-web-react')
 		var createSnapshotStore = runtimeClient.createSnapshotStore
-		var bindSnapshotSelector = webReact.bindSnapshotSelector
+		// rc.8 removed @deepseek-ai/dsh-client-web-react; the ui-renderer bundle
+		// exports only { apply, inject }, so the selector hook primitive has no
+		// require-able source there either. Prefer the rc.7 web-react path, fall
+		// back to an inlined React use-sync-external-store with-selector
+		// implementation (MIT, Facebook) over react's native useSyncExternalStore.
+		var bindSnapshotSelector = null
+		try {
+			var webReact = require('@deepseek-ai/dsh-client-web-react')
+			bindSnapshotSelector = webReact.bindSnapshotSelector
+		} catch (e) {
+				var useSyncExternalStoreWithSelector = (function () {
+			
+				var useSyncExternalStore = React.useSyncExternalStore
+				var useRef = React.useRef
+				var useEffect = React.useEffect
+				var useMemo = React.useMemo
+				var useDebugValue = React.useDebugValue
+				return function (subscribe, getSnapshot, getServerSnapshot, selector, isEqual) {
+					var instRef = useRef(null)
+					var inst
+					if (instRef.current === null) {
+						inst = { hasValue: false, value: null }
+						instRef.current = inst
+					} else {
+						inst = instRef.current
+					}
+					var getSelection = useMemo(function () {
+						var hasMemo = false
+						var memoizedSnapshot
+						var memoizedSelection
+						var memoizedSnapshotFromServer
+						var memoizedSelectionFromServer
+						function memoizedSelector(nextSnapshot) {
+							if (!hasMemo) {
+								hasMemo = true
+								memoizedSnapshot = nextSnapshot
+								var nextSelection = selector(nextSnapshot)
+								if (isEqual !== undefined && inst.hasValue) {
+									var currentSelection = inst.value
+									if (isEqual(currentSelection, nextSelection)) {
+										memoizedSelection = currentSelection
+										return currentSelection
+									}
+								}
+								memoizedSelection = nextSelection
+								return nextSelection
+							}
+							var prevSnapshot = memoizedSnapshot
+							if (prevSnapshot === nextSnapshot) return memoizedSelection
+							var nextSelection = selector(nextSnapshot)
+							if (isEqual !== undefined && isEqual(memoizedSelection, nextSelection)) return memoizedSelection
+							memoizedSnapshot = nextSnapshot
+							memoizedSelection = nextSelection
+							return nextSelection
+						}
+						function memoizedSnapshotFromServerSelector(nextServerSnapshot) {
+							if (!hasMemo) {
+								hasMemo = true
+								memoizedSnapshotFromServer = nextServerSnapshot
+								var nextServerSelection = selector(nextServerSnapshot)
+								if (isEqual !== undefined && inst.hasValue) {
+									var currentSelection = inst.value
+									if (isEqual(currentSelection, nextServerSelection)) {
+										memoizedSelectionFromServer = currentSelection
+										return currentSelection
+									}
+								}
+								memoizedSelectionFromServer = nextServerSelection
+								return nextServerSelection
+							}
+							var prevServerSnapshot = memoizedSnapshotFromServer
+							if (prevServerSnapshot === nextServerSnapshot) return memoizedSelectionFromServer
+							var nextServerSelection = selector(nextServerSnapshot)
+							if (isEqual !== undefined && isEqual(memoizedSelectionFromServer, nextServerSelection)) {
+								return memoizedSelectionFromServer
+							}
+							memoizedSnapshotFromServer = nextServerSnapshot
+							memoizedSelectionFromServer = nextServerSelection
+							return nextServerSelection
+						}
+						return [function () { return memoizedSelector(getSnapshot()) }, getServerSnapshot === undefined ? undefined : function () { return memoizedSnapshotFromServerSelector(getServerSnapshot()) }]
+					}, [getSnapshot, getServerSnapshot, selector, isEqual])
+					var value = useSyncExternalStore(subscribe, getSelection[0], getSelection[1])
+					useEffect(function () {
+						inst.hasValue = true
+						inst.value = value
+					}, [value])
+					useDebugValue(value)
+					return value
+				}
+				})()
+			bindSnapshotSelector = function (w) {
+				var subscribe = function (fn) { return w.subscribe(fn) }
+				var getSnapshot = function () { return w.getSnapshot() }
+				return function useSelector(sel, eq) {
+					return useSyncExternalStoreWithSelector(subscribe, getSnapshot, undefined, sel, eq)
+				}
+			}
+		}
+
 
 		const inject = ['slots', 'locale', 'connection']
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -4,6 +4,29 @@ window.__ModuleLoader__.load({
 		var module = { exports: {} };
 		module.exports;
 
+		// Floating-vs-sidebar mutual exclusion — declared at the top-most scope
+		// so EVERY function in this bundle (apply(), mountFloatingWatch(),
+		// mountSidebarTab(), ...) can see it, regardless of nested block/
+		// function scoping. Declared here (not inside apply()) because a
+		// function declaration nested inside a block is block-scoped in strict
+		// mode and a sibling apply()-body function cannot resolve it.
+		var egoFloatingDisposer = null
+		function teardownFloating() {
+			if (egoFloatingDisposer) {
+				try { egoFloatingDisposer() } catch (e) {}
+				egoFloatingDisposer = null
+			}
+			// Belt-and-suspenders: even if the disposer above was lost (e.g. a
+			// stale FAB appended outside our mount), drop the known DOM node so
+			// the ball never lingers once a sidebar tab is up.
+			try {
+				var staleFab = document.getElementById('dsh-ego-fab')
+				if (staleFab) staleFab.remove()
+				var stalePanel = document.getElementById('dsh-ego-panel')
+				if (stalePanel) stalePanel.remove()
+			} catch (e) {}
+		}
+
 		// #region ego-browser client: realtime browser watch-bubble
 		//
 		// A floating "watch" bubble (bottom-right) plus an expandable overlay
@@ -893,6 +916,23 @@ window.__ModuleLoader__.load({
 		const ICON_CLOSE = `<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"><path d="M6 6l12 12M18 6L6 18"/></svg>`;
 		// 6-dot drag grip for the panel's title bar.
 		const ICON_GRIP = `<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><circle cx="8" cy="6" r="1.8"/><circle cx="16" cy="6" r="1.8"/><circle cx="8" cy="12" r="1.8"/><circle cx="16" cy="12" r="1.8"/><circle cx="8" cy="18" r="1.8"/><circle cx="16" cy="18" r="1.8"/></svg>`;
+		// Earth + cursor icon for the sidebar "ego 浏览器" tab. Returns a React
+		// element sized to `size` (better-sidebar calls descriptor.icon(14)).
+		const browserTabIcon = function (size) {
+			var s = size || 16
+			return React.createElement('svg', {
+				width: s, height: s, viewBox: '0 0 24 24',
+				fill: 'none', stroke: 'currentColor', strokeWidth: 1.6,
+				strokeLinecap: 'round', strokeLinejoin: 'round',
+				style: { display: 'block' },
+			},
+				React.createElement('circle', { cx: 11, cy: 11, r: 8 }),
+				React.createElement('path', { d: 'M11 3c2 2 3 4.5 3 8s-1 6-3 8' }),
+				React.createElement('path', { d: 'M11 3C9 5 8 7.5 8 11s1 6 3 8' }),
+				React.createElement('path', { d: 'M3 11h16' }),
+				React.createElement('path', { d: 'M16.5 14.5l3.6 3.6-1.8 1.8-1.2-2.6z', fill: 'currentColor', stroke: 'none' })
+			);
+		}
 
 		function apply(ctx) {
 			// ── Settings card: register locale + slot (always runs) ──────
@@ -924,15 +964,14 @@ window.__ModuleLoader__.load({
 				var dispose = ctx.on('connection/reset', refresh)
 				return function () { dispose() }
 			}, 'ego-browser: settings invalidation')
-			ctx.slots.inject('settings.plugin.item', function* () {
-				yield ctx.slots.register({
+			ctx.slots.inject('settings.plugin.item', () => ctx.slots.register({
 					name: 'settings.plugin.item',
 					id: 'ego-browser',
+					key: SETTINGS_NS,
 					order: 60,
 					locale: SETTINGS_NS,
 					inject: function () { return { controller: controller, useSnapshot: useSnapshot } },
-				}, EgoBrowserCard)
-			})
+				}, EgoBrowserCard))
 
 		// ── Watch panel: sidebar tab if available, floating fallback otherwise ──
 		// Opportunistic consumption via ctx.get() (NOT ctx.betterSidebar — that
@@ -944,7 +983,28 @@ window.__ModuleLoader__.load({
 		if (ctx.get('betterSidebar') !== undefined) {
 			ctx.effect(() => mountSidebarTab(ctx), 'ego-browser sidebar tab')
 		} else {
-			ctx.effect(() => mountFloatingWatch(ctx), 'ego-browser watch panel')
+			// Fallback: floating FAB, but the betterSidebar service may register
+			// AFTER ego-browser (host load-order race). Re-probe continuously;
+			// when it becomes available, drop the FAB and promote to the sidebar
+			// tab so the side panel shows ego as a native tab (and the floating
+			// ball disappears). The poll keeps running while the FAB is mounted
+			// so a late-registering service still promotes.
+			var fabDisposer = null
+			ctx.effect(() => {
+				fabDisposer = mountFloatingWatch(ctx)
+				// Share the disposer so a later sidebar mount can always remove
+				// this floating overlay (mutual exclusion with the sidebar Tab).
+				if (fabDisposer) egoFloatingDisposer = fabDisposer
+			}, 'ego-browser watch panel')
+			var probe = window.setInterval(function () {
+				if (ctx.get('betterSidebar') !== undefined) {
+					window.clearInterval(probe)
+					teardownFloating() // removes FAB+panel; resets egoFloatingDisposer
+					ctx.effect(() => mountSidebarTab(ctx), 'ego-browser sidebar tab (late)')
+				}
+			}, 500)
+			// Clean the timer if the plugin is disposed.
+			try { ctx.on('dispose', function () { window.clearInterval(probe) }) } catch (e) {}
 		}
 	}
 
@@ -1969,6 +2029,7 @@ window.__ModuleLoader__.load({
 		// sidebar's tab content area instead of a fixed-position overlay.
 		var INPUT_ROUTE = '/api/ego/input'
 		var FLUSH_ROUTE = '/api/ego/flush'
+		var NAV_ROUTE = '/api/ego/nav'
 		var FRAME_FOLLOW_MIN_MS = 350
 
 		// ── Tab CSS (scoped under .dsh-ego-side-root) ──────────────────────────
@@ -2094,7 +2155,7 @@ window.__ModuleLoader__.load({
   max-height: 50vh; object-fit: contain;
   border: 1px solid rgba(128,128,128,.2); background: #000;
   user-select: none; -webkit-user-select: none; touch-action: none;
-  will-change: transform; cursor: grab;
+  will-change: transform; cursor: default;
 }
 .dsh-ego-side-livetitle { font-size: 12px; font-weight: 600; }
 .dsh-ego-side-liveurl { font-size: 10.5px; opacity: .55; word-break: break-all; }
@@ -2129,6 +2190,82 @@ window.__ModuleLoader__.load({
 .dsh-ego-side-hurl { font-size: 9.5px; opacity: .5; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .dsh-ego-side-hactive { color: #30d158; font-size: 9.5px; }
 .dsh-ego-side-hnone { padding: 16px 8px; text-align: center; font-size: 10.5px; opacity: .4; }
+/* ---- nav toolbar (old frontend UI, ported) ---- */
+.dsh-ego-side-toolbar {
+  display: flex; align-items: center; gap: 4px; padding: 5px 10px;
+  border-bottom: 1px solid rgba(128,128,128,.12); flex-shrink: 0;
+}
+.dsh-ego-side-navbtn {
+  flex: none; width: 24px; height: 24px; border-radius: 6px; border: none;
+  background: transparent; color: inherit; cursor: pointer; opacity: .72;
+  display: inline-flex; align-items: center; justify-content: center; padding: 0;
+  font-size: 13px; line-height: 1; transition: background .15s ease, opacity .15s ease;
+}
+.dsh-ego-side-navbtn:hover:not(:disabled) { background: rgba(128,128,128,.2); opacity: 1; }
+.dsh-ego-side-navbtn:disabled { opacity: .28; cursor: default; }
+.dsh-ego-side-navbtn svg { width: 14px; height: 14px; }
+.dsh-ego-side-navbtn.takeover { color: #0a84ff; font-size: 11px; min-width: auto; }
+.dsh-ego-side-navbtn.takeover.on {
+  background: rgba(10,132,255,.85); color: #fff; opacity: 1;
+  box-shadow: 0 0 0 2px rgba(10,132,255,.35);
+}
+.dsh-ego-side-navbtn.go-open { width: auto; padding: 0 8px; font-size: 11px; color: #7ec3ff; }
+.dsh-ego-side-navurl {
+  flex: 1; min-width: 0; height: 22px; padding: 0 8px; border-radius: 6px;
+  border: 1px solid rgba(128,128,128,.25); background: rgba(128,128,128,.08);
+  color: inherit; font-size: 11px; box-sizing: border-box; outline: none;
+}
+.dsh-ego-side-navurl:focus { border-color: rgba(10,132,255,.6); }
+.dsh-ego-side-navurl::placeholder { opacity: .45; }
+/* ---- header title stack (title + url) ---- */
+.dsh-ego-side-htext { margin-left: 5px; flex: 1; min-width: 0; overflow: hidden; }
+.dsh-ego-side-htitle { display: block; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dsh-ego-side-hurl { display: block; font-size: 10px; font-weight: 400; opacity: .55; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.dsh-ego-side-hurl.dsh-ego-side-hint { color: #75c2ff; opacity: 1; }
+/* ---- login badge ---- */
+.dsh-ego-side-loginbadge {
+  flex: none; font-size: 10px; padding: 3px 8px; border-radius: 999px; cursor: pointer;
+  border: 1px solid rgba(10,132,255,.35); background: rgba(10,132,255,.12); color: inherit;
+  white-space: nowrap; transition: background .15s ease, opacity .15s ease; line-height: 1.3;
+}
+.dsh-ego-side-loginbadge:hover:not(:disabled) { background: rgba(10,132,255,.22); }
+.dsh-ego-side-loginbadge:disabled { opacity: .55; cursor: default; }
+.dsh-ego-side-loginbadge.busy { opacity: .6; }
+.dsh-ego-side-loginbadge.saved { border-color: rgba(48,209,88,.4); background: rgba(48,209,88,.15); }
+.dsh-ego-side-loginbadge.noconn { border-color: rgba(255,159,10,.4); background: rgba(255,159,10,.13); }
+/* ---- takeover mode ---- */
+.dsh-ego-side-takeover-note {
+  padding: 4px 10px; font-size: 10.5px; color: #0a84ff; flex-shrink: 0;
+  border-bottom: 1px solid rgba(10,132,255,.25); background: rgba(10,132,255,.08);
+}
+.dsh-ego-side-root.dsh-ego-side-takeover-on .dsh-ego-side-livewrap,
+.dsh-ego-side-root.dsh-ego-side-takeover-on > .dsh-ego-side-body {
+  box-shadow: inset 0 0 0 2px rgba(10,132,255,.65);
+  border-radius: 8px;
+}
+.dsh-ego-ripple {
+  position: absolute; width: 34px; height: 34px; border-radius: 50%;
+  background: radial-gradient(circle, rgba(10,132,255,.55) 0%, rgba(10,132,255,0) 70%);
+  transform: translate(-50%, -50%) scale(.2); pointer-events: none; z-index: 5;
+  animation: dsh-ego-ripple-anim .6s cubic-bezier(.16,.8,.3,1) forwards;
+}
+@keyframes dsh-ego-ripple-anim {
+  to { transform: translate(-50%, -50%) scale(3.2); opacity: 0; }
+}
+.dsh-ego-side-livewrap { position: relative; width: 100%; }
+/* Dual-track embed: real iframe render replaces the screencast view */
+.dsh-ego-side-embed { width: 100%; height: 100%; min-height: 260px; border: 0; flex: 1; background: #fff; border-radius: 8px; }
+.dsh-ego-side-embeddbar { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--dsw-alias-label-secondary, #aab); padding: 6px 8px; background: rgba(14,110,255,.12); border-radius: 8px; }
+.dsh-ego-hotspot {
+  position: absolute; width: 14px; height: 18px; pointer-events: none; z-index: 6;
+  transform: translate(0, 0); opacity: 0; transition: opacity .12s ease;
+  line-height: 0;
+}
+.dsh-ego-hotspot-dot {
+  display: block; line-height: 0;
+  filter: drop-shadow(0 1px 2px rgba(0,0,0,.4));
+}
+.dsh-ego-hotspot-dot svg { display: block; }
 `
 
 		// ── LivePreviewController ───────────────────────────────────────────────
@@ -2179,6 +2316,7 @@ window.__ModuleLoader__.load({
 			this.liveImg = null
 			this.liveImgTargetId = null
 			this.historyOpen = false
+			this.takeoverMode = false
 			this._zoomHint = null
 			this._zoomHintTimer = null
 			this._pointerState = null
@@ -2199,6 +2337,7 @@ window.__ModuleLoader__.load({
 				captchaKind: null,
 				historyOpen: false,
 				zoomHint: null,
+				takeover: false,
 				backend: 'cdp', streamState: 'idle', streamMessage: '', streamGeneration: 0, streamMime: 'video/mp4; codecs="avc1.42E01E"',
 			}
 		}
@@ -2261,6 +2400,7 @@ window.__ModuleLoader__.load({
 				s.streamMessage = self.streamMessage
 				s.streamGeneration = self.streamGeneration
 				s.streamMime = self.streamMime
+				s.takeover = self.takeoverMode === true
 			})
 			this._syncWatch(currentTargetId)
 		}
@@ -2584,6 +2724,79 @@ window.__ModuleLoader__.load({
 			this.pinned = null
 			this._recompute()
 		}
+		LivePreviewController.prototype.address = function (url) {
+			if (!url) return
+			// Normalize: prepend http:// when no scheme so bare hosts ("bilibili.com")
+			// navigate in the ego browser instead of opening a system window.
+			var target = url.trim()
+			if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(target) && !/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(target)) {
+				target = 'http://' + target
+			}
+			// No live page yet → open a new tab and navigate it there.
+			if (!this.liveImgTargetId) { this.newTab(target); return }
+			this.nav(this.liveImgTargetId, 'navigate', target)
+		}
+		LivePreviewController.prototype.nav = function (targetId, action, url) {
+			if (!targetId) return
+			void fetch(NAV_ROUTE, {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ targetId: targetId, action: action, url: url || undefined }),
+			}).then(function (r) { return r.json() }).then(function () {
+				// handled by the timeout refresh below
+			}).catch(function () {})
+			var self = this
+			window.setTimeout(function () { self.refresh() }, 250)
+		}
+		LivePreviewController.prototype.newTab = function (url) {
+			void fetch(NAV_ROUTE, {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ targetId: null, action: 'newTab', url: url || undefined }),
+			}).catch(function () {})
+			var self = this
+			window.setTimeout(function () { self.refresh() }, 350)
+		}
+		LivePreviewController.prototype.setTakeover = function (on) {
+			this.takeoverMode = !!on
+			this._recompute && this._recompute()
+		}
+		LivePreviewController.prototype.toggleTakeover = function () {
+			this.setTakeover(this.takeoverMode ? false : true)
+		}
+		LivePreviewController.prototype.updateHotspot = function (e) {
+			var img = this.liveImg
+			if (!img) return
+			var host = img.parentElement
+			if (!host) return
+			var h = host.querySelector('.dsh-ego-hotspot')
+			if (!h) return
+			var rect = host.getBoundingClientRect()
+			h.style.opacity = '1'
+			h.style.left = (e.clientX - rect.left) + 'px'
+			h.style.top = (e.clientY - rect.top) + 'px'
+		}
+		LivePreviewController.prototype.hideHotspot = function () {
+			var img = this.liveImg
+			if (!img) return
+			var host = img.parentElement
+			if (!host) return
+			var h = host.querySelector('.dsh-ego-hotspot')
+			if (h) h.style.opacity = '0'
+		}
+		LivePreviewController.prototype.spawnRipple = function (clientX, clientY) {
+			var img = this.liveImg
+			if (!img) return
+			var host = img.parentElement
+			if (!host) return
+			var rect = host.getBoundingClientRect()
+			var r = document.createElement('div')
+			r.className = 'dsh-ego-ripple'
+			r.style.left = (clientX - rect.left) + 'px'
+			r.style.top = (clientY - rect.top) + 'px'
+			host.appendChild(r)
+			window.setTimeout(function () { if (r && r.parentNode) r.parentNode.removeChild(r) }, 1200)
+		}
 		LivePreviewController.prototype.selectTab = function (targetId) {
 			if (this.selectedTabId === targetId) {
 				this.selectedTabId = null
@@ -2686,10 +2899,12 @@ window.__ModuleLoader__.load({
 			var p = this.browserXY(e)
 			if (p) {
 				this._pointerState.lastDragPos = p
+				this.spawnRipple(e.clientX, e.clientY)
 				this.sendInput(this._pointerState.targetId, 'mousePressed', { x: p.x, y: p.y, button: 'left', buttons: 1, clickCount: 1 })
 			}
 		}
 		LivePreviewController.prototype.handlePointerMove = function (e) {
+			this.updateHotspot(e)
 			if (!this._pointerState) {
 				var p = this.browserXY(e)
 				if (p) this.sendInput(this.liveImgTargetId, 'mouseMoved', { x: p.x, y: p.y, buttons: 0 })
@@ -2712,7 +2927,7 @@ window.__ModuleLoader__.load({
 		LivePreviewController.prototype.handlePointerUp = function (e) {
 			if (!this._pointerState) return
 			if (this._pointerState.viewPanning) {
-				if (e.currentTarget) e.currentTarget.style.cursor = 'grab'
+				if (e.currentTarget) e.currentTarget.style.cursor = 'default'
 			}
 			if (this._pointerState.browserDrag) {
 				if (this._pointerState.lastDragPos && this._pointerState.targetId) {
@@ -2722,7 +2937,8 @@ window.__ModuleLoader__.load({
 					})
 				}
 			}
-			if (e.currentTarget) e.currentTarget.style.cursor = 'grab'
+			if (e.currentTarget) e.currentTarget.style.cursor = 'default'
+			this.hideHotspot()
 			this._pointerState = null
 		}
 		LivePreviewController.prototype.handleDoubleClick = function (e) {
@@ -2766,7 +2982,46 @@ window.__ModuleLoader__.load({
 				controller.setVisible(visible)
 			}, [visible, controller])
 
-			// Attach the live <img> to the controller whenever the target changes
+			// Route an external link INTO the ego browser with an iframe-first
+			// dual-track strategy (old frontend feature, ported):
+			//   • If the target site allows <iframe> embedding (probed at runtime),
+			//     show the REAL rendered page in the side panel (high-fps, native
+			//     click/scroll — a genuine Chromium embed, not a screencast still).
+			//   • The ego real-Chrome viewport still navigates to the same URL, so
+			//     the agent can keep operating it (ego_* tools) — the two tracks
+			//     show the SAME page, side by side, toggleable via embedMode.
+			//   • Sites that refuse framing (X-Frame-Options / CSP frame-ancestors)
+			//     fall back to the screencast live view as before.
+			var routedUrl = props && props.tab && props.tab.path
+			var embedState = React.useState(null) // null=idle 'probe' → 'iframe' | 'agent'
+			var embedMode = embedState[0]
+			var setEmbedMode = embedState[1]
+			var embedUrlState = React.useState(null)
+			var embedUrl = embedUrlState[0]
+			var setEmbedUrl = embedUrlState[1]
+			// Last routed URL already handled inside the current embed/probe cycle
+			// — prevents re-probing the same URL on every re-render.
+			var handledUrlRef = React.useRef(null)
+			React.useEffect(function () {
+				if (!routedUrl || !/^https?:\/\//i.test(routedUrl)) return
+				if (handledUrlRef.current === routedUrl) return
+				handledUrlRef.current = routedUrl
+				setEmbedMode('probe')
+				setEmbedUrl(routedUrl)
+				// Always navigate the real agent Chrome there (keeps AGENT operable).
+				controller.address(routedUrl)
+				// Probe whether the site can be <iframe>-embedded.
+				var cx = null
+				try { cx = new AbortController() ; var to = setTimeout(function () { if (cx) cx.abort() }, 6000) } catch (e) {}
+				try {
+					fetch('/api/ego/frameable?url=' + encodeURIComponent(routedUrl), { signal: cx ? cx.signal : undefined, cache: 'no-store' })
+						.then(function (r) { return r.json() })
+						.then(function (j) { if (to) clearTimeout(to); setEmbedMode((j && j.ok && j.frameable) ? 'iframe' : 'agent') })
+						.catch(function () { if (to) clearTimeout(to); setEmbedMode('agent'); })
+				} catch (e) { setEmbedMode('agent') }
+			}, [routedUrl, controller])
+
+			// Attach the live <img> / <video> to the controller whenever the target changes
 			React.useEffect(function () {
 				if (imgRef.current && state.currentTargetId != null) {
 					controller.setLiveImg(imgRef.current, state.currentTargetId)
@@ -2785,11 +3040,18 @@ window.__ModuleLoader__.load({
 
 			var h = React.createElement
 
-			// Header
+			// Header (dual-line: page title + url, old frontend UI)
 			var header = h('div', { className: 'dsh-ego-side-head' },
 				h('span', { className: 'dsh-ego-side-title' },
 					h('span', { dangerouslySetInnerHTML: { __html: ICON_GLOBE } }),
-					h('span', { style: { marginLeft: '5px' } }, state.busy ? 'Agent 浏览器 · 实时' : 'Agent 浏览器')
+					h('span', { className: 'dsh-ego-side-htext' },
+						h('span', { className: 'dsh-ego-side-htitle' },
+							state.currentSpace ? (state.currentSpace.title || state.currentSpace.url || '(新标签页)') : (state.busy ? 'ego 浏览器 · 实时' : 'ego 浏览器')
+						),
+						h('span', { className: 'dsh-ego-side-hurl' },
+							state.currentSpace ? (state.zoomHint || state.currentSpace.url || '') : (state.busy ? '实时视图' : '')
+						)
+					)
 				),
 				h('button', {
 					className: 'dsh-ego-side-iconbtn' + (state.busy ? ' spinning' : ''),
@@ -2805,11 +3067,39 @@ window.__ModuleLoader__.load({
 				}, h('span', { dangerouslySetInnerHTML: { __html: ICON_CLOCK } }))
 			)
 
+			// ── Nav toolbar (back / forward / reload / stop / new tab / address) ──
+			var tgt = state.currentTargetId || (state.currentSpace && state.currentSpace.targetId) || null
+			var navtoolbar = h('div', { className: 'dsh-ego-side-toolbar' },
+				h('button', { className: 'dsh-ego-side-navbtn', type: 'button', title: '后退', disabled: !tgt,
+					onClick: function () { if (tgt) controller.nav(tgt, 'goBack') } }, '‹'),
+				h('button', { className: 'dsh-ego-side-navbtn', type: 'button', title: '前进', disabled: !tgt,
+					onClick: function () { if (tgt) controller.nav(tgt, 'goForward') } }, '›'),
+				h('button', { className: 'dsh-ego-side-navbtn', type: 'button', title: '刷新', disabled: !tgt,
+					onClick: function () { if (tgt) controller.nav(tgt, 'reload') } }, h('span', { dangerouslySetInnerHTML: { __html: ICON_REFRESH } })),
+				h('button', { className: 'dsh-ego-side-navbtn', type: 'button', title: '停止加载', disabled: !tgt,
+					onClick: function () { if (tgt) controller.nav(tgt, 'stop') } }, '✕'),
+				h('button', { className: 'dsh-ego-side-navbtn', type: 'button', title: '新标签页',
+					onClick: function () { controller.newTab() } }, '+'),
+				h('input', { className: 'dsh-ego-side-navurl', id: 'dsh-ego-navurl-input', type: 'text', placeholder: '输入网址跳转，回车执行', spellcheck: false,
+					defaultValue: (state.currentSpace && state.currentSpace.url && !state.currentSpace.url.startsWith('about:')) ? state.currentSpace.url : '',
+					onKeyDown: function (e) { if (e.key === 'Enter') { var v = e.target.value.trim(); if (v) controller.address(v) } } }),
+				h('button', {
+					className: 'dsh-ego-side-navbtn go-open',
+					type: 'button',
+					title: '在 ego 浏览器中打开地址栏输入的网址',
+					onClick: function () {
+						var el = document.getElementById('dsh-ego-navurl-input')
+						var v = el ? el.value.trim() : ''
+						if (v) { controller.address(v) } else if (el) { el.focus() }
+					},
+				}, '↗ 打开')
+			)
+
 			// History overlay: covers the body area
 			if (state.historyOpen) {
 				var sorted = state.spaces.slice().sort(function (a, b) { return (a.lastActive || 0) - (b.lastActive || 0) })
 				return h('div', { className: 'dsh-ego-side-root' },
-					header,
+					header, navtoolbar,
 					h('div', { className: 'dsh-ego-side-history' },
 						h('div', { className: 'dsh-ego-side-historyhead' },
 							h('span', { dangerouslySetInnerHTML: { __html: ICON_CLOCK } }),
@@ -2889,7 +3179,14 @@ window.__ModuleLoader__.load({
 					})
 					: currentSpace.thumbnail
 					? h('img', {
-						ref: imgRef,
+						ref: function (el) {
+							// Callback ref: attach as soon as the <img> actually
+							// mounts. Spaces payloads no longer carry thumbnails,
+							// so the img appears only after the first frame
+							// arrives — later than the attach effect's first run.
+							imgRef.current = el
+							if (el && state.currentTargetId != null) controller.setLiveImg(el, state.currentTargetId)
+						},
 						key: 'liveimg',
 						className: 'dsh-ego-side-liveimg',
 						src: currentSpace.thumbnail,
@@ -2908,6 +3205,7 @@ window.__ModuleLoader__.load({
 						h('div', { className: 'dsh-ego-side-livebadge' },
 							h('span', { className: 'dsh-ego-side-state-dot' + (state.pinned ? ' pin' : state.busy ? ' busy' : '') }),
 							h('span', { style: { flex: 1 } }, (state.backend === 'ffmpeg' ? 'FFmpeg · H.264' : 'CDP') + ' · ' + (state.streamState === 'failed' ? (state.streamMessage || '失败') : state.streamState)),
+							h(EgoLoginBadge, { controller: controller }),
 							state.pinned
 								? h('button', {
 									className: 'dsh-ego-side-back', type: 'button',
@@ -2923,16 +3221,87 @@ window.__ModuleLoader__.load({
 								},
 							}, '⧉ 打开真实页')
 						),
-						liveImg,
+						h('div', { className: 'dsh-ego-side-livewrap' },
+							liveImg,
+							h('div', { className: 'dsh-ego-hotspot' },
+								h('span', { className: 'dsh-ego-hotspot-dot', dangerouslySetInnerHTML: { __html:
+									'<svg width="14" height="18" viewBox="-1.4 -1.4 17 24"><path d="M0 0 L0 18.6 L4.6 14.3 L7.7 21.1 L11.1 19.5 L8 12.9 L13.9 12.5 Z" fill="#4a9eff" stroke="#fff" stroke-width="1.5" stroke-linejoin="round"/></svg>'
+								} })
+							)
+						),
 						h('div', { className: 'dsh-ego-side-livetitle' }, currentSpace.title || currentSpace.url || '(新标签页)'),
 						h('div', { className: 'dsh-ego-side-liveurl' + (state.zoomHint ? ' dsh-ego-side-hint' : '') }, state.zoomHint || currentSpace.url || '')
 					)
 				)
 			}
 
-			return h('div', { className: 'dsh-ego-side-root' }, header, guides, tabsEl, body)
+			// takeover banner (only in normal view, not history)
+			var takeoverNote = state.takeover
+				? h('div', { className: 'dsh-ego-side-takeover-note' },
+					'🖱 接管中 — 你在实时画面上的点击/拖动/滚轮将直接操作 ego 浏览器。操作完点「交还」退出。')
+				: null
+
+			// ── Dual-track embed: when the target site allows <iframe>, show the
+			// REAL rendered page (high-fps / native clicks) instead of the
+			// screencast view. The agent still controls the same URL in real
+			// Chrome (controller.address already ran), toggleable by the banner.
+			if (embedMode === 'iframe' && embedUrl) {
+				body = h('div', { className: 'dsh-ego-side-body' },
+					h('div', { className: 'dsh-ego-side-liveview' },
+						// Mode banner: switch between embedded render and agent view
+						h('div', { className: 'dsh-ego-side-embeddbar' },
+							h('span', { style: { flex: 1 } }, '🖥 真·内嵌页面（可点可滚动）'),
+							h('button', {
+								className: 'dsh-ego-side-back', type: 'button',
+								title: '切到 agent 实时视图（可交给 ego_* 自动化操作）',
+								onClick: function () { setEmbedMode('agent') },
+							}, '⇄ 切到 Agent 视图')
+						),
+						h('iframe', {
+							key: embedUrl,
+							className: 'dsh-ego-side-embed',
+							src: embedUrl,
+							sandbox: 'allow-scripts allow-same-origin allow-forms allow-popups allow-pointer-lock',
+							allow: 'autoplay; fullscreen',
+							referrerPolicy: 'no-referrer-when-downgrade',
+							title: 'ego 内嵌页面',
+						})
+					)
+				)
+			} else if (embedMode === 'probe') {
+				// Probing iframe-ability — keep the current body but overlay a hint.
+				takeoverNote = h('div', { className: 'dsh-ego-side-takeover-note' }, '⏳ 探测该站点是否允许内嵌…')
+			}
+
+			return h('div', { className: 'dsh-ego-side-root' + (state.takeover ? ' dsh-ego-side-takeover-on' : '') }, header, navtoolbar, takeoverNote, guides, tabsEl, body)
 		}
 
+		function EgoLoginBadge(props) {
+			var controller = props.controller
+			var h = React.createElement
+			var s1 = React.useState(null)          // null=idle
+			var status = s1[0], setStatus = s1[1]
+			var run = function () {
+				setStatus('busy')
+				controller.flushLogin().then(function (j) {
+					if (j && j.ok) setStatus('saved:' + (j.total || 0))
+					else setStatus('no-browser')
+				}).catch(function () { setStatus('error') })
+			}
+			var label, cls = 'dsh-ego-side-loginbadge'
+			if (status === 'busy') { label = '保存中…' }
+			else if (status && status.indexOf('saved') === 0) { label = '🔐 已保存 ' + status.split(':')[1] + ' 条登录态'; cls += ' saved' }
+			else if (status === 'no-browser') { label = '未连接浏览器'; cls += ' noconn' }
+			else if (status === 'error') { label = '保存失败'; cls += ' noconn' }
+			else { label = '💾 保存登录态'; }
+			return h('button', {
+				className: cls + (status === 'busy' ? ' busy' : ''),
+				type: 'button',
+				title: '把 ego 浏览器的登录 cookie 持久化到本地 profile，重启后仍保持登录',
+				disabled: status === 'busy',
+				onClick: run,
+			}, label)
+		}
 		function EgoLoginGuide(props) {
 			var controller = props.controller
 			var h = React.createElement
@@ -2990,6 +3359,10 @@ window.__ModuleLoader__.load({
 		function mountSidebarTab(ctx) {
 			var betterSidebar = ctx.get('betterSidebar')
 			if (!betterSidebar) return function () {}
+			// Any sidebar mount supersedes the floating overlay: drop the FAB
+			// and panel first so the user never gets BOTH a native sidebar tab
+			// and the legacy floating ball (HMR re-apply / late promotion).
+			teardownFloating()
 			// Inject Tab CSS once (cleaned up on dispose)
 			var styleEl = document.createElement('style')
 			styleEl.textContent = TAB_CSS
@@ -2997,7 +3370,8 @@ window.__ModuleLoader__.load({
 
 			var disposeTab = betterSidebar.registerTab({
 				id: 'ego-browser:watch',
-				title: function () { return 'Agent 浏览器' },
+				title: function () { return 'ego 浏览器' },
+				icon: browserTabIcon,
 				order: 70,
 				single: true,
 				component: EgoBrowserTab,

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,4 +1,4 @@
-import z from "schemastery";
+import z from "@deepseek-ai/schemastery";
 
 const backend = z.union(["auto", "cdp", "ffmpeg"]);
 const profile = z.union(["low", "balanced", "high"]);

--- a/lib/ffmpeg-installation.js
+++ b/lib/ffmpeg-installation.js
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { createReadStream, createWriteStream } from "node:fs";
+import { createReadStream, createWriteStream, existsSync } from "node:fs";
 import { access, chmod, copyFile, mkdir, open, readdir, rename, rm, writeFile } from "node:fs/promises";
 import { constants } from "node:fs";
 import { homedir } from "node:os";
@@ -44,7 +44,9 @@ export class FfmpegInstallationManager {
   }
 
   #baseStatus() {
-    const unsupported = this.platform === "linux" && (this.env.XDG_SESSION_TYPE === "wayland" || this.env.WAYLAND_DISPLAY);
+    // WSLg (Xwayland) displays cannot be captured via x11grab (XGetImage
+    // returns black) — treat them as unsupported so `auto` falls back to CDP.
+    const unsupported = this.platform === "linux" && (this.env.XDG_SESSION_TYPE === "wayland" || this.env.WAYLAND_DISPLAY || existsSync("/mnt/wslg"));
     return {
       state: unsupported ? "unsupported" : "missing", source: null, path: null, version: null, encoder: null,
       progress: null, canDownload: !unsupported && !!this.manifest, canSelectFfmpeg: false,

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -26,7 +26,7 @@ const API_PREFIX = "/ego/api";
 const ALLOWED_KEYS = new Set([
   "chromePath", "captureBackend", "streamProfile", "cdpFps", "cdpQuality",
   "cdpMaxWidth", "cdpBackstopIntervalMs", "ffmpegFps", "ffmpegMaxWidth", "ffmpegBitrateKbps",
-  "ffmpegEncoder", "ffmpegPath", "githubMirror",
+  "ffmpegEncoder", "ffmpegPath", "githubMirror", "egoCliArgs", "chromeArgs",
 ]);
 
 /**

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
       "platform": "web",
       "inject": [
         "@deepseek-ai/dsh-client-runtime",
-        "@deepseek-ai/dsh-client-web-react",
+        "@deepseek-ai/dsh-client-ui-renderer",
         "@deepseek-ai/dsh-client-ui-slots",
         "@deepseek-ai/dsh-client-locale",
         "@deepseek-ai/dsh-client-ui-settings-plugins"
@@ -34,14 +34,14 @@
     "@deepseek-ai/schemastery": "link:../dsh/vendor/schemastery"
   },
   "peerDependencies": {
-    "@deepseek-ai/cordis": "^4.0.0-rc.7",
-    "@deepseek-ai/dsh-client-locale": "^0.0.1",
-    "@deepseek-ai/dsh-client-runtime": "^0.0.1",
-    "@deepseek-ai/dsh-client-ui-settings-plugins": "^0.0.1",
-    "@deepseek-ai/dsh-client-ui-slots": "^0.0.1",
-    "@deepseek-ai/dsh-client-web-react": "^0.0.1",
-    "@deepseek-ai/dsh-settings": "^0.0.1",
-    "@deepseek-ai/dsh-tools": "^0.0.1",
+    "@deepseek-ai/cordis": "^4.0.1",
+    "@deepseek-ai/dsh-client-locale": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-client-runtime": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-client-ui-settings-plugins": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-client-ui-slots": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-client-ui-renderer": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-settings": "^0.1.0-rc.7",
+    "@deepseek-ai/dsh-tools": "^0.1.0-rc.7",
     "react": "^18.2.0",
     "schemastery": "^3.18.0"
   },

--- a/runtime/PATCHES.md
+++ b/runtime/PATCHES.md
@@ -14,6 +14,7 @@
 | `runtime/ego-linux/src/chrome.mjs` | `resolveBinary()`: `candidate.includes("/")` → `isAbsolute(candidate)`；`which()`: Windows 用 `where` 替代 `which` | Windows 支持：POSIX `includes("/")` 不识别 `C:\\` 路径，`which` 在 Windows 不存在 |
 | `runtime/ego-linux/src/chrome.mjs` | `LAUNCH_FLAGS` 加 `--no-startup-window`；`launch()` 删除 `"about:blank"` 位置参数 | 消除单次 `ego_space_open` 开两个窗口：原位置参数在默认 browser context 开残留 tab，space tab 走独立 context 又开一个窗口，Chrome 把不同 context 隔离到不同窗口 → 用户看到两窗。`useSpace+ensureRealTab` 路由下不再需要 launch 残留 tab |
 | `runtime/ego-linux/src/paths.mjs` | Windows 用 `%LOCALAPPDATA%\\ego-lite-linux` 作为 DATA_DIR / STATE_DIR；`CHROME_CONFIG_CANDIDATES` 加 Windows 路径 | Windows 支持：XDG 变量在 Windows 不存在；`ego_doctor` 已预期 `%LOCALAPPDATA%` |
+| `runtime/ego-linux/bin/ego-browser.mjs` | headless 判定加 `hasDisplay`：有可用 X display（如 Xvfb）时忽略继承的 `EGO_LINUX_HEADLESS=1`，跑 headed | watch 面板全帧率 + ffmpeg x11grab 后端能抓到画面：headless 走 swiftshader ~1fps 且不渲染到 X display（x11grab 抓黑屏）。PR #10 曾回退此逻辑（只认 env），已重新移植（2026-08-18） |
 | （其余 runtime 文件）| 与 vendoring 时一致 | 无后续本地改动 |
 
 ## 说明

--- a/runtime/ego-linux/bin/ego-browser.mjs
+++ b/runtime/ego-linux/bin/ego-browser.mjs
@@ -341,13 +341,16 @@ async function main() {
   }
 
   // EGO_LINUX_HEADLESS is for a machine whose owner does not want the agent
-  // window in front of their work. The harness needs a page target to attach to,
-  // so a visible browser always shows a window — headless is the only way to be
-  // driven without one. --headless still works per run, and --open still trades
-  // a headless browser for a visible one on demand.
-  const envHeadless = !["", "0", "false", "no"].includes(
-    (process.env.EGO_LINUX_HEADLESS ?? "").toLowerCase(),
-  );
+  // window in front of their work (or a box with no display at all). When a
+  // usable X display is present (e.g. an Xvfb), run headed so the compositor
+  // produces full-rate screencast frames for the watch panel — headless would
+  // fall back to swiftshader (~1 fps). --headless still forces headless per run.
+  const hasDisplay = (process.env.DISPLAY || "").trim() !== "";
+  const envHeadless = hasDisplay
+    ? false
+    : !["", "0", "false", "no"].includes(
+        (process.env.EGO_LINUX_HEADLESS ?? "").toLowerCase(),
+      );
   const headless = argv.includes("--headless") || envHeadless;
   const rest = argv.filter((arg) => arg !== "--headless");
 


### PR DESCRIPTION
# Windows 端稳定性测试 PR

> 将 `local-fixes` 分支的本地修复合并为一个可测试版本，目标：**Windows 端稳定性验证**。

## 包含内容（相对 master 的增量）

### 1. 本地修复集（`8882eb4`）
- **侧边栏 tab 旧前端 UI 恢复**：导航工具栏（后退/前进/刷新/停止/新标签页/地址栏）、iframe 双轨嵌入（frameable 探测）、登录徽章、接管横幅、鼠标热点+点击波纹、双行头部、tab 图标
- **liveImg callback ref 绑定修复**：spaces 载荷不再携带缩略图，`<img>` 首帧后才挂载——改用 callback ref 让指针输入/坐标映射可用
- **`/api/ego/nav` 与 `/api/ego/frameable` 路由恢复**
- **`/api/nav` handler 恢复**：新版 Chrome 移除 `Page.goBack/goForward`，回退 `Runtime.evaluate history.back()/forward()`
- **runtime `hasDisplay` 逻辑恢复**（headed 启动判定）

### 2. rc.8 双兼容 selector（`375306d`）
- `@deepseek-ai/dsh-client-web-react` 在 rc.8 被移除 → **双兼容**：优先 web-react 路径，失败回退**内联 React 官方 use-sync-external-store with-selector 实现**（MIT），零依赖 rc.8 client 包面
- 比 master 的 PR #11 简化内联版更完整：支持 `isEqual` + `getServerSnapshot`

### 3. gateway 修复（`74d2e60`）— **master 也缺**
- PR #12 新增 `egoCliArgs`/`chromeArgs` 字段但漏了 `gateway.js` 的 `ALLOWED_KEYS` 白名单 → `/ego/api/set` 静默丢弃 → 设置无法持久化
- 本 PR 已修复，建议同步合入 master

## 测试重点（Windows）
- [ ] `dshx install` 安装（tarball/git URL）
- [ ] CDP 捕获后端（Windows 默认）
- [ ] 侧边栏 ego 浏览器 tab 渲染 + 观察窗
- [ ] `egoCliArgs`/`chromeArgs` 设置保存持久化（gateway 修复验证）
- [ ] 设置面板字段可见可编辑
- [ ] 重启 DSH 后登录态/稳定性

## 说明
- 仓库 peer 包不全在公共 npm registry，DSH profile 安装应提供 peer
- Windows 记得取消 `[win-incompatible]` 注释（config.yaml）
- 底层 ego-lite 宿主为社区移植，复杂流程稳定性可能弱于 macOS