### PR TITLE
fix: macOS agent browser forced into headless mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2021,7 +2021,7 @@ function isPosixRoot(platform = process.platform) {
 }
 /** No display server → headless is required (Linux/macOS headless servers). */
 function isHeadlessDetected(platform = process.platform, env = process.env) {
-	if (platform === "win32") return false;
+	if (platform === "win32" || platform === "darwin") return false;
 	return env.DISPLAY === void 0 || env.DISPLAY === "";
 }
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,8 +284,9 @@ function isPosixRoot(platform: NodeJS.Platform = process.platform): boolean {
 }
 /** No display server → headless is required (Linux/macOS headless servers). */
 function isHeadlessDetected(platform: NodeJS.Platform = process.platform, env: NodeJS.ProcessEnv = process.env): boolean {
-  if (platform === 'win32') {
-    return false // Windows always has a desktop session.
+  // Windows and macOS always have a desktop session; only Linux headless servers need to run the backing browser headless.
+  if (platform === 'win32' || platform === 'darwin') {
+    return false
   }
   return env.DISPLAY === undefined || env.DISPLAY === ''
 }


### PR DESCRIPTION
## 1. Issue / PR Title

**fix: do not force headless on macOS — DISPLAY is an X11-only variable**

## 2. The Bug

On macOS the agent browser always launches **headless**. The promised
"ego lite — agent" window never appears on the desktop, so the user cannot
interact with pages directly (e.g. to pass a CAPTCHA, click through a login,
or take over a flow mid-way).

### Repro

1. macOS with Google Chrome installed; launch DSH (`dsh web`).
2. Open the agent browser and navigate to a specific page.
3. Observe: no window appears on the desktop; the running browser reports
   `headless: true` in its browser state file.

### Environment

- OS: macOS 25.5 (Darwin arm64)
- Node: v22.15.0
- Plugin: `@dsh-external/ego-browser@0.8.0`
- Chrome: 151.0.7922.174 (`/Applications/Google Chrome.app`)

## 3. Root Cause

`lib/index.js` decides "is this a display-less server" with:

```js
/** No display server → headless is required (Linux/macOS headless servers). */
function isHeadlessDetected(platform = process.platform, env = process.env) {
	if (platform === "win32") return false;
	return env.DISPLAY === void 0 || env.DISPLAY === "";
}
```

The check is built for **Linux/BSD**: there, a desktop always exports `DISPLAY`
(an X11 variable), so a missing `DISPLAY` genuinely means "no display server".

**macOS is the exception**: its GUI is Aqua/Quartz and *never* sets `DISPLAY` —
on a normal Mac desktop the variable is simply absent. Therefore **every**
macOS user trips this check, the plugin sets `EGO_LINUX_HEADLESS=1`, and the
browser is launched with `--headless=new` (see `runtime/ego-linux/src/chrome.mjs`).

The runtime itself (`runtime/ego-linux/`) is innocent — it only *reads*
`EGO_LINUX_HEADLESS` / `EGO_LINUX_CHROME` from the environment. The wrong
default originates in the plugin's env-adaptation layer (`resolveEgoEnv`).

## 4. The Fix

```diff
 /** No display server → headless is required (Linux/macOS headless servers). */
 function isHeadlessDetected(platform: NodeJS.Platform = process.platform, env: NodeJS.ProcessEnv = process.env): boolean {
-  if (platform === 'win32') {
-    return false // Windows always has a desktop session.
+  // Windows and macOS always have a desktop session; only Linux headless servers need to run the backing browser headless.
+  if (platform === 'win32' || platform === 'darwin') {
+    return false
   }
   return env.DISPLAY === undefined || env.DISPLAY === ''
 }
```

Only `platform === "darwin"` is added. Windows was already special-cased for
the same reason (no `DISPLAY` semantics there either).