### PR TITLE
docs: 补充 DSH 与 dsh-better-sidebar 版本兼容矩阵及适配说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,37 @@
   <a href="https://dshfind.com/zh/plugins/Fisfzy/ego-browser"><img src="https://dshfind.com/api/card/Fisfzy/ego-browser?lang=zh" alt="ego-browser card"></a>
 </p>
 
+<p align="center">
+  <img src="https://img.shields.io/badge/DSH-%3E%3D0.1.2--rc.1-blue" alt="DSH >= 0.1.2-rc.1">
+  <img src="https://img.shields.io/badge/DSH--better--sidebar-%3E%3D0.12.2(optional)-red" alt="dsh-better-sidebar >= 0.12.2 (optional)">
+  <img src="https://img.shields.io/badge/Node-%3E%3D22-brightgreen?logo=node.js&logoColor=white" alt="Node >= 22">
+</p>
+
 > **仓库**：`github.com/Fisfzy/ego-browser`｜版本历史见 [CHANGELOG.md](CHANGELOG.md)｜详情页：[dshfind](https://dshfind.com/zh/plugins/Fisfzy/ego-browser)
 
-**DSH 版本支持**：本版本 **v0.8.3** 针对 **DeepSeek Harness ≥ `0.1.2-rc.1`** 适配（`engines.dsh` 声明兼容地板即 `0.1.2-rc.1`；peer 依赖同步锁定 `>=0.1.2-rc.1`。已在本机 DSH 0.1.2-rc.1 + Windows + web profile 完成实机安装、启动、工具调用与 watch 面板验收）。**0.1.2-alpha.x 系列按声明可装但未实测**（审计如实记录为 unknown）；**0.1.0-rc.x / 0.1.1-rc.x 宿主请使用 v0.8.0 及更早版本**。v0.8.2 → v0.8.3 主要变更：合并 6 个社区 PR（root/xvfb/macOS headless 适配、rc.1 兼容、Windows 稳定性），修复无认证 `/api/ego/*` 路由安全漏洞、无 dsh-better-sidebar 宿主 client 启动失败（#29）、Windows 冷启动回归（#22 引入的 Xvfb 误判），并修复 gateway 设置白名单缺 `egoCliArgs`/`chromeArgs`。适配点：client 运行时改名（`@deepseek-ai/dsh-client-store`）、client 模块注册 id 与装载行名按声明包名、`dsh.client.inject` 仅声明真实模块图行、`webServer` 以嵌套注入交付（可选服务），并同步侧边栏 Tab（dsh-better-sidebar）模式。
+### 版本兼容矩阵
 
-**侧边栏支持（[dsh-better-sidebar](https://www.npmjs.com/package/dsh-better-sidebar)）**：当宿主安装了 `dsh-better-sidebar`（实测 0.17.x）时，实时观察窗注册为**侧边栏原生 Tab**——「Agent 浏览器」出现在侧边栏「+」菜单中，点击即打开并随侧边栏抽屉固定展示；agent 首次调用 `ego_*` 工具时会自动打开该 Tab。未安装 `dsh-better-sidebar` 时自动回退为右下角**浮动观察球**（`#dsh-ego-fab`）模式。两种形态共用同一套 SSE 实时推流 / 点击 / 输入 / 下载捕获能力。
+| 依赖 | 最低版本 | 推荐版本 | 说明 |
+|---|---|---|---|
+| **DSH** (DeepSeek Harness) | `0.1.2-rc.1` | `≥ 0.1.2-rc.1`（截至 v0.1.5-rc.2 验证通过） | `engines.dsh` 声明地板；peer 依赖同步锁定 `>=0.1.2-rc.1`。0.1.0-rc.x / 0.1.1-rc.x 请使用 v0.8.0 及更早版本 |
+| **dsh-better-sidebar** | `0.12.2`（可选） | `≥ 0.17.1` | 未安装时自动回退浮动观察球；`< 0.12.2` 可运行但外部链接拦截（`urlTarget`）静默降级 |
+| **Node.js** | `22` | — | harness 环境自带 |
+
+**DSH 全版本适配说明**：本版本 v0.8.3 已通过源码审计确认与 DSH `0.1.2-rc.1` 至 `0.1.5-rc.2` 全部发布版本兼容（`defineTool`、`ctx.tools.register`、`ctx.subprocess.spawn`、`ctx.webServer.register`、`ctx.inject`、`ModuleLoader` CJS factory、`cordis.patch.yml` 等核心 API 在 v0.1.0-rc.7 → v0.1.5-rc.2 无破坏性变更）。0.1.2-alpha.x 系列按声明可装但未实测。
+
+**dsh-better-sidebar 适配说明**：ego-browser 通过 `ctx.betterSidebar` 服务（try-catch 防御性获取）注册侧边栏 Tab 并监听外部链接。关键 API 引入版本：
+
+| API | ego-browser 用法 | better-sidebar 引入版本 |
+|---|---|---|
+| `registerTab()` / `openTab()` / `ctx.betterSidebar` | Tab 注册 + 打开 | v0.9.0+ |
+| `TabDescriptor.single` | 单实例 Tab | v0.9.0+ |
+| `TabDescriptor.urlTarget` | 外部链接拦截 | **v0.12.2+**（低于此版本链接拦截静默失效） |
+
+---
+
+**DSH 版本支持详情**：v0.8.2 → v0.8.3 主要变更：合并 6 个社区 PR（root/xvfb/macOS headless 适配、rc.1 兼容、Windows 稳定性），修复无认证 `/api/ego/*` 路由安全漏洞、无 dsh-better-sidebar 宿主 client 启动失败（#29）、Windows 冷启动回归（#22 引入的 Xvfb 误判），并修复 gateway 设置白名单缺 `egoCliArgs`/`chromeArgs`。适配点：client 运行时改名（`@deepseek-ai/dsh-client-store`）、client 模块注册 id 与装载行名按声明包名、`dsh.client.inject` 仅声明真实模块图行、`webServer` 以嵌套注入交付（可选服务），并同步侧边栏 Tab（dsh-better-sidebar）模式。
+
+**侧边栏支持（[dsh-better-sidebar](https://www.npmjs.com/package/dsh-better-sidebar)）**：当宿主安装了 `dsh-better-sidebar`（推荐 ≥ v0.12.2）时，实时观察窗注册为**侧边栏原生 Tab**——「Agent 浏览器」出现在侧边栏「+」菜单中，点击即打开并随侧边栏抽屉固定展示；agent 首次调用 `ego_*` 工具时会自动打开该 Tab。未安装 `dsh-better-sidebar` 时自动回退为右下角**浮动观察球**（`#dsh-ego-fab`）模式。两种形态共用同一套 SSE 实时推流 / 点击 / 输入 / 下载捕获能力。
 
 把 [CitroLabs/ego-lite](https://github.com/CitroLabs/ego-lite)（给 AI Agent 用的 Chromium）接入 DeepSeek Harness：以 **32 个结构化 `ego_*` 工具**驱动浏览器，并配一套**实时观察前端口**——agent 后台操作网页时，你能像看直播一样看到它正在浏览的每个页面，还能直接操作它。
 


### PR DESCRIPTION
### 变更概述

通过源码审计 DSH (`deepseek-harness`) v0.1.0-rc.7 → v0.1.5-rc.2 全部 16 个版本标签和 dsh-better-sidebar v0.9.0 → v0.19.0 全部 API 演进历史，在 README 中补充了版本兼容矩阵、适配说明和 shields.io badge 图标。

### 改动内容

1. **新增三个版本兼容 badge**：DSH 最低版本、dsh-better-sidebar 最低版本（标注 optional）、Node.js 版本要求
2. **新增版本兼容矩阵表格**：DSH / dsh-better-sidebar / Node.js 的最低版本、推荐版本和说明
3. **DSH 全版本适配说明**：基于源码审计的结论——`defineTool`、`ctx.tools.register`、`ctx.subprocess.spawn`、`ctx.webServer.register`、`ModuleLoader` CJS factory、`cordis.patch.yml` 等核心 API 在 v0.1.0-rc.7 → v0.1.5-rc.2 全部版本中无破坏性变更
4. **dsh-better-sidebar 适配说明**：追溯了 `registerTab()`/`openTab()` (v0.9.0+)、`TabDescriptor.single` (v0.9.0+)、`TabDescriptor.urlTarget` (v0.12.2+) 的引入版本，明确低于 v0.12.2 时外部链接拦截静默降级
5. **侧边栏支持描述更新**：版本要求从"实测 0.17.x"修正为"推荐 ≥ v0.12.2"

### 审计结论摘要

| 依赖 | 完全兼容 | 备注 |
|---|---|---|
| DSH | v0.1.2-rc.1 ~ v0.1.5-rc.2 | 0.1.0-rc.x / 0.1.1-rc.x 需用 v0.8.0 及更早版本 |
| dsh-better-sidebar | v0.12.2+（推荐 v0.17.1+） | v0.9.0~v0.12.1 可运行但 urlTarget 静默失效 |
| Node.js | ≥ 22 | — |

### 测试

- [x] 源码审计覆盖 DSH 全部 16 个发布标签
- [x] 源码审计覆盖 better-sidebar v0.9.0 ~ v0.19.0 的 `TabDescriptor` / `BetterSidebarService` API 演进
- [x] 确认 ego-browser 使用的所有 API 字段在兼容范围内签名未变
- [x] README badge URL 格式验证